### PR TITLE
adds distribution columns to checklist index csv download

### DIFF
--- a/app/models/checklist/column_display_name_mapping.rb
+++ b/app/models/checklist/column_display_name_mapping.rb
@@ -21,14 +21,21 @@ module Checklist::ColumnDisplayNameMapping
     :species_name => 'Species',
     :subspecies_name => 'Subspecies',
     :effective_at_formatted => 'EffectiveAt',
-    :countries_iso_codes => 'DistributionISOCodes',
-    :countries_full_names => 'DistributionFullNames',
     :cites_listing => 'CurrentListing',
     :cites_listing_original => 'CurrentListing',
     :eu_listing => 'CurrentListing',
     :eu_listing_original => 'CurrentListing',
     :cms_listing => 'CurrentListing',
-    :cms_listing_original => 'CurrentListing'
+    :cms_listing_original => 'CurrentListing',
+    :all_distribution_iso_codes => 'All_DistributionISOCodes',
+    :all_distribution => 'All_DistributionFullNames',
+    :native_distribution => 'NativeDistributionFullNames',
+    :introduced_distribution => 'Introduced_Distribution',
+    :introduced_uncertain_distribution =>'Introduced(?)_Distribution',
+    :reintroduced_distribution => 'Reintroduced_Distribution',
+    :extinct_distribution => 'Extinct_Distribution',
+    :extinct_uncertain_distribution => 'Extinct(?)_Distribution',
+    :uncertain_distribution => 'Distribution_Uncertain'
   }
 
   def self.column_display_name_for(column_name)

--- a/app/models/checklist/csv/index.rb
+++ b/app/models/checklist/csv/index.rb
@@ -18,7 +18,12 @@ class Checklist::Csv::Index < Checklist::Index
       if @english_common_names then :english_names end,
       if @spanish_common_names then :spanish_names end,
       if @french_common_names then :french_names end,
-      :cites_accepted, :countries_iso_codes, :countries_full_names
+      :cites_accepted,
+      :all_distribution_iso_codes, :all_distribution,
+      :native_distribution, :introduced_distribution,
+      :introduced_uncertain_distribution, :reintroduced_distribution,
+      :extinct_distribution, :extinct_uncertain_distribution,
+      :uncertain_distribution
     ]
   end
 

--- a/app/models/m_taxon_concept.rb
+++ b/app/models/m_taxon_concept.rb
@@ -188,13 +188,17 @@ class MTaxonConcept < ActiveRecord::Base
     end
   end
 
-  def countries_iso_codes
-    CountryDictionary.instance.get_iso_codes_by_ids(countries_ids)
-  end
-
-  def countries_full_names
-    CountryDictionary.instance.get_names_by_ids(countries_ids)
-  end
+  def countries_iso_codes; all_distribution_iso_codes; end
+  def countries_full_names; all_distribution; end
+  def all_distribution; parse_pg_array(all_distribution_ary || ''); end
+  def all_distribution_iso_codes; parse_pg_array(all_distribution_iso_codes_ary || ''); end
+  def native_distribution; parse_pg_array(native_distribution_ary || ''); end
+  def introduced_distribution; parse_pg_array(introduced_distribution_ary || ''); end
+  def introduced_uncertain_distribution; parse_pg_array(introduced_uncertain_distribution_ary || ''); end
+  def reintroduced_distribution; parse_pg_array(reintroduced_distribution_ary || ''); end
+  def extinct_distribution; parse_pg_array(extinct_distribution_ary || ''); end
+  def extinct_uncertain_distribution; parse_pg_array(extinct_uncertain_distribution_ary || ''); end
+  def uncertain_distribution; parse_pg_array(uncertain_distribution_ary || ''); end
 
   def recently_changed
     return (cites_listing_updated_at ? cites_listing_updated_at > 8.year.ago : false)


### PR DESCRIPTION
Ended up doing the simplest set of changes, that is without the COPY support and the translations. I believe adding COPY support to checklist csv downloads would be best done by approaching all outputs (because of the required amendments to the underlying sql), which would be too many changes to carry out now. As for translations, I think it's best to do that work in the checklist branch.
