### PR TITLE
fix the calculation of show_in_checklist_ac flag

### DIFF
--- a/db/mviews/001_rebuild_taxon_concepts_mview.sql
+++ b/db/mviews/001_rebuild_taxon_concepts_mview.sql
@@ -118,7 +118,6 @@ CREATE OR REPLACE FUNCTION rebuild_taxon_concepts_mview() RETURNS void
     CASE
       WHEN
         name_status = 'A'
-        AND listing->'cites_status' != 'LISTED'
         AND (
           ranks.name != 'SUBSPECIES'
           AND ranks.name != 'VARIETY'

--- a/spec/models/taxon_concept/boa_constrictor_spec.rb
+++ b/spec/models/taxon_concept/boa_constrictor_spec.rb
@@ -87,7 +87,7 @@ describe TaxonConcept do
         end
         context "for subspecies Boa constrictor constrictor" do
           specify{ @subspecies2.cites_show.should be_false }
-        end        
+        end
       end
 
       describe :cites_listed_descendants do
@@ -117,6 +117,42 @@ describe TaxonConcept do
         end
         context "for subspecies Boa constrictor occidentalis" do
           specify{ @subspecies1.eu_listed.should be_true }
+        end
+      end
+
+      describe :show_in_species_plus_ac do
+        context "for family Boidae" do
+          specify{ @family.show_in_species_plus_ac.should be_true }
+        end
+        context "for genus Boa" do
+          specify{ @genus.show_in_species_plus_ac.should be_true }
+        end
+        context "for species Boa constrictor (inclusion in higher taxa listing)" do
+          specify{ @species.show_in_species_plus_ac.should be_true }
+        end
+        context "for subspecies Boa constrictor occidentalis" do
+          specify{ @subspecies1.show_in_species_plus_ac.should be_true }
+        end
+        context "for subspecies Boa constrictor constrictor" do
+          specify{ @subspecies2.show_in_species_plus_ac.should be_false }
+        end
+      end
+
+      describe :show_in_checklist_ac do
+        context "for family Boidae" do
+          specify{ @family.show_in_checklist_ac.should be_true }
+        end
+        context "for genus Boa" do
+          specify{ @genus.show_in_checklist_ac.should be_true }
+        end
+        context "for species Boa constrictor (inclusion in higher taxa listing)" do
+          specify{ @species.show_in_checklist_ac.should be_true }
+        end
+        context "for subspecies Boa constrictor occidentalis" do
+          specify{ @subspecies1.show_in_checklist_ac.should be_true }
+        end
+        context "for subspecies Boa constrictor constrictor" do
+          specify{ @subspecies2.show_in_checklist_ac.should be_false }
         end
       end
 

--- a/spec/models/taxon_concept/canis_lupus_spec.rb
+++ b/spec/models/taxon_concept/canis_lupus_spec.rb
@@ -20,11 +20,32 @@ describe TaxonConcept do
         context "for species Canis lupus" do
           specify{ @species.cites_listed.should be_true }
         end
+        context "for subspecies Canis lupus crassodon" do
+          specify{ @subspecies.cites_listed.should be_blank }
+        end
       end
 
       describe :eu_listed do
         context "for species Canis lupus" do
           specify{ @species.eu_listed.should be_true }
+        end
+      end
+
+      describe :show_in_species_plus_ac do
+        context "for species Canis lupus" do
+          specify{ @species.show_in_species_plus_ac.should be_true }
+        end
+        context "for subspecies Canis lupus crassodon" do
+          specify{ @subspecies.show_in_species_plus_ac.should be_false }
+        end
+      end
+
+      describe :show_in_checklist_ac do
+        context "for species Canis lupus" do
+          specify{ @species.show_in_checklist_ac.should be_true }
+        end
+        context "for subspecies Canis lupus crassodon" do
+          specify{ @subspecies.show_in_checklist_ac.should be_false }
         end
       end
 

--- a/spec/shared/canis_lupus.rb
+++ b/spec/shared/canis_lupus.rb
@@ -83,6 +83,10 @@ shared_context "Canis lupus" do
       :taxon_name => create(:taxon_name, :scientific_name => 'Lupus'),
       :parent => @genus
     )
+    @subspecies = create_cites_eu_subspecies(
+      :taxon_name => create(:taxon_name, :scientific_name => 'crassodon'),
+      :parent => @species
+    )
 
     [bhutan, india, nepal, pakistan, poland, spain, greece].each do |country|
       create(


### PR DESCRIPTION
there was an error in calculation of that flag in taxon_concepts_mview. it is not used at the moment (the checklist autocomplete uses the show_in_species_plus_ac flag). at this point the values of those 2 flags should be identical, but they will possibly diverge once the subspecies changes are applied to Species+ autocomplete. at which point it would be good to have the other flag working properly.
