### PR TITLE
[#61992448] hybrids should be searchable in trade

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -543,8 +543,8 @@ $(document).ready(function(){
           data: {
             taxonomy: 'CITES',
             taxon_concept_query: term,
-            autocomplete: true,
-            'ranks[]': "SPECIES"
+            'ranks[]': 'SPECIES',
+            visibility: 'trade'
           },
           success: function(data) {
             response(parseTaxonData(data, term));
@@ -578,8 +578,8 @@ $(document).ready(function(){
           data: {
             taxonomy: 'CITES',
             taxon_concept_query: request.term,
-            autocomplete: true,
-            'ranks[]': 'GENUS'
+            'ranks[]': 'GENUS',
+            visibility: 'trade'
           },
           success: function(data) {
             response(parseTaxonData(data, term));

--- a/app/assets/javascripts/trade/controllers/shipments_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/shipments_controller.js.coffee
@@ -92,8 +92,7 @@ Trade.ShipmentsController = Ember.ArrayController.extend Trade.QueryParams, Trad
     Trade.AutoCompleteTaxonConcept.find(
       taxonomy: 'CITES'
       taxon_concept_query: taxonConceptQuery
-      ranks: ['KINGDOM', 'PHYLUM', 'CLASS', 'ORDER', 'FAMILY', 'SUBFAMILY', 'GENUS', 'SPECIES']
-      autocomplete: true
+      visibility: 'trade'
     )
   ).property('taxonConceptQuery')
   autoCompleteTaxonConceptsByRank: ( ->

--- a/app/assets/javascripts/trade/helpers/taxon_concept_select2.js.coffee
+++ b/app/assets/javascripts/trade/helpers/taxon_concept_select2.js.coffee
@@ -32,6 +32,7 @@ Trade.TaxonConceptSelect2 = Ember.TextField.extend
         dataType: 'json'
         data: (term, page) ->
           taxon_concept_query: term # search term
+          visibility: 'trade'
           per_page: 10
           page: page
         results: (data, page) => # parse the results into the format expected by Select2.

--- a/app/models/species/search_params.rb
+++ b/app/models/species/search_params.rb
@@ -16,8 +16,9 @@ class Species::SearchParams < Hash
         params[:taxon_concept_query] ? params[:taxon_concept_query].upcase.strip : nil,
       :geo_entities => params[:geo_entities_ids].blank? ? [] : params[:geo_entities_ids],
       :higher_taxa_ids => params[:higher_taxa_ids] ? params[:higher_taxa_ids] : nil,
-      :ranks => params[:ranks] ? 
+      :ranks => params[:ranks] ?
         Rank.dict & params[:ranks].map(&:upcase) : [Rank::SPECIES],
+      :visibility => params[:visibility] ? params[:visibility].downcase.to_sym : nil,
       :page => params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,
       :per_page => params[:per_page] && params[:per_page].to_i > 0 ? params[:per_page].to_i : 25
     }
@@ -26,6 +27,9 @@ class Species::SearchParams < Hash
     end
     unless [:cites, :eu, :cms].include? sanitized_params[:geo_entity_scope]
       sanitized_params[:geo_entity_scope] = :cites
+    end
+    unless [:speciesplus, :trade].include? sanitized_params[:visibility]
+      sanitized_params[:visibility] = :speciesplus
     end
     super(sanitized_params)
     self.merge!(sanitized_params)

--- a/app/models/species/taxon_concept_prefix_matcher.rb
+++ b/app/models/species/taxon_concept_prefix_matcher.rb
@@ -36,7 +36,11 @@ class Species::TaxonConceptPrefixMatcher
       @query.by_cites_eu_taxonomy
     end
 
-    @query = @query.without_hidden_subspecies
+    if @visibility == :trade
+      @query = @query.where(:name_status => ['A', 'H', 'T'])
+    else
+      @query = @query.without_hidden_subspecies.where(:name_status => 'A')
+    end
 
     if @taxon_concept_query
       @query = @query.select(
@@ -71,7 +75,7 @@ class Species::TaxonConceptPrefixMatcher
           SELECT * FROM UNNEST(spanish_names_ary) name WHERE UPPER(name) LIKE :sci_name_prefix
         )
       ", :sci_name_prefix => "#{@taxon_concept_query}%", :sci_name_infix => "%#{@taxon_concept_query}%"
-      ]).where(:name_status => 'A')
+      ])
     end
   end
 

--- a/spec/models/species/hybrid_prefix_matcher_spec.rb
+++ b/spec/models/species/hybrid_prefix_matcher_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+describe Species::TaxonConceptPrefixMatcher do
+  include_context "Falconiformes"
+  describe :results do
+    context "when searching for hybrid" do
+      context "when trade visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Falco hybrid',
+            :ranks => [],
+            :visibility => :trade
+          })
+        }
+        specify { subject.results.should include(@hybrid) }
+      end
+      context "when speciesplus visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Falco hybrid',
+            :ranks => []
+          })
+        }
+        specify { subject.results.should be_empty }
+      end
+    end
+  end
+end


### PR DESCRIPTION
adds a new parameter called 'visibility', which defaults to 'speciesplus'; if 'trade' passed, will use a less restrictive check on name_status and ignore the check on rank and cites_show
