### PR TITLE
Adds 'proxy' taxon_concept's updated at from taxon_concepts_mview. 

### DIFF
--- a/app/serializers/species/show_taxon_concept_serializer.rb
+++ b/app/serializers/species/show_taxon_concept_serializer.rb
@@ -111,7 +111,7 @@ class Species::ShowTaxonConceptSerializer < ActiveModel::Serializer
       self.class.name,
       self.id,
       object.updated_at,
-      object.m_taxon_concept.try(:updated_at) || object.updated_at
+      object.m_taxon_concept.try(:updated_at) || ""
     ]
     Rails.logger.debug "CACHE KEY: #{key.inspect}"
     key


### PR DESCRIPTION
to ensure that the cache is cleared after the mview is rebuilt if there had been changes to the taxon_concept
