### PR TITLE
do not return unnecessary search metadata to public frontend

### DIFF
--- a/app/controllers/cites_trade/shipments_controller.rb
+++ b/app/controllers/cites_trade/shipments_controller.rb
@@ -6,8 +6,9 @@ class CitesTrade::ShipmentsController < CitesTradeController
       :per_page => Trade::ShipmentsExport::PUBLIC_WEB_LIMIT
     }))
     render :json => @search,
-      :serializer => serializer_for_search(@search),
-      :meta => metadata_for_search(@search)
+      :serializer => serializer_for_search(@search)
+      # note: not returning search metadata here, since we're not paginating
+      # and calculating the total # of results for reports is expensive
   end
 
   private


### PR DESCRIPTION
Do not return search meta data to the front-end. Initially we thought we might need that to paginate, but since that never happened it's better to remove this. Under normal usage this does not cause issues other than a slowdown for unnecessary calculation of the totals. However, this opens a system vulnerability for creative users.
