### PR TITLE
Extend documents edit form with review phase

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -19,6 +19,9 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   def edit
     edit! do |format|
       load_associations
+      if @document.is_a?(Document::ReviewOfSignificantTrade)
+        @document.review_details ||= Document::ReviewDetails.new
+      end
       @document.citations.build
       @geo_entities = GeoEntity.joins(:geo_entity_type).where(
         'geo_entity_types.name' => [GeoEntityType::COUNTRY, GeoEntityType::TERRITORY]

--- a/app/models/document/review_details.rb
+++ b/app/models/document/review_details.rb
@@ -12,7 +12,9 @@
 #
 
 class Document::ReviewDetails < ActiveRecord::Base
+  attr_accessible :document_id, :review_phase_id
   self.table_name = 'review_details'
 
   def self.display_name; 'Review Details'; end
+
 end

--- a/app/models/document/review_of_significant_trade.rb
+++ b/app/models/document/review_of_significant_trade.rb
@@ -1,7 +1,10 @@
 class Document::ReviewOfSignificantTrade < Document
+  def self.display_name; 'Review of Significant Trade'; end
+
+  attr_accessible :review_details_attributes
+
   has_one :review_details,
     :class_name => 'Document::ReviewDetails',
     :foreign_key => 'document_id'
-
-  def self.display_name; 'Review of Significant Trade'; end
+  accepts_nested_attributes_for :review_details, :allow_destroy => true
 end

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -75,6 +75,21 @@
     </div>
   </div>
 
+  <% if @document.is_a?(Document::ReviewOfSignificantTrade) %>
+    <%= f.fields_for :review_details do |ff| %>
+      <div class="control-group">
+        <%= ff.label :review_phase_id, class: 'control-label' %>
+        <div class="controls">
+          <%= ff.select :review_phase_id,
+            options_for_select(DocumentTag::ReviewPhase.all.map { |rp| [rp.name, rp.id] },
+              @document.review_details.review_phase_id),
+            { :class => 'phases', :style => 'width: 220px' }
+          %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
   <div class="control-group">
     <%= f.label :citations, class: 'control-label' %>
     <div class="controls">

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -129,6 +129,20 @@ describe Admin::DocumentsController do
         expect(document.reload.tags).to eq([tag])
       end
     end
+
+    context "with nested review_details attributes" do
+      let(:document){ create(:review_of_significant_trade) }
+      let(:review_phase){ create(:document_tag, type: 'DocumentTag::ReviewPhase') }
+
+      it "assign review phase to Document" do
+        put :update, id: document.id, document: {
+          date: Date.today, review_details_attributes: {review_phase_id: review_phase.id}
+        }
+        response.should redirect_to(admin_documents_url)
+
+        expect(document.reload.review_details.review_phase_id).to eq(review_phase.id)
+      end
+    end
   end
 
   describe "DELETE destroy" do

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
     filename { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'annual_report_upload_exporter.csv')) }
     event
     type 'Document'
+
+    factory :review_of_significant_trade, class: Document::ReviewOfSignificantTrade do
+      type 'Document::ReviewOfSignificantTrade'
+    end
   end
 
   factory :document_citation do


### PR DESCRIPTION
The documents edit form is extended with a "Review Phase" field, showing only for documents of the type `Document::ReviewOfSignificantTrade`, using `accepts_nested_attributes_for` on `review_details`.
