### PR TITLE
faster way to filter down taxa for different autocomplete targets

### DIFF
--- a/app/models/species/taxon_concept_prefix_matcher.rb
+++ b/app/models/species/taxon_concept_prefix_matcher.rb
@@ -39,9 +39,9 @@ class Species::TaxonConceptPrefixMatcher
     @query = if @visibility == :trade_internal
        @query # no filter on name_status for internal search
     elsif @visibility == :trade
-      @query.where(:name_status => ['A', 'H', 'N'])
+      @query.where(:show_in_trade_ac => true)
     else
-      @query.without_hidden_subspecies.where(:name_status => 'A')
+      @query = @query.where(:show_in_species_plus_ac => true)
     end
 
     if @taxon_concept_query

--- a/db/mviews/001_rebuild_taxon_concepts_mview.sql
+++ b/db/mviews/001_rebuild_taxon_concepts_mview.sql
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION rebuild_taxon_concepts_mview() RETURNS void
     WHEN data->'kingdom_name' = 'Animalia' THEN 0
     ELSE 1
     END AS kingdom_position,
-    taxonomic_position,
+    taxon_concepts.taxonomic_position,
     data->'kingdom_name' AS kingdom_name,
     data->'phylum_name' AS phylum_name,
     data->'class_name' AS class_name,
@@ -103,10 +103,40 @@ CREATE OR REPLACE FUNCTION rebuild_taxon_concepts_mview() RETURNS void
     common_names.*,
     synonyms.*,
     subspecies.subspecies_ary,
-    countries_ids_ary
+    countries_ids_ary,
+    CASE
+      WHEN
+        name_status = 'A'
+        AND (
+          ranks.name != 'SUBSPECIES'
+          AND ranks.name != 'VARIETY'
+          OR (listing->'cites_show')::BOOLEAN
+        )
+      THEN TRUE
+      ELSE FALSE
+    END AS show_in_species_plus_ac,
+    CASE
+      WHEN
+        name_status = 'A'
+        AND listing->'cites_status' != 'LISTED'
+        AND (
+          ranks.name != 'SUBSPECIES'
+          AND ranks.name != 'VARIETY'
+          OR (listing->'cites_show')::BOOLEAN
+        )
+      THEN TRUE
+      ELSE FALSE
+    END AS show_in_checklist_ac,
+    CASE
+      WHEN
+        taxonomies.name = 'CITES_EU'
+        AND ARRAY['A', 'H', 'N']::VARCHAR[] && ARRAY[name_status]
+      THEN TRUE
+      ELSE FALSE
+    END AS show_in_trade_ac
     FROM taxon_concepts
-    LEFT JOIN taxonomies
-    ON taxonomies.id = taxon_concepts.taxonomy_id
+    JOIN ranks ON ranks.id = rank_id
+    JOIN taxonomies ON taxonomies.id = taxon_concepts.taxonomy_id
     LEFT JOIN (
       SELECT *
       FROM
@@ -176,14 +206,25 @@ CREATE OR REPLACE FUNCTION rebuild_taxon_concepts_mview() RETURNS void
     RAISE INFO 'Creating indexes on taxon_concepts materialized view (tmp)';
     CREATE INDEX ON taxon_concepts_mview_tmp (id);
     CREATE INDEX ON taxon_concepts_mview_tmp (parent_id);
-    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops);
     CREATE INDEX ON taxon_concepts_mview_tmp (taxonomy_is_cites_eu, cites_listed, kingdom_position);
-    CREATE INDEX ON taxon_concepts_mview_tmp (taxonomy_is_cites_eu, rank_name); --this one used for Species+ autocomplete (both main and higher taxa in downloads)
     CREATE INDEX ON taxon_concepts_mview_tmp (cms_show, name_status, cms_listing_original, taxonomy_is_cites_eu, rank_name); -- cms csv download
     CREATE INDEX ON taxon_concepts_mview_tmp (cites_show, name_status, cites_listing_original, taxonomy_is_cites_eu, rank_name); -- cites csv download
     CREATE INDEX ON taxon_concepts_mview_tmp (eu_show, name_status, eu_listing_original, taxonomy_is_cites_eu, rank_name); -- eu csv download
     CREATE INDEX ON taxon_concepts_mview_tmp USING GIN (countries_ids_ary);
 
+    --this one used for Species+ autocomplete (both main and higher taxa in downloads)
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_species_plus_ac);
+    --this one used for Checklist autocomplete
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_checklist_ac);
+    --this one used for Trade autocomplete
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_trade_ac);
+
+    --this one used for Species+ autocomplete (both main and higher taxa in downloads)
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_species_plus_ac);
+    --this one used for Checklist autocomplete
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_checklist_ac);
+    --this one used for Trade autocomplete
+    CREATE INDEX ON taxon_concepts_mview_tmp USING BTREE(UPPER(full_name) text_pattern_ops, taxonomy_is_cites_eu, rank_name, show_in_trade_ac);
 
     RAISE INFO 'Swapping concepts materialized view';
     DROP table IF EXISTS taxon_concepts_mview CASCADE;


### PR DESCRIPTION
rake db:migrate
select \* from rebuild_taxon_concepts_mview()
