### PR TITLE
[Finishes #67098860] 

### DIFF
--- a/app/serializers/species/quota_serializer.rb
+++ b/app/serializers/species/quota_serializer.rb
@@ -3,4 +3,12 @@ class Species::QuotaSerializer < ActiveModel::Serializer
     :notes, :url, :public_display, :is_current, :unit_name, :subspecies_info
 
   has_one :geo_entity, :serializer => Species::GeoEntitySerializer
+
+  def quota
+    if object.quota == -1
+      "in prep."
+    else
+      object.quota
+    end
+  end
 end


### PR DESCRIPTION
When quotas value is -1 it should display as 'in prep.' in species plus (examploe: Strombus gigas)
