### PR TITLE
[Finishes #65473470] 

### DIFF
--- a/app/models/trade/sandbox_filter.rb
+++ b/app/models/trade/sandbox_filter.rb
@@ -17,7 +17,8 @@ class Trade::SandboxFilter < Trade::Filter
      :source_code, :purpose_code, :trading_partner, :country_of_origin,
      :export_permit, :origin_permit, :import_permit, :quantity ].each do |var|
       if @options[var]
-        @query = @query.where(var => (@options[var] == "-1" ? nil : @options[var]))
+        @query = @query.
+          where(var => (@options[var] == "-1" ? nil : @options[var].split(',')))
       end
     end
   end


### PR DESCRIPTION
If the error has a string with comma separated values, there were no results being fetch.

This can be tested with the following file:
- test_upload_exporter_all_primary_errors.csv

And the error with the year format and the year data type.
