### PR TITLE
Taxon level internal notes

### DIFF
--- a/app/assets/javascripts/admin/taxon_concept.js.coffee
+++ b/app/assets/javascripts/admin/taxon_concept.js.coffee
@@ -20,3 +20,9 @@ $(document).ready ->
     format: "dd/mm/yyyy",
     autoclose: true
   )
+
+  $('#taxon_concept_internal_notes_popover_link').popover(
+    container: 'body'
+    content: $('#taxon_concept_internal_notes_popover').html(),
+    template: '<div class="popover" style="max-width:800px"><div class="arrow"></div><div class="popover-inner"><h3 class="popover-title"></h3><div class="popover-content"><p></p></div></div></div>'
+  )

--- a/app/assets/stylesheets/admin/taxon_concept.scss
+++ b/app/assets/stylesheets/admin/taxon_concept.scss
@@ -160,3 +160,12 @@ ul.relationship_parts{
   }
 }
 
+.internal-notes-meta {
+  color: #666;
+  font-size: 11px;
+}
+
+.internal-notes-type {
+  color: #666;
+  text-transform: uppercase;
+}

--- a/app/controllers/admin/taxon_concept_comments_controller.rb
+++ b/app/controllers/admin/taxon_concept_comments_controller.rb
@@ -1,0 +1,30 @@
+class Admin::TaxonConceptCommentsController < Admin::SimpleCrudController
+  defaults :resource_class => Comment, :collection_name => 'comments',
+    :instance_name => 'comment'
+  belongs_to :taxon_concept
+  before_filter :load_search
+  layout 'taxon_concepts'
+  authorize_resource :class => false
+
+  def index
+    @taxon_concept = TaxonConcept.find(params[:taxon_concept_id])
+    @taxon_concept.general_comment ||= @taxon_concept.build_general_comment
+    @taxon_concept.nomenclature_comment ||= @taxon_concept.build_nomenclature_comment
+    @taxon_concept.distribution_comment ||= @taxon_concept.build_distribution_comment
+  end
+
+  def create
+    @taxon_concept = TaxonConcept.find(params[:taxon_concept_id])
+    @comment = @taxon_concept.comments.create(params[:comment])
+    redirect_to admin_taxon_concept_comments_url(@taxon_concept),
+      notice: 'Operation succeeded'
+  end
+
+  def update
+    @taxon_concept = TaxonConcept.find(params[:taxon_concept_id])
+    @comment = @taxon_concept.comments.find(params[:id])
+    @comment.update_attributes(params[:comment])
+    redirect_to admin_taxon_concept_comments_url(@taxon_concept),
+      notice: 'Operation succeeded'
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -30,20 +30,6 @@ module AdminHelper
     end.html_safe
   end
 
-  def taxon_concept_internal_notes tc
-    notes = [
-      tc.internal_general_note,
-      tc.internal_nomenclature_note,
-      tc.internal_distribution_note
-    ].compact
-    return '' if notes.empty?
-    info = content_tag(:div) do
-      content_tag(:b, 'Internal notes:')
-      notes.each{ |n| concat content_tag(:p, n) }
-    end
-    comment_icon_with_tooltip(info)
-  end
-
   def internal_notes record
     return '' unless record.internal_notes.present?
     info = content_tag(:div) do
@@ -206,30 +192,6 @@ module AdminHelper
       :style => "clear: both"
     ) do
       render :partial => 'admin/simple_crud/simple_search'
-    end
-  end
-
-  def taxon_concept_internal_note_form(note_name)
-    content_tag(:div, style: 'clear: both', id: note_name) do
-      form_for [:admin, @taxon_concept], remote: true do |f|
-        content_tag(:div, class: 'control-group') do
-          f.label(note_name, 'Internal notes', class: 'control-label span2') +
-          content_tag(:span) do
-            updater = @taxon_concept.send("#{note_name}_updater")
-            updated_at = @taxon_concept.send("#{note_name}_updated_at")
-            "Last updated by #{updater.try(:name)} at #{updated_at}"
-          end +
-          content_tag(:div, class: 'controls controls-row') do
-            f.text_area(
-              note_name,
-              value: @taxon_concept.send(note_name),
-              class: 'span9',
-              rows: 4
-            ) +
-            f.submit('Update', class: 'btn btn-primary span1')
-          end
-        end
-      end
     end
   end
 

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -174,4 +174,82 @@ module TaxonConceptHelper
     obj.excluded_taxon_concepts.
       map(&:full_name).join(', ')
   end
+
+  def taxon_concept_internal_notes_popover_link
+    content_tag(
+      :span, rel: 'popover', href: '#',
+      'data-original-title' => 'Internal notes',
+      'data-html' => true,
+      'data-trigger' => 'hover',
+      'data-placement' => 'left',
+      id: 'taxon_concept_internal_notes_popover_link'
+    ) do
+      comment_icon
+    end
+  end
+
+  def taxon_concept_internal_note_label(comment)
+    content_tag(:label) do
+      content_tag(:p, class: 'internal-notes-type') do
+        comment.comment_type + ' note'
+      end +
+      content_tag(:div, class: 'internal-notes-meta') do
+        updater = comment.try(:updater)
+        if updater
+          "Last updated by #{updater.try(:name)}"
+        else
+          ''
+        end
+      end +
+      content_tag(:div, class: 'internal-notes-meta') do
+        updated_at = comment.try(:updated_at).try(:strftime, "%d/%m/%y %H:%M")
+        if updated_at
+          "at #{updated_at}"
+        else
+          ''
+        end
+      end
+    end
+  end
+
+  def taxon_concept_internal_note_form(comment)
+    form_for [:admin, @taxon_concept, comment] do |f|
+      content_tag(:table, style:'width:100%') do
+        content_tag(:tr) do
+          content_tag(:td, style:'width:30%') do
+            taxon_concept_internal_note_label(comment)
+          end +
+          content_tag(:td) do
+            f.text_area(
+              :note,
+              rows: 4,
+              style:'width:100%'
+            ) +
+            f.hidden_field(:comment_type) +
+            f.submit('Update', class: 'btn btn-primary')
+          end
+        end
+      end
+    end
+  end
+
+  def taxon_concept_internal_note_display(comment)
+    return '' unless comment
+    content_tag(:table, style:'width:100%') do
+      content_tag(:tr) do
+        content_tag(:td, style:'width:30%') do
+          taxon_concept_internal_note_label(comment)
+        end +
+        content_tag(:td, comment.note)
+      end
+    end
+  end
+
+  def taxon_concept_internal_note_tab_display(comment)
+    if comment && comment.note.present?
+      content_tag(:div, {class: 'alert alert-info'}) do
+        taxon_concept_internal_note_display(comment)
+      end
+    end
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ActiveRecord::Base
+  track_who_does_it
+  attr_accessible :comment_type, :commentable_id, :commentable_type, :note,
+    :created_by_id, :updated_by_id
+  belongs_to :commentable, polymorphic: true
+end

--- a/app/models/taxon_concept_observer.rb
+++ b/app/models/taxon_concept_observer.rb
@@ -30,23 +30,6 @@ class TaxonConceptObserver < ActiveRecord::Observer
     end
   end
 
-  def before_save(taxon_concept)
-    updated_at = taxon_concept.updated_at
-    updated_by_id = taxon_concept.updated_by_id
-    if taxon_concept.internal_general_note_changed?
-      taxon_concept.internal_general_note_updated_at = updated_at
-      taxon_concept.internal_general_note_updated_by_id = updated_by_id
-    end
-    if taxon_concept.internal_nomenclature_note_changed?
-      taxon_concept.internal_nomenclature_note_updated_at = updated_at
-      taxon_concept.internal_nomenclature_note_updated_by_id = updated_by_id
-    end
-    if taxon_concept.internal_distribution_note_changed?
-      taxon_concept.internal_distribution_note_updated_at = updated_at
-      taxon_concept.internal_distribution_note_updated_by_id = updated_by_id
-    end
-  end
-
   def after_create(taxon_concept)
     ensure_species_touched(taxon_concept)
     Species::Search.increment_cache_iterator

--- a/app/views/admin/distributions/index.html.erb
+++ b/app/views/admin/distributions/index.html.erb
@@ -1,9 +1,12 @@
-<h3 class="pull-left">Distribution</h3>
-<%= admin_add_new_distribution_button %>
+<%= taxon_concept_internal_note_tab_display(@taxon_concept.distribution_comment) %>
+<div class="admin-header">
+  <h3>Distribution</h3>
+  <div class="action-buttons">
+    <%= admin_add_new_distribution_button %>
+  </div>
+</div>
 <%= admin_new_distribution_modal(true) %>
-<%= taxon_concept_internal_note_form(:internal_distribution_note) %>
-<hr />
-<div class="distributions-list">
+<div class="distributions-list" style="clear:both">
   <% if @taxon_concept.has_distribution? %>
     <%= render 'admin/distributions/list' %>
   <% else %>

--- a/app/views/admin/names/index.html.erb
+++ b/app/views/admin/names/index.html.erb
@@ -1,4 +1,4 @@
-<%= taxon_concept_internal_note_form(:internal_nomenclature_note) %>
+<%= taxon_concept_internal_note_tab_display(@taxon_concept.nomenclature_comment) %>
 <div class="row-fluid">
   <div class="span4">
     <h3>Synonyms</h3>

--- a/app/views/admin/taxon_concept_comments/index.html.erb
+++ b/app/views/admin/taxon_concept_comments/index.html.erb
@@ -1,0 +1,3 @@
+<%= taxon_concept_internal_note_form(@taxon_concept.general_comment) %>
+<%= taxon_concept_internal_note_form(@taxon_concept.nomenclature_comment) %>
+<%= taxon_concept_internal_note_form(@taxon_concept.distribution_comment) %>

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -22,7 +22,6 @@
     <%= link_to delete_icon, admin_taxon_concept_url(@taxon_concept), 
       :confirm => "Warning: you are about to delete data. Are you sure?", :method => :delete %>
   <% end %>
-  <%= taxon_concept_internal_notes(@taxon_concept) %>
   <%= @taxon_concept.author_year %>
   <% if @taxon_concept.tag_list %>
     <%= tag_list(@taxon_concept.tag_list) %><br />
@@ -149,5 +148,19 @@
   <li class="<%= if controller_name == "children" then "active" end%>">
     <%= link_to "Children", admin_taxon_concept_children_path(@taxon_concept) %>
   </li>
+
+  <li class="<%= if controller_name == "taxon_concept_comments" then "active" end%>">
+    <%= link_to admin_taxon_concept_comments_path(@taxon_concept) do %>
+      Notes
+      <% if @taxon_concept.has_comments? %>
+        <%= taxon_concept_internal_notes_popover_link %>
+      <% end %>
+    <% end %>
+  </li>
 </ul>
 <% end %>
+<div id="taxon_concept_internal_notes_popover" class="hidden">
+    <%= taxon_concept_internal_note_display(@taxon_concept.general_comment) %>
+    <%= taxon_concept_internal_note_display(@taxon_concept.nomenclature_comment) %>
+    <%= taxon_concept_internal_note_display(@taxon_concept.distribution_comment) %>
+</table>

--- a/app/views/admin/taxon_concepts/_form.html.erb
+++ b/app/views/admin/taxon_concepts/_form.html.erb
@@ -39,12 +39,6 @@
     %>
   </div>
   <div class="control-group">
-    <label class="control-label">General notes (internal)</label>
-    <div class="controls">
-      <%= f.text_area :internal_general_note, :value => @taxon_concept.internal_general_note %>
-    </div>
-  </div>
-  <div class="control-group">
     <label>Author & year</label>
     <%= f.text_field :author_year %>
   </div>

--- a/app/views/admin/taxon_concepts/update.js.erb
+++ b/app/views/admin/taxon_concepts/update.js.erb
@@ -1,11 +1,5 @@
 $('.modal').modal('hide');
 $('#basic-info').html("<%= escape_javascript(render('basic_info')) %>");
-$('#internal_distribution_note').html(
-  "<%= escape_javascript(taxon_concept_internal_note_form('internal_distribution_note')) %>"
-);
-$('#internal_nomenclature_note').html(
-  "<%= escape_javascript(taxon_concept_internal_note_form('internal_nomenclature_note')) %>"
-);
 window.adminEditor.initEditors();
 window.adminEditor.alertSuccess("Operation successful");
 $("[rel='tooltip']").tooltip();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,8 @@ SAPI::Application.routes.draw do
       get :autocomplete, :on => :collection
       resources :children, :only => [:index]
       resources :taxon_relationships, :only => [:index, :create, :destroy]
+      resources :comments, only: [:index, :create, :update],
+        controller: :taxon_concept_comments
       resources :designations, :only => [] do
         resources :taxon_listing_changes, :as => :listing_changes
       end

--- a/db/migrate/20141004213258_create_comments.rb
+++ b/db/migrate/20141004213258_create_comments.rb
@@ -1,0 +1,21 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.integer :commentable_id
+      t.string :commentable_type
+      t.string :comment_type
+      t.text :note
+      t.integer :created_by_id
+      t.integer :updated_by_id
+
+      t.timestamps
+    end
+    add_foreign_key :comments, :users, name: 'comments_created_by_id_fk',
+      column: 'created_by_id'
+    add_foreign_key :comments, :users, name: 'comments_updated_by_id_fk',
+      column: 'updated_by_id'
+    add_index 'comments', [
+      'commentable_id', 'commentable_type', 'comment_type'
+    ], name: 'index_comments_on_commentable_and_comment_type'
+  end
+end

--- a/db/migrate/20141004214703_change_of_plan_remove_internal_notes_from_taxon_concepts.rb
+++ b/db/migrate/20141004214703_change_of_plan_remove_internal_notes_from_taxon_concepts.rb
@@ -1,0 +1,38 @@
+class ChangeOfPlanRemoveInternalNotesFromTaxonConcepts < ActiveRecord::Migration
+  def up
+    execute 'DROP VIEW IF EXISTS orphaned_taxon_concepts_view'
+    execute 'DROP VIEW IF EXISTS synonyms_and_trade_names_view'
+    execute 'DROP VIEW IF EXISTS taxon_concepts_names_view'
+    execute 'DROP VIEW IF EXISTS taxon_concepts_distributions_view'
+    remove_column :taxon_concepts, :internal_general_note_updated_at
+    remove_column :taxon_concepts, :internal_nomenclature_note_updated_at
+    remove_column :taxon_concepts, :internal_distribution_note_updated_at
+    remove_column :taxon_concepts, :internal_general_note_updated_by_id
+    remove_column :taxon_concepts, :internal_nomenclature_note_updated_by_id
+    remove_column :taxon_concepts, :internal_distribution_note_updated_by_id
+    remove_column :taxon_concepts, :internal_general_note
+    remove_column :taxon_concepts, :internal_nomenclature_note
+    remove_column :taxon_concepts, :internal_distribution_note
+  end
+
+  def down
+    add_column :taxon_concepts, :internal_general_note_updated_at, :datetime
+    add_column :taxon_concepts, :internal_nomenclature_note_updated_at, :datetime
+    add_column :taxon_concepts, :internal_distribution_note_updated_at, :datetime
+    add_column :taxon_concepts, :internal_general_note_updated_by_id, :integer
+    add_column :taxon_concepts, :internal_nomenclature_note_updated_by_id, :integer
+    add_column :taxon_concepts, :internal_distribution_note_updated_by_id, :integer
+    add_foreign_key :taxon_concepts, :users,
+      name: 'taxon_concepts_internal_general_note_updated_by_id_fk',
+      column: 'internal_general_note_updated_by_id'
+    add_foreign_key :taxon_concepts, :users,
+      name: 'taxon_concepts_internal_nomenclature_note_updated_by_id_fk',
+      column: 'internal_nomenclature_note_updated_by_id'
+    add_foreign_key :taxon_concepts, :users,
+      name: 'taxon_concepts_internal_distribution_note_updated_by_id_fk',
+      column: 'internal_distribution_note_updated_by_id'
+    add_column :taxon_concepts, :internal_general_note, :text
+    add_column :taxon_concepts, :internal_nomenclature_note, :text
+    add_column :taxon_concepts, :internal_distribution_note, :text
+  end
+end

--- a/db/views/orphaned_taxon_concepts_view.sql
+++ b/db/views/orphaned_taxon_concepts_view.sql
@@ -12,9 +12,9 @@ SELECT
   taxonomies.name AS taxonomy_name,
   ARRAY_TO_STRING(
     ARRAY[
-      tc.internal_general_note,
-      tc.internal_nomenclature_note,
-      tc.internal_distribution_note
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
     ],
     E'\n'
   ) AS internal_notes,
@@ -27,6 +27,18 @@ JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
 LEFT JOIN taxon_relationships tr1 ON tr1.taxon_concept_id = tc.id
 LEFT JOIN taxon_relationships tr2 ON tr2.other_taxon_concept_id = tc.id
 LEFT JOIN taxon_concepts children ON children.parent_id = tc.id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = tc.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = tc.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = tc.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
 LEFT JOIN users uc ON tc.created_by_id = uc.id
 LEFT JOIN users uu ON tc.updated_by_id = uu.id
 WHERE tc.parent_id IS NULL

--- a/db/views/synonyms_and_trade_names_view.sql
+++ b/db/views/synonyms_and_trade_names_view.sql
@@ -24,9 +24,9 @@ SELECT
   taxonomies.name AS taxonomy_name,
   ARRAY_TO_STRING(
     ARRAY[
-      st.internal_general_note,
-      st.internal_nomenclature_note,
-      st.internal_distribution_note
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
     ],
     E'\n'
   ) AS internal_notes,
@@ -40,6 +40,18 @@ LEFT JOIN taxon_relationships
 ON taxon_relationships.other_taxon_concept_id = st.id
 LEFT JOIN taxon_concepts a
 ON taxon_relationships.taxon_concept_id = a.id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = st.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = st.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = st.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
 LEFT JOIN users uc
 ON st.created_by_id = uc.id
 LEFT JOIN users uu

--- a/db/views/taxon_concepts_distributions_view.sql
+++ b/db/views/taxon_concepts_distributions_view.sql
@@ -21,7 +21,7 @@ SELECT
   taxonomy_id,
   ARRAY_TO_STRING(
     ARRAY[
-      taxon_concepts.internal_distribution_note,
+      distribution_note.note,
       distributions.internal_notes
     ],
     E'\n'
@@ -40,10 +40,14 @@ LEFT JOIN "references" ON "references".id = distribution_references.reference_id
 LEFT JOIN taggings ON taggings.taggable_id = distributions.id
   AND taggings.taggable_type = 'Distribution'
 LEFT JOIN tags ON tags.id = taggings.tag_id
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = taxon_concepts.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
 LEFT JOIN users uc ON distributions.created_by_id = uc.id
 LEFT JOIN users uu ON distributions.updated_by_id = uu.id
 WHERE taxon_concepts.name_status IN ('A')
 GROUP BY taxon_concepts.id, taxon_concepts.legacy_id, geo_entity_types.name,
   geo_entities.name_en, geo_entities.iso_code2, "references".citation, "references".id,
-  taxonomies.name, distributions.internal_notes,
+  taxonomies.name, distributions.internal_notes, distribution_note.note,
   uc.name, uu.name, distributions.created_at, distributions.updated_at

--- a/db/views/taxon_concepts_names_view.sql
+++ b/db/views/taxon_concepts_names_view.sql
@@ -19,9 +19,9 @@ SELECT
   taxonomies.name AS taxonomy_name,
   ARRAY_TO_STRING(
     ARRAY[
-      internal_general_note,
-      internal_nomenclature_note,
-      internal_distribution_note
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
     ],
     E'\n'
   ) AS internal_notes,
@@ -31,5 +31,17 @@ SELECT
   uu.name AS updated_by
 FROM taxon_concepts
 JOIN taxonomies ON taxonomies.id = taxon_concepts.taxonomy_id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = taxon_concepts.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = taxon_concepts.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = taxon_concepts.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
 LEFT JOIN users uc ON taxon_concepts.created_by_id = uc.id
 LEFT JOIN users uu ON taxon_concepts.updated_by_id = uu.id;

--- a/spec/controllers/admin/taxon_concept_comments_controller_spec.rb
+++ b/spec/controllers/admin/taxon_concept_comments_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Admin::TaxonConceptCommentsController do
+  login_admin
+
+  before do
+    @taxon_concept = create(:taxon_concept)
+  end
+
+  describe 'GET index' do
+    it 'renders the index template' do
+      get :index, taxon_concept_id: @taxon_concept.id
+      response.should render_template('index')
+    end
+  end
+
+  describe 'POST create' do
+    it 'redirects to index with notice when success' do
+      post :create,
+        taxon_concept_id: @taxon_concept.id,
+        comment: { note: 'blah' }
+      response.should redirect_to(
+        admin_taxon_concept_comments_url(@taxon_concept)
+      )
+      flash[:notice].should_not be_nil
+    end
+  end
+
+
+  describe 'PUT update' do
+    let(:comment){ @taxon_concept.comments.create({note: 'bleh'}) }
+    it 'redirects to index with notice when success' do
+      put :update,
+        id: comment.id,
+        taxon_concept_id: @taxon_concept.id,
+        comment: { note: 'blah' }
+      response.should redirect_to(
+        admin_taxon_concept_comments_url(@taxon_concept)
+      )
+      flash[:notice].should_not be_nil
+    end
+  end
+
+end


### PR DESCRIPTION
An amazing new feature allowing to create 3 types of internal notes on the taxon concept level:
1. general - this one is edited through the taxon concept edit form
2. nomenclature - edited through a text field on the nomenclature tab
3. distribution - same for distribution tab

Each comes with its own updated at / by combo to keep everyone super informed.

The notes are viewable as one note when you hover over the "comment bubble" on taxon concept page. They were also added to the admin downloads.
