### PR TITLE
Fixes bug with display of EU Decisions

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -35,7 +35,7 @@
             {{#if decision.subspecies_info}}
               {{{decision.subspecies_info}}}<br />
             {{/if}}
-            {{decision.term.name_en}} {{decision.source.name_en}} <br />
+            {{decision.term.name}} {{decision.source.name}} <br />
             {{{decision.notes}}}
           </td>
           <td class="last">
@@ -86,7 +86,7 @@
                 {{#if decision.subspecies_info}}
                   {{{decision.subspecies_info}}}<br />
                 {{/if}}
-                {{decision.term.name_en}} {{decision.source.name_en}} <br />
+                {{decision.term.name}} {{decision.source.name}} <br />
                 {{{decision.notes}}}
               </td>
               <td class="last">

--- a/app/assets/javascripts/species/templates/taxon_concept/distribution.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/distribution.handlebars
@@ -10,17 +10,17 @@
       <div class="three-columns">
         <ul class="col">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=0}}
-            <li>{{name_en}} {{formattedTags tags_list}}</li>
+            <li>{{name}} {{formattedTags tags_list}}</li>
           {{/eachPart}}
         </ul>
         <ul class="col">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=1}}
-            <li>{{name_en}} {{formattedTags tags_list}}</li>
+            <li>{{name}} {{formattedTags tags_list}}</li>
           {{/eachPart}}
         </ul>
         <ul class="col last-child">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=2}}
-            <li>{{name_en}} {{formattedTags tags_list}}</li>
+            <li>{{name}} {{formattedTags tags_list}}</li>
           {{/eachPart}}
         </ul>
       </div>

--- a/app/serializers/species/show_taxon_concept_serializer.rb
+++ b/app/serializers/species/show_taxon_concept_serializer.rb
@@ -3,8 +3,7 @@ class Species::ShowTaxonConceptSerializer < ActiveModel::Serializer
   root 'taxon_concept'
   attributes :id, :full_name, :author_year, :standard_references,
     :common_names, :distributions, :subspecies, :distribution_references,
-    :taxonomy,
-    :kingdom_name, :phylum_name, :order_name, :class_name, :family_name,
+    :taxonomy, :kingdom_name, :phylum_name, :order_name, :class_name, :family_name,
     :genus_name, :species_name
 
   has_many :synonyms, :serializer => Species::SynonymSerializer
@@ -81,7 +80,7 @@ class Species::ShowTaxonConceptSerializer < ActiveModel::Serializer
 
   def distributions
     object.distributions.joins(:geo_entity).
-      select('geo_entities.name_en AS name_en').
+      select('geo_entities.name_en AS name').
       joins("LEFT JOIN taggings ON
         taggings.taggable_id = distributions.id
         AND taggings.taggable_type = 'Distribution'


### PR DESCRIPTION
This Pull Request fixes a bug with the display of Source and Term codes in the EU Decisions section of a Taxon Concept's page, see: http://www.speciesplus.net/#/taxon_concepts/5467/legal , output should be as the screenshot below:
![screen shot 2014-01-07 at 16 50 36](https://f.cloud.github.com/assets/10764/1860999/de573d06-77bb-11e3-9761-469aea710221.png)
- It also updates the distributions method in the show_taxon_concept serializer to use the variable name instead of name_en, for consistency.
