### PR TITLE
Transfer trade names

### DIFF
--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -14,6 +14,11 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
     elsif reassignable.kind_of?(Trade::Shipment)
       reassignable.taxon_concept_id = new_taxon_concept.id
       reassignable
+    elsif reassignable.is_a?(TaxonRelationship) &&
+      reassignable.taxon_relationship_type.name == TaxonRelationshipType::HAS_TRADE_NAME
+
+      reassignable.taxon_concept_id = new_taxon_concept.id
+      reassignable
     else
       # Each reassignable object implements find_duplicate,
       # which is called from here to make sure we're not adding a duplicate.

--- a/app/views/admin/nomenclature_changes/split/names.html.erb
+++ b/app/views/admin/nomenclature_changes/split/names.html.erb
@@ -14,26 +14,49 @@
       Local selection
     </p>
     <%= ff.fields_for :name_reassignments do |fff| %>
-      <div class="control-group">
-        <label class="control-label">
-          <%= fff.object.reassignable.other_taxon_concept.full_name %><br>
-          <%= fff.object.reassignable.other_taxon_concept.author_year %>
-          (<%= fff.object.reassignable.other_taxon_concept.name_status %>)
-        </label>
-        <div class="controls">
-          <%= fff.select :output_ids,
-            options_for_select(
-              @nomenclature_change.outputs.map do |o|
-                [o.display_full_name, o.id]
-              end,
-              ff.object.name_reassignments.map(&:reassignment_targets).flatten.
-                map(&:output).compact.map(&:id)
-            ),
-            {}, {:class => 'simple-taxon-concept', :multiple => ''}
-          %>
-          <input type="checkbox" class="select-all-checkbox">Select All
+      <% if fff.object.reassignable.taxon_relationship_type.
+        name == TaxonRelationshipType::HAS_TRADE_NAME %>
+        <div class="control-group">
+          <label class="control-label">
+            <%= fff.object.reassignable.other_taxon_concept.full_name %><br>
+            <%= fff.object.reassignable.other_taxon_concept.author_year %>
+            (<%= fff.object.reassignable.other_taxon_concept.name_status %>)
+          </label>
+          <div class="controls">
+            <%= fff.select :output_ids,
+              options_for_select(
+                @nomenclature_change.outputs.map do |o|
+                  [o.display_full_name, o.id]
+                end,
+                ff.object.name_reassignments.map(&:reassignment_targets).flatten.
+                  map(&:output).compact.map(&:id)
+              ),
+              {}
+            %>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <div class="control-group">
+          <label class="control-label">
+            <%= fff.object.reassignable.other_taxon_concept.full_name %><br>
+            <%= fff.object.reassignable.other_taxon_concept.author_year %>
+            (<%= fff.object.reassignable.other_taxon_concept.name_status %>)
+          </label>
+          <div class="controls">
+            <%= fff.select :output_ids,
+              options_for_select(
+                @nomenclature_change.outputs.map do |o|
+                  [o.display_full_name, o.id]
+                end,
+                ff.object.name_reassignments.map(&:reassignment_targets).flatten.
+                  map(&:output).compact.map(&:id)
+              ),
+              {}, {:class => 'simple-taxon-concept', :multiple => ''}
+            %>
+            <input type="checkbox" class="select-all-checkbox">Select All
+          </div>
+        </div>
+      <% end %>
     <% end %>
 
   <% end %>


### PR DESCRIPTION
- Added constraint inside the split copy processor for the trade names
- Added dropdown single selection for the trade names inside the names page of the split wizard
