### PR TITLE
Hide trade names in public auto complete

### DIFF
--- a/app/models/species/search_params.rb
+++ b/app/models/species/search_params.rb
@@ -28,7 +28,7 @@ class Species::SearchParams < Hash
     unless [:cites, :eu, :cms].include? sanitized_params[:geo_entity_scope]
       sanitized_params[:geo_entity_scope] = :cites
     end
-    unless [:speciesplus, :trade].include? sanitized_params[:visibility]
+    unless [:speciesplus, :trade, :trade_internal].include? sanitized_params[:visibility]
       sanitized_params[:visibility] = :speciesplus
     end
     super(sanitized_params)

--- a/app/models/species/taxon_concept_prefix_matcher.rb
+++ b/app/models/species/taxon_concept_prefix_matcher.rb
@@ -36,10 +36,13 @@ class Species::TaxonConceptPrefixMatcher
       @query.by_cites_eu_taxonomy
     end
 
-    if @visibility == :trade
-      @query = @query.where(:name_status => ['A', 'H', 'T'])
+    @query = if @visibility == :trade_internal
+       @query # no filter on name_status for internal search by reported taxon
+    elsif @visibility == :trade
+      # for both public & internal search by accepted taxon
+      @query.where(:name_status => ['A', 'H'])
     else
-      @query = @query.without_hidden_subspecies.where(:name_status => 'A')
+      @query.without_hidden_subspecies.where(:name_status => 'A')
     end
 
     if @taxon_concept_query

--- a/spec/models/species/hybrid_prefix_matcher_spec.rb
+++ b/spec/models/species/hybrid_prefix_matcher_spec.rb
@@ -13,6 +13,16 @@ describe Species::TaxonConceptPrefixMatcher do
         }
         specify { subject.results.should include(@hybrid) }
       end
+      context "when trade internal visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Falco hybrid',
+            :ranks => [],
+            :visibility => :trade_internal
+          })
+        }
+        specify { subject.results.should include(@hybrid) }
+      end
       context "when speciesplus visibility" do
         subject {
           Species::TaxonConceptPrefixMatcher.new({

--- a/spec/models/species/trade_name_prefix_matcher_spec.rb
+++ b/spec/models/species/trade_name_prefix_matcher_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+describe Species::TaxonConceptPrefixMatcher do
+  before(:each) do
+    @accepted_name = create_cites_eu_genus(
+      :taxon_name => create(:taxon_name, :scientific_name => 'Pavona')
+    )
+    @trade_name = create_cites_eu_species(
+      :taxon_name => create(:taxon_name, :scientific_name => 'Pavona minor'),
+      :name_status => 'T'
+    )
+    create(:taxon_relationship,
+      :taxon_concept => @accepted_name,
+      :other_taxon_concept => @trade_name,
+      :taxon_relationship_type => create(
+        :taxon_relationship_type,
+        :name => TaxonRelationshipType::HAS_TRADE_NAME
+      )
+    )
+    Sapi::StoredProcedures.rebuild_cites_taxonomy_and_listings
+    @accepted_name = MTaxonConcept.find(@accepted_name.id)
+    @trade_name = MTaxonConcept.find(@trade_name.id)
+  end
+  describe :results do
+    context "when searching for trade name" do
+      context "when trade visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Pavona',
+            :ranks => [],
+            :visibility => :trade
+          })
+        }
+        specify { subject.results.should_not include(@trade_name) }
+        specify { subject.results.should include(@accepted_name) }
+      end
+      context "when trade internal visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Pavona',
+            :ranks => [],
+            :visibility => :trade_internal
+          })
+        }
+        specify { subject.results.should include(@trade_name) }
+        specify { subject.results.should include(@accepted_name) }
+      end
+      context "when speciesplus visibility" do
+        subject {
+          Species::TaxonConceptPrefixMatcher.new({
+            :taxon_concept_query => 'Pavona',
+            :ranks => []
+          })
+        }
+        specify { subject.results.should_not include(@trade_name) }
+        specify { subject.results.should include(@accepted_name) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trade names should not show up in the public website auto complete (e.g. Pavona minor, Ovis canadensis canadensis). Because we're making them searchable in the admin tool through the filter by reported taxon functionality, I guess it should not show up in the accepted taxon concept autocomplete in trade admin either.
I added a new visibility scope for the autocomplete, which is called trade_internal - that one should be passed for the "reported ad autocomplete query" as it does not filter by name status at all, so will allow to search by synonym, trade name or anything else. I hope this does not conflict with the work on search_by_reported_as.
