### PR TITLE
prevent exceptions when incorrect geo entity types set sent

### DIFF
--- a/app/controllers/api/v1/geo_entities_controller.rb
+++ b/app/controllers/api/v1/geo_entities_controller.rb
@@ -6,7 +6,8 @@ class Api::V1::GeoEntitiesController < ApplicationController
 
   def index
     locale = params['locale'] || I18n.locale
-    geo_entity_types = if params[:geo_entity_types_set]
+    geo_entity_types = if params[:geo_entity_types_set] &&
+      GeoEntityType::SETS.has_key?(params[:geo_entity_types_set])
                          GeoEntityType::SETS[params[:geo_entity_types_set]]
                        else
                          GeoEntityType::SETS[GeoEntityType::DEFAULT_SET]

--- a/app/controllers/checklist/geo_entities_controller.rb
+++ b/app/controllers/checklist/geo_entities_controller.rb
@@ -7,7 +7,8 @@ class Checklist::GeoEntitiesController < ApplicationController
 
   #override the serializer by using render :text, old ember-data won't handle json root
   def index
-    geo_entity_types = if params[:geo_entity_types_set]
+    geo_entity_types = if params[:geo_entity_types_set] &&
+      GeoEntityType::SETS.has_key?(params[:geo_entity_types_set])
                          GeoEntityType::SETS[params[:geo_entity_types_set]]
                        else
                          GeoEntityType::SETS[GeoEntityType::DEFAULT_SET]


### PR DESCRIPTION
A NoMethodError occurred in geo_entities#index:

  undefined method `empty?' for nil:NilClass
  app/controllers/checklist/geo_entities_controller.rb:16:in`index'

---
## Request:
- URL        : http://sapi.unepwcmc-013.vm.brightbox.net/checklist/geo_entities?geo_entity_types_set=1?
- HTTP Method: GET
- IP address : 193.5.216.100
- Parameters : {"geo_entity_types_set"=>"1?", "action"=>"index", "controller"=>"checklist/geo_entities"}
- Timestamp  : 2014-02-28 09:43:00 UTC
- Server : unepwcmc-013.vm.brightbox.net
- Rails root : /home/rails/sapi/releases/20140228075541
- Process: 8330
