### PR TITLE
[#64913026] show net report confirmation

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -704,7 +704,7 @@ $(document).ready(function(){
     window.location.href = $link.attr("href");
   }
   
-  function handleDownloadRequest () {
+  function handleDownloadRequest (ignoreWarning) {
     var output_type = $( "input[name='outputType']:checked" ).val(),
       report_type = $( "input[name='report']:checked" ).val(),
       query = location.search.substr(1);
@@ -716,6 +716,13 @@ $(document).ready(function(){
       query = query.replace(/report_type%5D=(raw|comptab)/,
         "report_type%5D=" + report_type);
     }
+    if (!ignoreWarning &&
+      (report_type == 'net_imports' || report_type == 'net_exports')
+    ) {
+      $('#this_should_not_be_a_table').hide();
+      $('#net-trade-warning').show();
+      return;
+    }
     if (output_type === 'web') {
       goToResults(query);
       return;
@@ -725,7 +732,8 @@ $(document).ready(function(){
     }
   }
 
-  $('#button_report').click( function (e) {handleDownloadRequest() });
+  $('#button_report').click( function (e) {handleDownloadRequest(false) });
+  $('#ignore_warning_button_report').click( function (e) {handleDownloadRequest(true) });
 
   //////////////////////////////
   // View results page specific:

--- a/app/views/cites_trade/_net_trade_warning.html.erb
+++ b/app/views/cites_trade/_net_trade_warning.html.erb
@@ -1,0 +1,36 @@
+<table id="net-trade-warning" width="80%" cellspacing="0" cellpadding="10" border="0" align="center" style="display:none">
+  <tbody>
+  <tr>
+    <td valign="top" class="style1">
+      <span style="font-size:14px;font-weight:bold;color:red;">
+        <%= t('warnings.net_trade_1') %>
+      </span>
+      <br><br>
+      <hr class="space">
+      <%= t('warnings.net_trade_2') %><br><%= t('warnings.net_trade_3') %>
+      <br><br>
+      <hr class="space">
+      <table>
+        <tbody>
+        <tr>
+          <td>
+            <a href="/<%= I18n.locale %>/cites_trade/">
+              <button value=" New Search " style="float:right" name="reset" type="submit">
+                <img alt="" src="/assets/cites_trade/page_find.gif">
+                <%= t('reselect') %>
+              </button>
+            </a>
+          </td>
+          <td>
+            <button id="ignore_warning_button_report" value=" New Search " style="float:right" name="ngTrade" type="submit">
+              <img alt="" src="/assets/cites_trade/page_right.gif">
+              <%= t('continue') %>
+            </button>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+  </tbody>
+</table>

--- a/app/views/cites_trade/download.html.erb
+++ b/app/views/cites_trade/download.html.erb
@@ -1,5 +1,7 @@
 <div class="grid_16 main_content">
-  
+
+  <%= render :partial => 'net_trade_warning' %>
+
   <table id="this_should_not_be_a_table" border="0" align="center">
     <tr>
       <td><h3 align="center"><%= t('reports') %> <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,10 @@ en:
   errors:
     no_data_1: "Your query has returned no data"
     no_data_2: "Please select other variables or check in the UNEP-WCMC Species Database that you are using the correct spelling/scientific name"
+  warnings:
+    net_trade_1: "Please read carefully:"
+    net_trade_2: "Net trade is the result of subtracting a country's re-exports from its imports. Therefore if your data selection involved imports to or exports from specified countries then you cannot calculate net imports or exports."
+    net_trade_3: "The result will be gross import or export."
 
   year_text: "Year Range"
   year_tip: "Select start (From) and end (To) years for your query. It is advisable to limit your data request to a year span not exceeding 5 years"
@@ -33,6 +37,8 @@ en:
   search_selection: "Search Selection:"
   search: "Search"
   reset: "Reset"
+  reselect: "Reselect Data"
+  continue: "Continue"
 
   download: "Download"
   db_guide: "A Guide to Using the CITES Trade Database"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,6 +4,10 @@ es:
   errors:
     no_data_1: "Su consulta ha devuelto ningún dato"
     no_data_2: "Por favor selecciona otras variables o verifica en la Base de Datos de Especies UNEP-WCMC que está utilizando la ortografía/el nombre correctos"
+  warnings:
+    net_trade_1: "Por favor, lea cuidadosamente:"
+    net_trade_2: "El comercio neto es el resultado de sustraer los re-exportaciones de un país de sus importaciones. Por lo tanto, si su selección de datos involucrada las importaciones o las exportaciones procedentes de países determinados, no se puede calcular las importaciones o exportaciones netas."
+    net_trade_3: "El resultado será la importación o la exportación bruta."
 
   year_text: "Rango de Años"
   year_tip: "Seleccione el año de inicio (De) y el año final (A) para su búsqueda. Es aconsejable limitar su búsqueda de datos a un rango que no exceda de los 5 años"
@@ -30,6 +34,8 @@ es:
   search_selection: "Criterios de búsqueda seleccionados:"
   search: "Buscar"
   reset: "Reajustar"
+  reselect: "Volver a Seleccionar los Datos"
+  continue: "Continuar"
 
   download: "Descargar"
   db_guide: "Una Guía para Utilizar la Base de Datos sobre el Comercio CITES"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,6 +4,10 @@ fr:
   errors:
     no_data_1: "Votre recherche n'a retourné aucune donnée"
     no_data_2: "S'il vous plaît sélectionner autres variables ou vérifier dans la Base de Données des Espèces UNEP-WCMC que vous utilisez l'orthographe/nom scientifique corrects"
+  warnings:
+    net_trade_1: "S'il vous plaît lire attentivement:"
+    net_trade_2: "Le commerce net est le résultat de la soustraction des réexportations d'un pays de ses importations. Par conséquent, si votre sélection de données concerne des importations ou des exportations des pays spécifiés, vous ne pouvez pas calculer les importations ou les exportations nettes."
+    net_trade_3: "Le résultat sera l'importation ou exportation brute."
 
   year_text: "Gamme des Années"
   year_tip: "Sélectionnez les années de début (De) et de fin (A) pour votre recherche. Il est conseillé de limiter votre demande de données avec une gamme des années de 5 ans ou moins"
@@ -30,6 +34,8 @@ fr:
   search_selection: "Critères de recherche sélectionnés:"
   search: "Rechercher"
   reset: "Réinitialiser"
+  reselect: "Resélectionner les Données"
+  continue: "Continuer"
 
   download: "Télécharger"
   db_guide: "Un Guide d'Utilisation de la Base de Données sur le Commerce CITES"


### PR DESCRIPTION
In the current web version of the database, if you select a net trade output, there is a warning message that automatically pops up (see attached) with options to either ‘reselect data’ or ‘continue’. Should replicate this.
