### PR TITLE
Removes filter fix for background image on IE < 9

### DIFF
--- a/app/assets/stylesheets/species/all.css
+++ b/app/assets/stylesheets/species/all.css
@@ -38,14 +38,6 @@ body {
 	background-position: top center;
 }
 
-html.lt-ie9 body {
-  background: none;
-  filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(
-  src='/assets/species/background_1.jpg',
-  sizingMethod='scale');
-}
-
-
 body.inner {
   background-attachment: fixed;
 }


### PR DESCRIPTION
This is a bit weird as initially I added this css rules to make sure the background image worked on IE8. It seems that this is not necessary and actually just makes it worse. So removing it fixes the issue of missing scrollbars.
