### PR TITLE
cites suspension observer to touch affected taxa

### DIFF
--- a/app/models/cites_suspension_observer.rb
+++ b/app/models/cites_suspension_observer.rb
@@ -1,0 +1,35 @@
+class CitesSuspensionObserver < ActiveRecord::Observer
+
+  def after_save(cites_suspension)
+    if cites_suspension.taxon_concept
+      cites_suspension.taxon_concept.touch
+    elsif cites_suspension.taxon_concept_id_was != cites_suspension.taxon_concept_id
+      TaxonConcept.find(cites_suspension.taxon_concept_id_was).touch
+    else
+      touch_taxa_with_applicable_distribution(cites_suspension)
+    end
+  end
+
+  def after_destroy(cites_suspension)
+    if cites_suspension.taxon_concept
+      cites_suspension.taxon_concept.touch
+    else
+      touch_taxa_with_applicable_distribution(cites_suspension)
+    end
+  end
+
+  def touch_taxa_with_applicable_distribution(cites_suspension)
+    update_stmt = TaxonConcept.send(:sanitize_sql_array, [
+      "UPDATE taxon_concepts
+      SET updated_at = NOW()
+      FROM distributions
+      WHERE distributions.taxon_concept_id = taxon_concepts.id
+      AND distributions.geo_entity_id IN (:geo_entity_id)",
+      :geo_entity_id => [
+        cites_suspension.geo_entity_id, cites_suspension.geo_entity_id_was
+      ].compact.uniq
+    ])
+    TaxonConcept.connection.execute update_stmt
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,8 @@ module SAPI
     config.active_record.observers = :destroy_observer, :annotation_observer,
       :cites_cop_observer, :cites_suspension_notification_observer,
       :eu_regulation_observer, :"trade/annual_report_upload_observer",
-      :listing_change_observer, :taxon_concept_observer
+      :listing_change_observer, :taxon_concept_observer,
+      :cites_suspension_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
Apparently cache was not invalidated when there were changes to cites suspensions.
