### PR TITLE
skip distribution validations for higher taxa

### DIFF
--- a/app/models/trade/inclusion_validation_rule.rb
+++ b/app/models/trade/inclusion_validation_rule.rb
@@ -109,20 +109,20 @@ class Trade::InclusionValidationRule < Trade::ValidationRule
     scope_nodes = sanitized_sandbox_scope.map do |scope_column, scope_def|
       tmp = []
       if scope_def['inclusion']
-        tmp << scope_def['inclusion'].map{ |value| s[scope_column].eq(value) }
+        inclusion_nodes = scope_def['inclusion'].map{ |value| s[scope_column].eq(value) }
+        tmp << inclusion_nodes.inject(&:or)
       end
       if scope_def['exclusion']
-        tmp << scope_def['exclusion'].map{ |value| s[scope_column].not_eq(value) }
+        exclusion_nodes = scope_def['exclusion'].map{ |value| s[scope_column].not_eq(value) }
+        tmp << exclusion_nodes.inject(&:or)
       end
       if scope_def['blank']
         tmp << s[scope_column].eq(nil)
       end
       tmp
     end.flatten
-    scope_conds = scope_nodes.shift
-    scope_nodes.each{ |n| scope_conds = scope_conds.and(n) }
+    scope_conds = scope_nodes.inject(&:and)
     result = result.where(scope_conds) if scope_conds
-
     result
   end
 

--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -135,26 +135,11 @@ class Trade::SandboxTemplate < ActiveRecord::Base
   end
 
   def self.create_view_stmt(target_table_name, idx)
-    sql = <<-SQL
-      CREATE VIEW #{target_table_name}_view AS
-      SELECT aru.point_of_view,
-      CASE
-        WHEN aru.point_of_view = 'E'
-        THEN geo_entities.iso_code2
-        ELSE trading_partner
-      END AS exporter,
-      CASE
-        WHEN aru.point_of_view = 'E'
-        THEN trading_partner
-        ELSE geo_entities.iso_code2 
-      END AS importer,
-      taxon_concepts.full_name AS accepted_taxon_name,
-      #{target_table_name}.*
-      FROM #{target_table_name}
-      JOIN trade_annual_report_uploads aru ON aru.id = #{idx}
-      JOIN geo_entities ON geo_entities.id = aru.trading_country_id
-      LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id
-    SQL
+    sanitize_sql_array([
+      "SELECT * FROM create_trade_sandbox_view(?, ?)",
+      target_table_name,
+      idx
+    ])
   end
 
   def self.drop_stmt(target_table_name)

--- a/app/models/trade/validation_rule.rb
+++ b/app/models/trade/validation_rule.rb
@@ -87,7 +87,7 @@ class Trade::ValidationRule < ActiveRecord::Base
     scope && scope.each do |scope_column, scope_def|
       if (
         Trade::SandboxTemplate.column_names +
-        ['point_of_view', 'importer', 'exporter']
+        ['point_of_view', 'importer', 'exporter', 'rank']
       ).include? scope_column
         res[scope_column] = scope_def
       end
@@ -103,8 +103,8 @@ class Trade::ValidationRule < ActiveRecord::Base
     res = {}
     sanitized_sandbox_scope.each do |scope_column, scope_def|
       case scope_column
-      when 'taxon_name'
-        false #basically no point scoping rules on taxon id
+      when 'taxon_name', 'rank'
+        false
       when 'appendix', 'year'
         res[scope_column] = scope_def
       when 'exporter', 'importer', 'country_of_origin'

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -183,6 +183,66 @@ Drops all trade_sandbox_n tables. Used in specs only, you need to know what
 you''re doing. If you''re looking to drop all sandboxes in the live system,
 use the rake db:drop_sandboxes task instead.';
 
+CREATE OR REPLACE FUNCTION refresh_trade_sandbox_views() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+    current_table_name TEXT;
+    current_view_name TEXT;
+    aru_id INT;
+  BEGIN
+    FOR current_table_name IN SELECT table_name FROM information_schema.tables
+    WHERE table_name LIKE 'trade_sandbox%'
+      AND table_name != 'trade_sandbox_template'
+      AND table_type != 'VIEW'
+    LOOP
+      aru_id := SUBSTRING(current_table_name, E'trade_sandbox_(\\\\d+)')::INT;
+      IF aru_id IS NULL THEN
+        RAISE WARNING 'Unable to determine annual report upload id from %', current_table_name;
+      END IF;
+      current_view_name := current_table_name || '_view';
+      EXECUTE 'DROP VIEW IF EXISTS ' || current_view_name || ' CASCADE';
+      PERFORM create_trade_sandbox_view(current_table_name, aru_id);
+    END LOOP;
+    RETURN;
+  END;
+  $$;
+
+COMMENT ON FUNCTION refresh_trade_sandbox_views() IS '
+Drops all trade_sandbox_n_view views and creates them again. Useful when the
+view definition has changed and has to be applied to existing views.';
+
+
+CREATE OR REPLACE FUNCTION create_trade_sandbox_view(
+  target_table_name TEXT, idx INT
+  ) RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    execute 'CREATE VIEW ' || target_table_name || '_view AS
+      SELECT aru.point_of_view,
+      CASE
+        WHEN aru.point_of_view = ''E''
+        THEN geo_entities.iso_code2
+        ELSE trading_partner
+      END AS exporter,
+      CASE
+        WHEN aru.point_of_view = ''E''
+        THEN trading_partner
+        ELSE geo_entities.iso_code2 
+      END AS importer,
+      taxon_concepts.full_name AS accepted_taxon_name,
+      taxon_concepts.data->''rank_name'' AS rank,
+      taxon_concepts.rank_id,
+      ' || target_table_name || '.*
+      FROM ' || target_table_name || '
+      JOIN trade_annual_report_uploads aru ON aru.id = ' || idx || '
+      JOIN geo_entities ON geo_entities.id = aru.trading_country_id
+      LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id';
+    RETURN;
+  END;
+  $$;
+
 CREATE OR REPLACE FUNCTION drop_eu_lc_mviews() RETURNS void
   LANGUAGE plpgsql
   AS $$

--- a/db/migrate/20140929092236_add_rank_name_to_sandbox_views.rb
+++ b/db/migrate/20140929092236_add_rank_name_to_sandbox_views.rb
@@ -1,0 +1,69 @@
+class AddRankNameToSandboxViews < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+
+CREATE OR REPLACE FUNCTION refresh_trade_sandbox_views() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+    current_table_name TEXT;
+    current_view_name TEXT;
+    aru_id INT;
+  BEGIN
+    FOR current_table_name IN SELECT table_name FROM information_schema.tables
+    WHERE table_name LIKE 'trade_sandbox%'
+      AND table_name != 'trade_sandbox_template'
+      AND table_type != 'VIEW'
+    LOOP
+      aru_id := SUBSTRING(current_table_name, E'trade_sandbox_(\\\\d+)')::INT;
+      IF aru_id IS NULL THEN
+        RAISE WARNING 'Unable to determine annual report upload id from %', current_table_name;
+      END IF;
+      current_view_name := current_table_name || '_view';
+      EXECUTE 'DROP VIEW IF EXISTS ' || current_view_name || ' CASCADE';
+      PERFORM create_trade_sandbox_view(current_table_name, aru_id);
+    END LOOP;
+    RETURN;
+  END;
+  $$;
+
+COMMENT ON FUNCTION refresh_trade_sandbox_views() IS '
+Drops all trade_sandbox_n_view views and creates them again. Useful when the
+view definition has changed and has to be applied to existing views.';
+
+
+CREATE OR REPLACE FUNCTION create_trade_sandbox_view(
+  target_table_name TEXT, idx INT
+  ) RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    execute 'CREATE VIEW ' || target_table_name || '_view AS
+      SELECT aru.point_of_view,
+      CASE
+        WHEN aru.point_of_view = ''E''
+        THEN geo_entities.iso_code2
+        ELSE trading_partner
+      END AS exporter,
+      CASE
+        WHEN aru.point_of_view = ''E''
+        THEN trading_partner
+        ELSE geo_entities.iso_code2 
+      END AS importer,
+      taxon_concepts.full_name AS accepted_taxon_name,
+      taxon_concepts.data->''rank_name'' AS rank,
+      taxon_concepts.rank_id,
+      ' || target_table_name || '.*
+      FROM ' || target_table_name || '
+      JOIN trade_annual_report_uploads aru ON aru.id = ' || idx || '
+      JOIN geo_entities ON geo_entities.id = aru.trading_country_id
+      LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id';
+    RETURN;
+  END;
+  $$;
+
+    SQL
+
+    execute "SELECT * FROM refresh_trade_sandbox_views()"
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -447,6 +447,7 @@ Trade::InclusionValidationRule.create(
 )
 Trade::InclusionValidationRule.create(
   :scope => {
+    :rank => { :inclusion => [Rank::SPECIES, Rank::SUBSPECIES] },
     :source_code => { :inclusion => ['W'] },
     :country_of_origin => { :exclusion => ['XX'] }
   },
@@ -458,6 +459,7 @@ Trade::InclusionValidationRule.create(
 )
 Trade::InclusionValidationRule.create(
   :scope => {
+    :rank => { :inclusion => [Rank::SPECIES, Rank::SUBSPECIES] },
     :source_code => { :inclusion => ['W'] },
     :country_of_origin => { :blank => true },
     :exporter => { :exclusion => ['XX'] }

--- a/spec/models/trade/pov_inclusion_validation_rule_spec.rb
+++ b/spec/models/trade/pov_inclusion_validation_rule_spec.rb
@@ -97,7 +97,7 @@ describe Trade::InclusionValidationRule, :drops_tables => true do
         subject.validation_errors(@aru).size.should == 1
       }
     end
-    context "when W source and country of origin blank and exporter XX" do
+    context "when W source and country XX" do
       before(:each) do
         @aru = build(:annual_report_upload, :point_of_view => 'I', :trading_country_id => argentina.id)
         @aru.save(:validate => false)
@@ -110,6 +110,28 @@ describe Trade::InclusionValidationRule, :drops_tables => true do
           :taxon_name => 'Pecari tajacu', :source_code => 'W',
           :trading_partner => xx.iso_code2,
           :country_of_origin => argentina.iso_code2
+        )
+      end
+      subject{
+        create_taxon_concept_exporter_validation
+      }
+      specify{
+        subject.validation_errors(@aru).should be_empty
+      }
+    end
+    context "when W source and country doesn't match distribution of higher taxa" do
+      before(:each) do
+        @aru = build(:annual_report_upload, :point_of_view => 'I', :trading_country_id => argentina.id)
+        @aru.save(:validate => false)
+        sandbox_klass = Trade::SandboxTemplate.ar_klass(@aru.sandbox.table_name)
+        sandbox_klass.create(
+          :taxon_name => 'Pecari', :source_code => 'W',
+          :trading_partner => canada.iso_code2, :country_of_origin => nil
+        )
+        sandbox_klass.create(
+          :taxon_name => 'Pecari', :source_code => 'W',
+          :trading_partner => canada.iso_code2,
+          :country_of_origin => canada.iso_code2
         )
       end
       subject{

--- a/spec/support/sapi_helpers.rb
+++ b/spec/support/sapi_helpers.rb
@@ -425,6 +425,7 @@ shared_context :sapi do
   def create_taxon_concept_country_of_origin_validation
     create(:inclusion_validation_rule,
       :scope => {
+        :rank => { :inclusion => [Rank::SPECIES, Rank::SUBSPECIES] },
         :source_code => { :inclusion => ['W'] },
         :country_of_origin => { :exclusion => ['XX'] }
       },
@@ -437,6 +438,7 @@ shared_context :sapi do
   def create_taxon_concept_exporter_validation
     create(:inclusion_validation_rule,
       :scope => {
+        :rank => { :inclusion => [Rank::SPECIES, Rank::SUBSPECIES] },
         :source_code => { :inclusion => ['W'] },
         :country_of_origin => { :blank => true },
         :exporter => { :exclusion => ['XX'] }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/79510388

The secondary errors for higher taxa are suppressed in sandbox mode, not in individual shipment edit mode (it would require lots of changes to do it, and it semms that the issue was primarily about reducing the large number of secondary errors raised in sandbox mode)
