### PR TITLE
redirect rather than blow up when things go wrong

### DIFF
--- a/app/controllers/cites_trade/exports_controller.rb
+++ b/app/controllers/cites_trade/exports_controller.rb
@@ -8,8 +8,12 @@ class CitesTrade::ExportsController < CitesTradeController
           :per_page => Trade::ShipmentsExport::PUBLIC_CSV_LIMIT
         }))
         result = search.export
-        send_file Pathname.new(result[0]).realpath, result[1]
-        Trade::TradeDataDownloadLogger.log_download request, search_params, search.total_cnt
+        if result.is_a?(Array)
+          send_file Pathname.new(result[0]).realpath, result[1]
+          Trade::TradeDataDownloadLogger.log_download request, search_params, search.total_cnt
+        else
+          redirect_to cites_trade_root_url
+        end
       }
       format.json {
         search = Trade::ShipmentsExportFactory.new(search_params.merge({

--- a/app/controllers/trade/exports_controller.rb
+++ b/app/controllers/trade/exports_controller.rb
@@ -6,7 +6,11 @@ class Trade::ExportsController < TradeController
     respond_to do |format|
       format.html {
         result = search.export
-        send_file Pathname.new(result[0]).realpath, result[1]
+        if result.is_a?(Array)
+          send_file Pathname.new(result[0]).realpath, result[1]
+        else
+          redirect_to trade_root_url
+        end
       }
       format.json {
         render :json => { :total => search.total_cnt }

--- a/spec/controllers/cites_trade/exports_controller_spec.rb
+++ b/spec/controllers/cites_trade/exports_controller_spec.rb
@@ -9,6 +9,8 @@ describe CitesTrade::ExportsController do
         get :download, :filters => {:report_type => 'raw'}, :format => :json
         parse_json(response.body)['total'].should == 1
       end
+    end
+    context "comptab" do
       it "returns comptab shipments file" do
         create(:shipment)
         Trade::ShipmentsExport.any_instance.stub(:public_file_name).and_return('shipments.csv')
@@ -33,8 +35,14 @@ describe CitesTrade::ExportsController do
         end.should change(Trade::TradeDataDownload, :count).by(1)
       end
     end
-
-
-
+    context 'when shipments cannot be retrieved' do
+      before(:each) do
+        Trade::ShipmentsExport.any_instance.stub(:export).and_return(false)
+      end
+      it "redirects to home page" do
+        get :download, :filters => {:report_type => :comptab}
+        expect(response).to redirect_to(cites_trade_root_url)
+      end
+    end
   end
 end

--- a/spec/controllers/trade/exports_controller_spec.rb
+++ b/spec/controllers/trade/exports_controller_spec.rb
@@ -23,8 +23,14 @@ describe Trade::ExportsController do
         end.should_not change(Trade::TradeDataDownload, :count).by(1)
       end
     end
-
-
-
+    context 'when shipments cannot be retrieved' do
+      before(:each) do
+        Trade::ShipmentsExport.any_instance.stub(:export).and_return(false)
+      end
+      it "redirects to home page" do
+        get :download, :filters => {:report_type => :comptab}
+        expect(response).to redirect_to(trade_root_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Handle trade downloads issues. Sometimes the download is not generated successfully, and why that is is a separate matter to consider, but for now it would be an improvement if the controller would recognize that the model has not returned results.
