### PR TITLE
Fix auto complete exception

### DIFF
--- a/app/models/species/taxon_concept_prefix_matcher.rb
+++ b/app/models/species/taxon_concept_prefix_matcher.rb
@@ -51,16 +51,18 @@ class Species::TaxonConceptPrefixMatcher
       @query.where(:show_in_species_plus_ac => true)
     end
 
-    if @taxon_concept_query
-      @query = @query.
+    @query = @query.
       select('id, full_name, rank_name,
         ARRAY_AGG_NOTNULL(matched_name ORDER BY matched_name) AS matching_names_ary').
-      where(
+      group([:id, :full_name, :rank_name, :rank_order])
+
+    if @taxon_concept_query
+      @query = @query.where(
         ActiveRecord::Base.send(:sanitize_sql_array, [
           "name_for_matching LIKE :sci_name_prefix",
           :sci_name_prefix => "#{@taxon_concept_query}%"
         ])
-      ).group([:id, :full_name, :rank_name, :rank_order])
+      )
     end
     @query
   end


### PR DESCRIPTION
Fix exception caused by this request:

 http://sapi.unepwcmc-012.vm.brightbox.net/api/v1/auto_complete_taxon_concepts?taxonomy=cms&ranks%5B%5D=KINGDOM&ranks%5B%5D=PHYLUM&ranks%5B%5D=CLASS&ranks%5B%5D=ORDER&ranks%5B%5D=FAMILY&per_page=1000
