### PR TITLE
save copied / transferred objects without validation

### DIFF
--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -2,15 +2,12 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
 
   def process_reassignment(reassignment, reassignable)
     o = copied_object_before_save(reassignment, reassignable)
-    if o.save # hope that saves the duplicated associations as well
-      if o.is_a?(TaxonConcept)
-        resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(o)
-        resolver.process
-      end
-      o
-    else
-      nil
+    o.save(validate: false) # hope that saves the duplicated associations as well
+    if o.is_a?(TaxonConcept)
+      resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(o)
+      resolver.process
     end
+    o
   end
 
   def copied_object_before_save(reassignment, reassignable)

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -2,15 +2,12 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
 
   def process_reassignment(reassignment, reassignable)
     o = transferred_object_before_save(reassignment, reassignable)
-    if o.save # hope that saves the duplicated associations as well
-      if o.is_a?(TaxonConcept)
-        resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(o)
-        resolver.process
-      end
-      o
-    else
-      nil
+    o.save(validate: false)
+    if o.is_a?(TaxonConcept)
+      resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(o)
+      resolver.process
     end
+    o
   end
 
   def transferred_object_before_save(reassignment, reassignable)


### PR DESCRIPTION
The reson why some quotas (and other things) would not get transferred was because they violated existing validation rules. For example, some of the quota records did not have a publication date (they were added before we had the validation in place, probably were imported from the old system). Since we don't want to lose this type of data, safest to disable validation.
