### PR TITLE
[#65555822] localised auto notes

### DIFF
--- a/app/models/m_listing_change.rb
+++ b/app/models/m_listing_change.rb
@@ -50,7 +50,7 @@ class MListingChange < ActiveRecord::Base
   self.primary_key = :id
 
   translates :short_note, :full_note, :hash_full_note,
-    :inherited_short_note, :inherited_full_note
+    :inherited_short_note, :inherited_full_note, :auto_note
 
   belongs_to :designation
   belongs_to :taxon_concept, :class_name => 'MTaxonConcept'
@@ -93,12 +93,12 @@ class MListingChange < ActiveRecord::Base
         :only => [
           :id, :change_type_name, :species_listing_name, :party_id,
           :is_current, :hash_ann_symbol, :hash_ann_parent_symbol,
-          :effective_at, :auto_note, :inclusion_taxon_concept_id
+          :effective_at, :inclusion_taxon_concept_id
         ],
         :methods => [
           :countries_ids,
           :short_note, :full_note, :hash_full_note,
-          :inherited_short_note, :inherited_full_note,
+          :inherited_short_note, :inherited_full_note, :auto_note
         ]
       ).symbolize_keys
     )

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -127,7 +127,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
                   taxon_concepts_mview.rank_name = 'SUBSPECIES'
                   OR taxon_concepts_mview.rank_name = 'VARIETY'
                 )
-                AND listing_changes_mview.auto_note IS NULL
+                AND listing_changes_mview.auto_note_en IS NULL
               )
             SQL
       ).
@@ -148,7 +148,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               listing_changes_mview.effective_at,
               listing_changes_mview.full_note_en,
               listing_changes_mview.short_note_en,
-              listing_changes_mview.auto_note,
+              listing_changes_mview.auto_note_en,
               listing_changes_mview.change_type_name,
               listing_changes_mview.hash_full_note_en,
               listing_changes_mview.hash_ann_parent_symbol,
@@ -185,7 +185,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
       where(<<-SQL
               taxon_concepts_mview.rank_name = 'SPECIES' OR 
               ( taxon_concepts_mview.rank_name = 'SUBSPECIES' AND
-                listing_changes_mview.auto_note IS NULL )
+                listing_changes_mview.auto_note_en IS NULL )
             SQL
       ).
       joins(<<-SQL
@@ -205,7 +205,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               listing_changes_mview.effective_at,
               listing_changes_mview.full_note_en,
               listing_changes_mview.short_note_en,
-              listing_changes_mview.auto_note,
+              listing_changes_mview.auto_note_en,
               listing_changes_mview.hash_full_note_en,
               listing_changes_mview.hash_ann_parent_symbol,
               listing_changes_mview.hash_ann_symbol,

--- a/app/serializers/species/show_taxon_concept_serializer_cms.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cms.rb
@@ -16,7 +16,7 @@ class Species::ShowTaxonConceptSerializerCms < Species::ShowTaxonConceptSerializ
                   taxon_concepts_mview.rank_name = 'SUBSPECIES'
                   OR taxon_concepts_mview.rank_name = 'VARIETY'
                 )
-                AND listing_changes_mview.auto_note IS NULL
+                AND listing_changes_mview.auto_note_en IS NULL
               )
             SQL
       ).
@@ -36,7 +36,7 @@ class Species::ShowTaxonConceptSerializerCms < Species::ShowTaxonConceptSerializ
               listing_changes_mview.effective_at,
               listing_changes_mview.full_note_en,
               listing_changes_mview.short_note_en,
-              listing_changes_mview.auto_note,
+              listing_changes_mview.auto_note_en,
               listing_changes_mview.inclusion_taxon_concept_id,
               listing_changes_mview.inherited_full_note_en,
               listing_changes_mview.inherited_short_note_en,

--- a/db/mviews/000_helpers.sql
+++ b/db/mviews/000_helpers.sql
@@ -84,21 +84,67 @@ CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name 
 COMMENT ON FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255)) IS
   'Returns full name with ssp where applicable depending on rank.';
 
-CREATE OR REPLACE FUNCTION ancestor_listing_auto_note(rank_name VARCHAR(255), full_name VARCHAR(255), change_type_name VARCHAR(255))
+DROP FUNCTION IF EXISTS ancestor_listing_auto_note(rank_name VARCHAR(255), full_name VARCHAR(255), change_type_name VARCHAR(255));
+
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note(taxon_concept taxon_concepts, listing_change listing_changes, locale CHAR(2))
+RETURNS TEXT
+  LANGUAGE plpgsql STRICT
+  AS $$
+  DECLARE
+    result TEXT;
+  BEGIN
+    IF NOT ARRAY[LOWER(locale)] && ARRAY['en', 'es', 'fr'] THEN
+      locale := 'en';
+    END IF;
+    EXECUTE 'SELECT
+      UPPER(COALESCE(
+        ranks.display_name_' || locale || ',
+        ranks.display_name_en,
+        ranks.name
+      )) || '' '' ||
+      COALESCE(
+        change_types.display_name_' || locale || ',
+        change_types.display_name_en,
+        change_types.name
+      ) || '' '' ||
+      full_name_with_spp(ranks.name, ''' || taxon_concept.full_name || ''')
+      FROM ranks, change_types
+      WHERE ranks.id = ' || taxon_concept.rank_id || '
+      AND change_types.id = ' || listing_change.change_type_id
+    INTO result;
+    RETURN result;
+  END;
+  $$;
+
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_en(taxon_concepts, listing_changes)
 RETURNS TEXT
   LANGUAGE sql IMMUTABLE
   AS $$
-    SELECT $1 || ' ' ||
-    CASE
-      WHEN $3 = 'DELETION' THEN 'deletion'
-      WHEN $3 = 'RESERVATION' THEN 'reservation'
-      WHEN $3 = 'RESERVATION_WITHDRAWAL' THEN 'reservaton withdrawn'
-      ELSE 'listing'
-    END || ' ' || full_name_with_spp($1, $2);
+    SELECT * FROM ancestor_listing_auto_note($1, $2, 'en');
   $$;
 
-COMMENT ON FUNCTION ancestor_listing_auto_note(rank_name VARCHAR(255), full_name VARCHAR(255), change_type_name VARCHAR(255)) IS
-  'Returns auto note (used for inherited listing changes).';
+COMMENT ON FUNCTION ancestor_listing_auto_note_en(taxon_concepts, listing_changes) IS
+  'Returns English auto note (used for inherited listing changes).';
+
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_es(taxon_concepts, listing_changes)
+RETURNS TEXT
+  LANGUAGE sql IMMUTABLE
+  AS $$
+    SELECT * FROM ancestor_listing_auto_note($1, $2, 'es');
+  $$;
+
+COMMENT ON FUNCTION ancestor_listing_auto_note_es(taxon_concepts, listing_changes) IS
+  'Returns Spanish auto note (used for inherited listing changes).';
+
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_fr(taxon_concepts, listing_changes)
+RETURNS TEXT
+  LANGUAGE sql IMMUTABLE
+  AS $$
+    SELECT * FROM ancestor_listing_auto_note($1, $2, 'fr');
+  $$;
+
+COMMENT ON FUNCTION ancestor_listing_auto_note_fr(taxon_concepts, listing_changes) IS
+  'Returns French auto note (used for inherited listing changes).';
 
 CREATE OR REPLACE FUNCTION rebuild_mviews() RETURNS void
   LANGUAGE plpgsql

--- a/db/mviews/005_rebuild_designation_listing_changes_mview.sql
+++ b/db/mviews/005_rebuild_designation_listing_changes_mview.sql
@@ -62,20 +62,38 @@ CREATE OR REPLACE FUNCTION rebuild_designation_listing_changes_mview(
     NULL::TEXT AS inherited_short_note_fr, -- this column is populated later
     NULL::TEXT AS inherited_full_note_fr, -- this column is populated later
     CASE
-    WHEN inclusion_taxon_concept_id IS NOT NULL
-    THEN ancestor_listing_auto_note(
-      inclusion_taxon_concepts.data->''rank_name'',
-      inclusion_taxon_concepts.full_name,
-      change_types.name
+    WHEN listing_changes.inclusion_taxon_concept_id IS NOT NULL
+    THEN ancestor_listing_auto_note_en(
+      inclusion_taxon_concepts, listing_changes
     )
     WHEN applicable_listing_changes.affected_taxon_concept_id != listing_changes.taxon_concept_id
-    THEN ancestor_listing_auto_note(
-      original_taxon_concepts.data->''rank_name'',
-      original_taxon_concepts.full_name,
-      change_types.name
+    THEN ancestor_listing_auto_note_en(
+      original_taxon_concepts, listing_changes
     )
     ELSE NULL
-    END AS auto_note,
+    END AS auto_note_en,
+    CASE
+    WHEN listing_changes.inclusion_taxon_concept_id IS NOT NULL
+    THEN ancestor_listing_auto_note_es(
+      inclusion_taxon_concepts, listing_changes
+    )
+    WHEN applicable_listing_changes.affected_taxon_concept_id != listing_changes.taxon_concept_id
+    THEN ancestor_listing_auto_note_es(
+      original_taxon_concepts, listing_changes
+    )
+    ELSE NULL
+    END AS auto_note_es,
+    CASE
+    WHEN listing_changes.inclusion_taxon_concept_id IS NOT NULL
+    THEN ancestor_listing_auto_note_fr(
+      inclusion_taxon_concepts, listing_changes
+    )
+    WHEN applicable_listing_changes.affected_taxon_concept_id != listing_changes.taxon_concept_id
+    THEN ancestor_listing_auto_note_fr(
+      original_taxon_concepts, listing_changes
+    )
+    ELSE NULL
+    END AS auto_note_fr,
     listing_changes.is_current,
     listing_changes.explicit_change,
     populations.countries_ids_ary,

--- a/db/mviews/007a_rebuild_cites_species_listing_mview.sql
+++ b/db/mviews/007a_rebuild_cites_species_listing_mview.sql
@@ -57,7 +57,7 @@ SELECT
     ARRAY_AGG(
       '**' || listing_changes_mview.species_listing_name || '** '
       || CASE 
-        WHEN LENGTH(listing_changes_mview.auto_note) > 0 THEN '[' || listing_changes_mview.auto_note || '] ' 
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] ' 
         ELSE '' 
       END 
       || CASE 

--- a/db/mviews/007b_rebuild_eu_species_listing_mview.sql
+++ b/db/mviews/007b_rebuild_eu_species_listing_mview.sql
@@ -56,7 +56,7 @@ SELECT
     ARRAY_AGG(
       '**' || listing_changes_mview.species_listing_name || '** '
       || CASE 
-        WHEN LENGTH(listing_changes_mview.auto_note) > 0 THEN '[' || listing_changes_mview.auto_note || '] ' 
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] ' 
         ELSE '' 
       END 
       || CASE 

--- a/db/mviews/007c_rebuild_cms_species_listing_mview.sql
+++ b/db/mviews/007c_rebuild_cms_species_listing_mview.sql
@@ -42,7 +42,7 @@ SELECT
     ARRAY_AGG(
       '**' || listing_changes_mview.species_listing_name || '** '
       || CASE 
-      WHEN LENGTH(listing_changes_mview.auto_note) > 0 THEN '[' || listing_changes_mview.auto_note || '] ' 
+      WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] ' 
       ELSE '' 
       END 
       || CASE 


### PR DESCRIPTION
This finalises dynamic content translations and builds on translated ranks & change types.

I used this data for testing:
UPDATE change_types SET display_name_en = 'listing', display_name_es = 'inclusión'
WHERE name = 'ADDITION';
UPDATE change_types SET display_name_en = 'reservation', display_name_es = 'reserva'
WHERE name = 'RESERVATION';
UPDATE change_types SET display_name_en = 'reservation withdrawn', display_name_es = 'reserva retirada'
WHERE name = 'RESERVATION_WITHDRAWN';
UPDATE change_types SET display_name_en = 'deletion', display_name_es = 'supresión'
WHERE name = 'DELETION';
UPDATE ranks SET display_name_es = 'Reino' WHERE name = 'KINGDOM';
UPDATE ranks SET display_name_es = 'Filo' WHERE name = 'PHYLUM';
UPDATE ranks SET display_name_es = 'Clase' WHERE name = 'CLASS';
UPDATE ranks SET display_name_es = 'Orden' WHERE name = 'ORDER';
UPDATE ranks SET display_name_es = 'Familia' WHERE name = 'FAMILY';
UPDATE ranks SET display_name_es = 'Género' WHERE name = 'GENUS';
UPDATE ranks SET display_name_es = 'Especie' WHERE name = 'SPECIES';
1. rake db:migrate
2. rebuild_listing_changes_mview()
3. rake tmp:clear

It is worth remembering that this change needs to be properly resolved when we merge develop in (or the other way round), because in develop the SQL functions which calculate auto notes are defined in a different file (db / helpers / 000_helpers.sql)
