### PR TITLE
Fixes task to import taxon_concept_term_pairs 

### DIFF
--- a/lib/tasks/import_trade_codes.rake
+++ b/lib/tasks/import_trade_codes.rake
@@ -236,17 +236,18 @@ namespace :import do
     drop_table(TMP_TABLE)
     create_table_from_csv_headers(file, TMP_TABLE)
     copy_data(file, TMP_TABLE)
-    initial_count = Trade::TaxonConceptCodePair.count
+    initial_count = Trade::TaxonConceptTermPair.count
     sql = <<-SQL
-      INSERT INTO trade_taxon_concept_code_pairs(taxon_concept_id, trade_code_id, trade_code_type,
+      INSERT INTO trade_taxon_concept_term_pairs(taxon_concept_id, term_id,
         created_at, updated_at)
-      SELECT DISTINCT taxon_concepts.id, terms.id, 'Term', current_date, current_date
+      SELECT DISTINCT taxon_concepts.id, terms.id, current_date, current_date
       FROM #{TMP_TABLE}
       INNER JOIN taxon_concepts_mview AS taxon_concepts ON UPPER(BTRIM(taxon_concepts.full_name)) = UPPER(BTRIM(#{TMP_TABLE}.TAXON_FAMILY))
       INNER JOIN trade_codes AS terms ON UPPER(BTRIM(terms.code)) = UPPER(BTRIM(#{TMP_TABLE}.TERM_CODE))
+        AND terms.type = 'Term'
       WHERE taxon_concepts.rank_name = '#{Rank::FAMILY}' AND taxon_concepts.taxonomy_is_cites_eu
     SQL
     ActiveRecord::Base.connection.execute(sql)
-    puts "#{Trade::TaxonConceptCodePair.count - initial_count} terms and unit codes pairs created"
+    puts "#{Trade::TaxonConceptTermPair.count - initial_count} terms and unit codes pairs created"
   end
 end


### PR DESCRIPTION
The task was using the old table name and attributes. I've grepped for more occurrences an none showed! =)

This PR is from the hotfix branch to master, is this correct? =)
