### PR TITLE
fix to search by taxon in admin tool

### DIFF
--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -15,7 +15,7 @@ class Admin::TaxonConceptsController < Admin::SimpleCrudController
     @hybrid.build_taxon_name
     @taxon_concepts = TaxonConceptMatcher.new(@search_params).taxon_concepts.
       includes([:rank, :taxonomy, :taxon_name, :parent]).
-      order(:taxonomic_position).page(params[:page])
+      order("taxon_concepts.taxonomic_position").page(params[:page])
     if @taxon_concepts.count == 1
       redirect_to admin_taxon_concept_names_path(@taxon_concepts.first),
         :notice => "Your search returned only one result,

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -129,13 +129,6 @@ class TaxonConcept < ActiveRecord::Base
   before_validation :check_accepted_taxon_concept_exists
   before_validation :ensure_taxonomic_position
 
-  scope :by_scientific_name, lambda { |scientific_name|
-    where([
-      "UPPER(full_name) LIKE BTRIM(UPPER(:sci_name_prefix))",
-      :sci_name_prefix => "#{scientific_name}%"
-    ])
-  }
-
   scope :at_parent_ranks, lambda{ |rank|
     joins_sql = <<-SQL
       INNER JOIN ranks ON ranks.id = taxon_concepts.rank_id

--- a/app/models/taxon_concept_matcher.rb
+++ b/app/models/taxon_concept_matcher.rb
@@ -17,7 +17,11 @@ class TaxonConceptMatcher
     @taxon_concepts = initialize_rel
     apply_taxonomy_options_to_rel
     if @scientific_name.present?
-      @taxon_concepts = @taxon_concepts.by_scientific_name(@scientific_name)
+      @taxon_concepts = @taxon_concepts.where([
+      "UPPER(taxon_concepts.full_name) LIKE BTRIM(UPPER(:sci_name_prefix))",
+      :sci_name_prefix => "#{@scientific_name}%"
+    ])
+
     end
   end
 

--- a/spec/controllers/admin/taxon_concepts_controller_spec.rb
+++ b/spec/controllers/admin/taxon_concepts_controller_spec.rb
@@ -1,10 +1,33 @@
+require 'spec_helper'
+
 describe Admin::TaxonConceptsController do
   describe "GET index" do
+    before(:each) do
+      @taxon = create_cites_eu_species(
+        :taxon_name => create(:taxon_name, :scientific_name => 'indefinitus'),
+        :taxonomic_position => '1.1.2',
+        :parent => create_cites_eu_genus(
+          :taxon_name => create(:taxon_name, :scientific_name => 'Foobarus'),
+          :taxonomic_position => '1.1.1'
+        )
+      )
+    end
     it "renders the index template" do
-      cites_eu
       get :index
       response.should render_template("index")
       response.should render_template("layouts/admin")
+    end
+    it "redirects if 1 result" do
+      get :index, search_params: {
+        taxonomy: {id: cites_eu.id}, scientific_name: 'Foobarus i'
+      }
+      response.should redirect_to(admin_taxon_concept_names_path(@taxon))
+    end
+    it "assigns taxa in taxonomic order" do
+      get :index, search_params: {
+        taxonomy: {id: cites_eu.id}, scientific_name: 'Foobarus'
+      }
+      assigns(:taxon_concepts).should eq([@taxon.parent, @taxon])
     end
   end
 


### PR DESCRIPTION
An ActiveRecord::StatementInvalid occurred in taxon_concepts#index:

  PG::AmbiguousColumn: ERROR:  column reference "full_name" is ambiguous
LINE 1: ...AND "taxon_concepts"."taxonomy_id" = 1 AND (UPPER(full_name)...
                                                             ^
: SELECT COUNT(DISTINCT count_column) FROM (SELECT  "taxon_concepts"."id" AS count_column FROM "taxon_concepts" LEFT OUTER JOIN "ranks" ON "ranks"."id" = "taxon_concepts"."rank_id" LEFT OUTER JOIN "taxonomies" ON "taxonomies"."id" = "taxon_concepts"."taxonomy_id" LEFT OUTER JOIN "taxon_names" ON "taxon_names"."id" = "taxon_concepts"."taxon_name_id" LEFT OUTER JOIN "taxon_concepts" "parents_taxon_concepts" ON "parents_taxon_concepts"."id" = "taxon_concepts"."parent_id" WHERE "taxon_concepts"."name_status" = 'A' AND "taxon_concepts"."taxonomy_id" = 1 AND (UPPER(full_name) LIKE BTRIM(UPPER('Acanthastrea spp.%'))) LIMIT 25 OFFSET 0) subquery_for_count
  activerecord (3.2.17) lib/active_record/connection_adapters/postgresql_adapter.rb:1163:in `exec'
