### PR TITLE
[#66065306] clear the auto complete input field

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -559,12 +559,19 @@ $(document).ready(function(){
         selected_taxa = ui.item.value;
     		$('#species_out').text(ui.item.label);
     		return false;
-    	}
+    	},
+      close: function( event, ui ) {
+        $(this).val('');
+      }
     }).data( "ui-autocomplete" )._renderItem = function( ul, item ) {
       return $( "<li>" )
         .append( "<a>" + item.drop_label + "</a>" )
         .appendTo( ul );
       };
+
+    $("#taxon_search").blur(function(e){
+      $(this).val('');
+    });
   }
 
   //Autocomplete for cites_genus


### PR DESCRIPTION
when user has started to type in autocomplete field but then never selected anything from dropdown,  just clear this field so that people don't think it's a valid selection
