### PR TITLE
downgrade and link with new species rather than upgrade

### DIFF
--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -25,12 +25,14 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
         chain << NomenclatureChange::OutputTaxonConceptProcessor.new(output)
       end
       if output.will_create_taxon?
+        # for the case when an existing accepted subspecies is turned into a species
         if ['A', 'N'].include?(output.name_status)
           chain << NomenclatureChange::ReassignmentTransferProcessor.new(output, output)
 
           chain << NomenclatureChange::StatusDowngradeProcessor.new(output)
+        # for the case when an existing synonym subspecies is turned into a species
         elsif ['S', 'T'].include?(output.name_status)
-          chain << NomenclatureChange::StatusUpgradeProcessor.new(output, [output])
+          chain << NomenclatureChange::StatusDowngradeProcessor.new(output, [output])
         end
       elsif !output.will_create_taxon? && ['S', 'T'].include?(output.name_status)
         chain << NomenclatureChange::StatusUpgradeProcessor.new(output)


### PR DESCRIPTION
https://trello.com/c/5M6GcyQt/43-when-we-upgrade-a-synonym-into-an-accepted-name-the-old-synonym-is-now-an-accepted-name-too-but-this-should-not-happen
