### PR TITLE
un-tick 'Select all' checkboxes and fixed previous step

### DIFF
--- a/app/assets/javascripts/admin/nomenclature_changes.js.coffee
+++ b/app/assets/javascripts/admin/nomenclature_changes.js.coffee
@@ -73,6 +73,12 @@ $(document).ready ->
     width: '200px'
   }
   $('.simple-taxon-concept').select2(simpleTaxonSelect2Options)
+  .on('select2-removed', (event) ->
+    $(this).closest('.controls').find('.select-all-checkbox').prop('checked', false)
+
+    $('.species-checkbox:contains('+event.choice.text+')')
+    .find('.select-partial-checkbox').prop('checked', false)
+  )
 
   $('.select-all-checkbox').click (e) ->
       checkboxElement = $(e.target)

--- a/app/views/admin/nomenclature_changes/split/children.html.erb
+++ b/app/views/admin/nomenclature_changes/split/children.html.erb
@@ -19,6 +19,7 @@
                 @nomenclature_change.outputs.map do |o|
                   [o.display_full_name, o.id]
                 end,
+                ffff.object.nomenclature_change_output_id
               )
             %>
           <% end %>

--- a/app/views/admin/nomenclature_changes/split/distribution.html.erb
+++ b/app/views/admin/nomenclature_changes/split/distribution.html.erb
@@ -25,8 +25,7 @@
               @nomenclature_change.outputs.map do |o|
                 [o.display_full_name, o.id]
               end,
-              ff.object.distribution_reassignments.map(&:reassignment_targets).flatten.
-              map(&:output).compact.map(&:id)
+              fff.object.output_ids
             ),
             {}, {:class => 'simple-taxon-concept', :multiple => ''}
           %>

--- a/app/views/admin/nomenclature_changes/split/names.html.erb
+++ b/app/views/admin/nomenclature_changes/split/names.html.erb
@@ -28,8 +28,7 @@
                 @nomenclature_change.outputs.map do |o|
                   [o.display_full_name, o.id]
                 end,
-                ff.object.name_reassignments.map(&:reassignment_targets).flatten.
-                  map(&:output).compact.map(&:id)
+                fff.object.output_ids
               ),
               {}
             %>
@@ -48,8 +47,7 @@
                 @nomenclature_change.outputs.map do |o|
                   [o.display_full_name, o.id]
                 end,
-                ff.object.name_reassignments.map(&:reassignment_targets).flatten.
-                  map(&:output).compact.map(&:id)
+                fff.object.output_ids
               ),
               {}, {:class => 'simple-taxon-concept', :multiple => ''}
             %>


### PR DESCRIPTION
- The 'Select all' checkbox will be un-checked if an element is removed along with the species global checkbox
- Fixed previous step entries
