### PR TITLE
Added to distributions downloads:

### DIFF
--- a/app/models/species/taxon_concepts_distributions_export.rb
+++ b/app/models/species/taxon_concepts_distributions_export.rb
@@ -19,7 +19,7 @@ private
 
   def sql_columns
     columns = [
-      :distribution_id, :id, :legacy_id, :phylum_name, :class_name, :order_name, :family_name,
+      :id, :legacy_id, :phylum_name, :class_name, :order_name, :family_name,
       :full_name, :rank_name, :geo_entity_type, :geo_entity_name,
       :geo_entity_iso_code2, :tags, :reference_full, :reference_id,
       :reference_legacy_id, :taxonomy_name, :created_at, :created_by
@@ -28,7 +28,7 @@ private
 
   def csv_column_headers
     headers = [
-      'Distribution Id', 'Id', 'Legacy Id', 'Phylum', 'Class', 'Order', 'Family',
+      'Id', 'Legacy Id', 'Phylum', 'Class', 'Order', 'Family',
       'Scientific Name', 'Rank', 'Geo_entity', 'Country_full',
       'ISO Code', 'Country Tags', 'Reference_full', 'Reference IDS',
       'Ref Legacy ID', 'Taxonomy', 'Added Date', 'Added by'

--- a/db/views/taxon_concepts_distributions_view.sql
+++ b/db/views/taxon_concepts_distributions_view.sql
@@ -1,7 +1,6 @@
 DROP VIEW IF EXISTS taxon_concepts_distributions_view;
 CREATE VIEW taxon_concepts_distributions_view AS
 SELECT
-  distributions.id AS distribution_id,
   taxon_concepts.id AS id,
   taxon_concepts.legacy_id AS legacy_id,
   data->'phylum_name' AS phylum_name,
@@ -33,6 +32,6 @@ LEFT JOIN taggings ON taggings.taggable_id = distributions.id
   AND taggings.taggable_type = 'Distribution'    
 LEFT JOIN tags ON tags.id = taggings.tag_id
 WHERE taxon_concepts.name_status IN ('A')
-GROUP BY distributions.id, taxon_concepts.id, taxon_concepts.legacy_id, geo_entity_types.name,
+GROUP BY taxon_concepts.id, taxon_concepts.legacy_id, geo_entity_types.name,
   geo_entities.name_en, geo_entities.iso_code2, "references".citation, "references".id,
   taxonomies.name


### PR DESCRIPTION
created_at, created_by
and including accepted taxons without distributions with distribution_id in the query result for extra clarity
