### PR TITLE
[Fixes #63802306] Bug with adding new EU Suspensions.

### DIFF
--- a/app/views/admin/taxon_eu_suspensions/index.html.erb
+++ b/app/views/admin/taxon_eu_suspensions/index.html.erb
@@ -3,7 +3,7 @@
   <div class="action-buttons">
     <%= admin_add_new_button(
       :resource => 'eu_suspension',
-      #:href => new_admin_taxon_concept_eu_suspension_path(@taxon_concept),
+      :href => new_admin_taxon_concept_eu_suspension_path(@taxon_concept),
       :"data-toggle" => nil,
       :role => nil,
       :name => 'Add new EU Suspension'


### PR DESCRIPTION
Removes comment that was disabling the link to the page to add EU suspensions
