### PR TITLE
Fix linking shared directories

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -104,15 +104,7 @@ set :copy_exclude, [ '.git' ]
 # The shared area is prepared with 'deploy:setup' and all the shared
 # items are symlinked in when the code is updated.
 set :local_shared_files, %w(config/database.yml)
-set :local_shared_dirs, %w(tmp/pids public/downloads public/uploads
-  public/downloads/cites_trade
-  public/downloads/cites_listings public/downloads/eu_listings public/downloads/cms_listings
-  public/downloads/eu_decisions public/downloads/cites_suspensions public/downloads/quotas
-  public/downloads/checklist public/downloads/taxon_concepts_names
-  public/downloads/shipments public/downloads/comptab
-  public/downloads/gross_exports public/downloads/gross_imports
-  public/downloads/net_exports public/downloads/net_imports
-  public/downloads/trade_download_stats public/downloads/taxon_concepts_distributions)
+set :local_shared_dirs, %w(tmp/pids public/downloads public/uploads)
 
 ## Global Shared Area
 # These are the list of files and directories that you want


### PR DESCRIPTION
While trying to get the trade guidelines to download, I realized that the way we're linking shared directories is probably incorrect. Why would we need to link every subdirectory?
