### PR TITLE
Use api views for speciesplus legislation queries

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_cites_quotas.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_cites_quotas.handlebars
@@ -21,7 +21,7 @@
           <tr class="current">
             <td>{{quota.year}}</td>
             <td>{{quota.geo_entity.name}}</td>
-            <td>{{quota.quota}} {{quota.unit_name}}</td>
+            <td>{{quota.quota}} {{quota.unit.name}}</td>
             <td class="last">
               {{#if quota.subspecies_info}}
                 {{{quota.subspecies_info}}}<br />
@@ -58,7 +58,7 @@
               <tr>
                 <td>{{quota.year}}</td>
                 <td>{{quota.geo_entity.name}}</td>
-                <td>{{quota.quota}} {{quota.unit_name}}</td>
+                <td>{{quota.quota}} {{quota.unit.name}}</td>
                 <td class="last">
                   {{#if quota.subspecies_info}}
                     {{{quota.subspecies_info}}}<br />

--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -18,12 +18,12 @@
           <td>{{decision.start_date}}</td>
           <td>{{decision.geo_entity.name}}</td>
           <td>
-              {{#if decision.eu_decision_type.tooltip}}
+              {{#if decision.eu_decision_type.description}}
                 <div class="link-holder">
                   <a class="legal-links">{{decision.eu_decision_type.name}}</a>
                   <div class="popup-holder">
                     <div class="popup">
-                      {{decision.eu_decision_type.tooltip}}
+                      {{decision.eu_decision_type.description}}
                     </div>
                   </div>
                 </div>
@@ -73,12 +73,12 @@
               <td>{{decision.start_date}}</td>
               <td>{{decision.geo_entity.name}}</td>
               <td>
-                {{#if decision.eu_decision_type.tooltip}}
+                {{#if decision.eu_decision_type.description}}
                   <div class="link-holder">
                     <a class="legal-links">{{decision.eu_decision_type.name}}</a>
                     <div class="popup-holder">
                       <div class="popup">
-                        {{decision.eu_decision_type.tooltip}}
+                        {{decision.eu_decision_type.description}}
                       </div>
                     </div>
                   </div>

--- a/app/models/trade_restriction.rb
+++ b/app/models/trade_restriction.rb
@@ -145,7 +145,7 @@ class TradeRestriction < ActiveRecord::Base
             if c.is_a?(Array)
               row << q.send(c[1])
             elsif c == :notes
-              row << "#{q.send(c)}. #{q.send(:nomenclature_note_en)}"
+              row << [q.send(c), q.send(:nomenclature_note_en)].reject(&:blank?).join('; ')
             else
               row << q.send(c)
             end

--- a/app/serializers/species/cites_suspension_serializer.rb
+++ b/app/serializers/species/cites_suspension_serializer.rb
@@ -1,8 +1,15 @@
 class Species::CitesSuspensionSerializer < ActiveModel::Serializer
   attributes :notes, {:start_date_formatted => :start_date},
     :is_current, :subspecies_info, :nomenclature_note_en, :nomenclature_note_fr,
-    :nomenclature_note_es
-  has_one :geo_entity, :serializer => Species::GeoEntitySerializer
-  has_one :start_notification, :serializer => Species::EventSerializer
+    :nomenclature_note_es,
+    :geo_entity,
+    :start_notification
+
+  def geo_entity
+    object['geo_entity_en'] && JSON.parse(object['geo_entity_en'])
+  end
+  def start_notification
+    object['start_notification'] && JSON.parse(object['start_notification'])
+  end
 end
 

--- a/app/serializers/species/eu_decision_serializer.rb
+++ b/app/serializers/species/eu_decision_serializer.rb
@@ -18,9 +18,9 @@ class Species::EuDecisionSerializer < ActiveModel::Serializer
     object['start_event'] && JSON.parse(object['start_event'])
   end
   def source
-    object['source'] && JSON.parse(object['source'])
+    object['source_en'] && JSON.parse(object['source_en'])
   end
   def term
-    object['term'] && JSON.parse(object['term'])
+    object['term_en'] && JSON.parse(object['term_en'])
   end
 end

--- a/app/serializers/species/eu_decision_serializer.rb
+++ b/app/serializers/species/eu_decision_serializer.rb
@@ -1,11 +1,26 @@
 class Species::EuDecisionSerializer < ActiveModel::Serializer
   attributes :notes, {:start_date_formatted => :start_date},
     :is_current, :subspecies_info, :nomenclature_note_en, :nomenclature_note_fr,
-    :nomenclature_note_es
+    :nomenclature_note_es,
+    :eu_decision_type,
+    :geo_entity,
+    :start_event,
+    :source,
+    :term
 
-  has_one :eu_decision_type, :serializer => Species::EuDecisionTypeSerializer
-  has_one :geo_entity, :serializer => Species::GeoEntitySerializer
-  has_one :start_event, :serializer => Species::EventSerializer
-  has_one :source, :serializer => Species::TradeCodeSerializer
-  has_one :term, :serializer => Species::TradeCodeSerializer
+  def eu_decision_type
+    object['eu_decision_type'] && JSON.parse(object['eu_decision_type'])
+  end
+  def geo_entity
+    object['geo_entity_en'] && JSON.parse(object['geo_entity_en'])
+  end
+  def start_event
+    object['start_event'] && JSON.parse(object['start_event'])
+  end
+  def source
+    object['source'] && JSON.parse(object['source'])
+  end
+  def term
+    object['term'] && JSON.parse(object['term'])
+  end
 end

--- a/app/serializers/species/eu_decision_type_serializer.rb
+++ b/app/serializers/species/eu_decision_type_serializer.rb
@@ -1,3 +1,0 @@
-class Species::EuDecisionTypeSerializer < ActiveModel::Serializer
-  attributes :name, :tooltip
-end

--- a/app/serializers/species/event_serializer.rb
+++ b/app/serializers/species/event_serializer.rb
@@ -1,3 +1,0 @@
-class Species::EventSerializer < ActiveModel::Serializer
-  attributes :name, :effective_at_formatted, :url
-end

--- a/app/serializers/species/quota_serializer.rb
+++ b/app/serializers/species/quota_serializer.rb
@@ -1,15 +1,14 @@
 class Species::QuotaSerializer < ActiveModel::Serializer
   attributes :quota, :year, {:publication_date_formatted => :publication_date},
-    :notes, :url, :public_display, :is_current, :unit_name, :subspecies_info,
-    :nomenclature_note_en, :nomenclature_note_fr, :nomenclature_note_es
+    :notes, :url, :public_display, :is_current, :subspecies_info,
+    :nomenclature_note_en, :nomenclature_note_fr, :nomenclature_note_es,
+    :geo_entity,
+    :unit
 
-  has_one :geo_entity, :serializer => Species::GeoEntitySerializer
-
-  def quota
-    if object.quota == -1
-      "in prep."
-    else
-      object.quota
-    end
+  def geo_entity
+    object['geo_entity_en'] && JSON.parse(object['geo_entity_en'])
+  end
+  def unit
+    object['unit_en'] && JSON.parse(object['unit_en'])
   end
 end

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -15,8 +15,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
             trade_restrictions.taxon_concept_id = ?
             OR (
               (trade_restrictions.taxon_concept_id IN (?) OR trade_restrictions.taxon_concept_id IS NULL)
-              AND trade_restrictions.geo_entity_id IN
-                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = ?)
+              AND matching_taxon_concept_ids @> ARRAY[?]::INT[]
             )
       ", object.id, children_and_ancestors, object.id).
       select(<<-SQL
@@ -56,8 +55,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
             trade_restrictions.taxon_concept_id = ?
             OR (
               (trade_restrictions.taxon_concept_id IN (?) OR trade_restrictions.taxon_concept_id IS NULL)
-              AND trade_restrictions.geo_entity_id IN
-                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = ?)
+              AND matching_taxon_concept_ids @> ARRAY[?]::INT[]
             )
       ", object.id, children_and_ancestors, object.id).
       select(<<-SQL

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -27,12 +27,13 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               trade_restrictions.is_current,
               trade_restrictions.geo_entity_id,
               trade_restrictions.unit_id,
-              trade_restrictions.unit_name,
               CASE WHEN quota IS NULL THEN 'in prep.' ELSE quota::TEXT END,
               trade_restrictions.public_display,
               trade_restrictions.nomenclature_note_en,
               trade_restrictions.nomenclature_note_fr,
               trade_restrictions.nomenclature_note_es,
+              geo_entity_en,
+              unit_en,
               CASE
                 WHEN taxon_concept->>'rank' = '#{object.rank_name}'
                 THEN NULL
@@ -43,7 +44,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
       ).
       order(<<-SQL
               trade_restrictions.start_date DESC,
-              geo_entity->>'name_en' ASC, trade_restrictions.notes ASC,
+              geo_entity_en->>'name' ASC, trade_restrictions.notes ASC,
               subspecies_info DESC
             SQL
       ).all
@@ -70,6 +71,8 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               trade_restrictions.nomenclature_note_en,
               trade_restrictions.nomenclature_note_fr,
               trade_restrictions.nomenclature_note_es,
+              trade_restrictions.geo_entity_en,
+              trade_restrictions.start_notification,
               CASE
                 WHEN taxon_concept->>'rank' = '#{object.rank_name}'
                 THEN NULL
@@ -80,7 +83,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
       ).
       order(<<-SQL
               trade_restrictions.is_current DESC,
-              trade_restrictions.start_date DESC, geo_entity->>'name_en' ASC,
+              trade_restrictions.start_date DESC, geo_entity_en->>'name' ASC,
               subspecies_info DESC
             SQL
       ).all
@@ -110,6 +113,13 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               eu_decisions.nomenclature_note_en,
               eu_decisions.nomenclature_note_fr,
               eu_decisions.nomenclature_note_es,
+              eu_decision_type,
+              start_event,
+              end_event,
+              geo_entity_en,
+              taxon_concept,
+              term_en,
+              source_en,
               CASE
                 WHEN (taxon_concept->>'rank')::TEXT = '#{object.rank_name}'
                 THEN NULL
@@ -119,7 +129,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
              SQL
       ).
       order(<<-SQL
-            geo_entity->>'name_en' ASC,
+            geo_entity_en->>'name' ASC,
             CASE
               WHEN eu_decisions.type = 'EuOpinion'
                 THEN eu_decisions.start_date

--- a/db/migrate/20141222103221_create_legislation_api_types.rb
+++ b/db/migrate/20141222103221_create_legislation_api_types.rb
@@ -1,0 +1,25 @@
+class CreateLegislationApiTypes < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    CREATE TYPE api_taxon_concept AS (
+      id INT,
+      full_name TEXT,
+      author_year TEXT,
+      rank TEXT
+    );
+    CREATE TYPE api_event AS (
+      name TEXT,
+      date DATE,
+      url TEXT
+    );
+    CREATE TYPE api_geo_entity AS (
+      id INT,
+      iso_code2 TEXT,
+      name_en TEXT,
+      name_es TEXT,
+      name_fr TEXT,
+      type TEXT
+    );
+    SQL
+  end
+end

--- a/db/migrate/20141222121945_create_eu_legislation_api_types.rb
+++ b/db/migrate/20141222121945_create_eu_legislation_api_types.rb
@@ -1,0 +1,19 @@
+class CreateEuLegislationApiTypes < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    CREATE TYPE api_trade_code AS (
+      id INT,
+      code TEXT,
+      name_en TEXT,
+      name_es TEXT,
+      name_fr TEXT
+    );
+    CREATE TYPE api_eu_decision_type AS (
+      id INT,
+      name TEXT,
+      description TEXT,
+      type TEXT
+    )
+    SQL
+  end
+end

--- a/db/migrate/20141222121945_create_eu_legislation_api_types.rb
+++ b/db/migrate/20141222121945_create_eu_legislation_api_types.rb
@@ -13,7 +13,7 @@ class CreateEuLegislationApiTypes < ActiveRecord::Migration
       name TEXT,
       description TEXT,
       type TEXT
-    )
+    );
     SQL
   end
 end

--- a/db/migrate/20141222133058_use_single_language.rb
+++ b/db/migrate/20141222133058_use_single_language.rb
@@ -1,0 +1,19 @@
+class UseSingleLanguage < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    DROP TYPE api_trade_code CASCADE;
+    CREATE TYPE api_trade_code AS (
+      id INT,
+      code TEXT,
+      name TEXT
+    );
+    DROP TYPE api_geo_entity CASCADE;
+    CREATE TYPE api_geo_entity AS (
+      id INT,
+      iso_code2 TEXT,
+      name TEXT,
+      type TEXT
+    );
+    SQL
+  end
+end

--- a/db/migrate/20141223141124_create_api_higher_taxa_type.rb
+++ b/db/migrate/20141223141124_create_api_higher_taxa_type.rb
@@ -1,0 +1,13 @@
+class CreateApiHigherTaxaType < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    CREATE TYPE api_higher_taxa AS (
+      kingdom TEXT,
+      phylum TEXT,
+      class TEXT,
+      "order" TEXT,
+      family TEXT
+    );
+    SQL
+  end
+end

--- a/db/migrate/20141223160054_timestamp_api_views.rb
+++ b/db/migrate/20141223160054_timestamp_api_views.rb
@@ -10,6 +10,8 @@ class TimestampApiViews < ActiveRecord::Migration
     execute "CREATE VIEW api_distributions_view AS #{view_sql('20141223160054', 'api_distributions_view')}"
     execute "DROP VIEW IF EXISTS api_eu_decisions_view"
     execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20141223160054', 'api_eu_decisions_view')}"
+    execute "DROP TYPE IF EXISTS higher_taxa"
+    execute "DROP TYPE IF EXISTS simple_taxon_concept"
     execute "DROP VIEW IF EXISTS api_taxon_concepts_view"
     execute "CREATE VIEW api_taxon_concepts_view AS #{view_sql('20141223160054', 'api_taxon_concepts_view')}"
   end

--- a/db/migrate/20141223160054_timestamp_api_views.rb
+++ b/db/migrate/20141223160054_timestamp_api_views.rb
@@ -1,0 +1,16 @@
+class TimestampApiViews < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_quotas_view"
+    execute "CREATE VIEW api_cites_quotas_view AS #{view_sql('20141223160054', 'api_cites_quotas_view')}"
+    execute "DROP VIEW IF EXISTS api_cites_suspensions_view"
+    execute "CREATE VIEW api_cites_suspensions_view AS #{view_sql('20141223160054', 'api_cites_suspensions_view')}"
+    execute "DROP VIEW IF EXISTS api_common_names_view"
+    execute "CREATE VIEW api_common_names_view AS #{view_sql('20141223160054', 'api_common_names_view')}"
+    execute "DROP VIEW IF EXISTS api_distributions_view"
+    execute "CREATE VIEW api_distributions_view AS #{view_sql('20141223160054', 'api_distributions_view')}"
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20141223160054', 'api_eu_decisions_view')}"
+    execute "DROP VIEW IF EXISTS api_taxon_concepts_view"
+    execute "CREATE VIEW api_taxon_concepts_view AS #{view_sql('20141223160054', 'api_taxon_concepts_view')}"
+  end
+end

--- a/db/migrate/20141223164041_create_some_more_legislation_api_types.rb
+++ b/db/migrate/20141223164041_create_some_more_legislation_api_types.rb
@@ -1,0 +1,10 @@
+class CreateSomeMoreLegislationApiTypes < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    CREATE TYPE api_annotation AS (
+      symbol TEXT,
+      note TEXT
+    );
+    SQL
+  end
+end

--- a/db/migrate/20141223171143_create_master_listing_changes_mviews.rb
+++ b/db/migrate/20141223171143_create_master_listing_changes_mviews.rb
@@ -1,0 +1,95 @@
+class CreateMasterListingChangesMviews < ActiveRecord::Migration
+  def change
+    [:cites, :eu, :cms].each do |designation|
+      listing_changes_mview = "#{designation}_listing_changes_mview"
+
+      # create master cites/eu/cms listing changes mview
+      execute <<-SQL
+      CREATE TABLE master_#{listing_changes_mview}
+      (
+        taxon_concept_id integer,
+        id integer,
+        original_taxon_concept_id integer,
+        effective_at timestamp without time zone,
+        species_listing_id integer,
+        species_listing_name character varying(255),
+        change_type_id integer,
+        change_type_name character varying(255),
+        designation_id integer,
+        designation_name character varying(255),
+        parent_id integer,
+        nomenclature_note_en text,
+        nomenclature_note_fr text,
+        nomenclature_note_es text,
+        party_id integer,
+        party_iso_code character varying(255),
+        party_full_name_en character varying(255),
+        party_full_name_es character varying(255),
+        party_full_name_fr character varying(255),
+        ann_symbol character varying(255),
+        full_note_en text,
+        full_note_es text,
+        full_note_fr text,
+        short_note_en text,
+        short_note_es text,
+        short_note_fr text,
+        display_in_index boolean,
+        display_in_footnote boolean,
+        hash_ann_symbol character varying(255),
+        hash_ann_parent_symbol character varying(255),
+        hash_full_note_en text,
+        hash_full_note_es text,
+        hash_full_note_fr text,
+        inclusion_taxon_concept_id integer,
+        inherited_short_note_en text,
+        inherited_full_note_en text,
+        inherited_short_note_es text,
+        inherited_full_note_es text,
+        inherited_short_note_fr text,
+        inherited_full_note_fr text,
+        auto_note_en text,
+        auto_note_es text,
+        auto_note_fr text,
+        is_current boolean,
+        explicit_change boolean,
+        updated_at timestamp without time zone,
+        show_in_history boolean,
+        show_in_downloads boolean,
+        show_in_timeline boolean,
+        listed_geo_entities_ids integer[],
+        excluded_geo_entities_ids integer[],
+        excluded_taxon_concept_ids integer[],
+        dirty boolean,
+        expiry timestamp with time zone,
+        event_id integer
+      )
+      SQL
+      if table_exists?(listing_changes_mview)
+        unless column_exists?(listing_changes_mview, :event_id)
+          execute "ALTER TABLE #{listing_changes_mview} ADD COLUMN event_id INT"
+        end
+        execute <<-SQL
+        UPDATE #{listing_changes_mview}
+        SET event_id = listing_changes.event_id
+        FROM listing_changes
+        WHERE listing_changes.id = #{listing_changes_mview}.id
+        SQL
+
+        # rename to child cites/eu/cms listing changes mview
+        # and link to master
+        execute <<-SQL
+        ALTER TABLE #{listing_changes_mview}
+        RENAME TO child_#{listing_changes_mview};
+        ALTER TABLE child_#{listing_changes_mview}
+        INHERIT master_#{listing_changes_mview};
+        SQL
+      end
+
+      # rename master
+      execute <<-SQL
+      ALTER TABLE master_#{listing_changes_mview}
+      RENAME TO #{listing_changes_mview};
+      SQL
+    end
+  end
+end

--- a/db/migrate/20141223171144_create_api_listing_changes_views.rb
+++ b/db/migrate/20141223171144_create_api_listing_changes_views.rb
@@ -1,0 +1,8 @@
+class CreateApiListingChangesViews < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_listing_changes_view"
+    execute "CREATE VIEW api_cites_listing_changes_view AS #{view_sql('20141223171144', 'api_cites_listing_changes_view')}"
+    execute "DROP VIEW IF EXISTS api_eu_listing_changes_view"
+    execute "CREATE VIEW api_eu_listing_changes_view AS #{view_sql('20141223171144', 'api_eu_listing_changes_view')}"
+  end
+end

--- a/db/migrate/20141228094935_update_api_cites_suspensions_view.rb
+++ b/db/migrate/20141228094935_update_api_cites_suspensions_view.rb
@@ -1,0 +1,6 @@
+class UpdateApiCitesSuspensionsView < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_suspensions_view"
+    execute "CREATE VIEW api_cites_suspensions_view AS #{view_sql('20141228094935', 'api_cites_suspensions_view')}"
+  end
+end

--- a/db/migrate/20141228101341_update_api_cites_quotas_view.rb
+++ b/db/migrate/20141228101341_update_api_cites_quotas_view.rb
@@ -1,0 +1,6 @@
+class UpdateApiCitesQuotasView < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_quotas_view"
+    execute "CREATE VIEW api_cites_quotas_view AS #{view_sql('20141228101341', 'api_cites_quotas_view')}"
+  end
+end

--- a/db/migrate/20141228224334_update_listing_changes_views.rb
+++ b/db/migrate/20141228224334_update_listing_changes_views.rb
@@ -1,0 +1,8 @@
+class UpdateListingChangesViews < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_listing_changes_view"
+    execute "CREATE VIEW api_cites_listing_changes_view AS #{view_sql('20141228224334', 'api_cites_listing_changes_view')}"
+    execute "DROP VIEW IF EXISTS api_eu_listing_changes_view"
+    execute "CREATE VIEW api_eu_listing_changes_view AS #{view_sql('20141228224334', 'api_eu_listing_changes_view')}"
+  end
+end

--- a/db/migrate/20141230193843_add_geo_entity_type_to_listing_changes_mviews.rb
+++ b/db/migrate/20141230193843_add_geo_entity_type_to_listing_changes_mviews.rb
@@ -2,8 +2,9 @@ class AddGeoEntityTypeToListingChangesMviews < ActiveRecord::Migration
   def change
     [:cites, :eu, :cms].each do |designation|
       listing_changes_mview = "#{designation}_listing_changes_mview"
-
-      add_column listing_changes_mview, :geo_entity_type, :string
+      unless column_exists? listing_changes_mview, :geo_entity_type
+        add_column listing_changes_mview, :geo_entity_type, :string
+      end
     end
   end
 end

--- a/db/migrate/20141230193843_add_geo_entity_type_to_listing_changes_mviews.rb
+++ b/db/migrate/20141230193843_add_geo_entity_type_to_listing_changes_mviews.rb
@@ -1,0 +1,9 @@
+class AddGeoEntityTypeToListingChangesMviews < ActiveRecord::Migration
+  def change
+    [:cites, :eu, :cms].each do |designation|
+      listing_changes_mview = "#{designation}_listing_changes_mview"
+
+      add_column listing_changes_mview, :geo_entity_type, :string
+    end
+  end
+end

--- a/db/migrate/20141230193844_remove_id_from_api_types.rb
+++ b/db/migrate/20141230193844_remove_id_from_api_types.rb
@@ -23,7 +23,7 @@ class RemoveIdFromApiTypes < ActiveRecord::Migration
         name TEXT,
         description TEXT,
         type TEXT
-      )
+      );
     SQL
 
     execute "CREATE VIEW api_cites_listing_changes_view AS #{view_sql('20141230193844', 'api_cites_listing_changes_view')}"

--- a/db/migrate/20141230193844_remove_id_from_api_types.rb
+++ b/db/migrate/20141230193844_remove_id_from_api_types.rb
@@ -1,0 +1,37 @@
+class RemoveIdFromApiTypes < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS api_cites_listing_changes_view"
+    execute "DROP VIEW IF EXISTS api_cites_suspensions_view"
+    execute "DROP VIEW IF EXISTS api_cites_quotas_view"
+    execute "DROP VIEW IF EXISTS api_eu_listing_changes_view"
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+
+    execute <<-SQL
+      DROP TYPE api_geo_entity;
+      CREATE TYPE api_geo_entity AS (
+        iso_code2 TEXT,
+        name TEXT,
+        type TEXT
+      );
+      DROP TYPE api_trade_code;
+      CREATE TYPE api_trade_code AS (
+        code TEXT,
+        name TEXT
+      );
+      DROP TYPE api_eu_decision_type;
+      CREATE TYPE api_eu_decision_type AS (
+        name TEXT,
+        description TEXT,
+        type TEXT
+      )
+    SQL
+
+    execute "CREATE VIEW api_cites_listing_changes_view AS #{view_sql('20141230193844', 'api_cites_listing_changes_view')}"
+    execute "CREATE VIEW api_cites_suspensions_view AS #{view_sql('20141230193844', 'api_cites_suspensions_view')}"
+    execute "CREATE VIEW api_cites_quotas_view AS #{view_sql('20141230193844', 'api_cites_quotas_view')}"
+    execute "CREATE VIEW api_eu_listing_changes_view AS #{view_sql('20141230193844', 'api_eu_listing_changes_view')}"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20141230193844', 'api_eu_decisions_view')}"
+
+20141230193844
+  end
+end

--- a/db/migrate/20150107171940_remove_new_line_after_notes.rb
+++ b/db/migrate/20150107171940_remove_new_line_after_notes.rb
@@ -1,0 +1,6 @@
+class RemoveNewLineAfterNotes < ActiveRecord::Migration
+  def change
+    execute "DROP VIEW IF EXISTS eu_decisions_view"
+    execute "CREATE VIEW eu_decisions_view AS #{view_sql('20150107171940', 'eu_decisions_view')}"
+  end
+end

--- a/db/mviews/005_rebuild_designation_listing_changes_mview.sql
+++ b/db/mviews/005_rebuild_designation_listing_changes_mview.sql
@@ -61,6 +61,7 @@ CREATE OR REPLACE FUNCTION rebuild_designation_listing_changes_mview(
     geo_entities.name_en AS party_full_name_en,
     geo_entities.name_es AS party_full_name_es,
     geo_entities.name_fr AS party_full_name_fr,
+    geo_entity_types.name AS geo_entity_type,
     annotations.symbol AS ann_symbol,
     annotations.full_note_en,
     annotations.full_note_es,
@@ -156,6 +157,8 @@ CREATE OR REPLACE FUNCTION rebuild_designation_listing_changes_mview(
     ON listing_changes.species_listing_id = species_listings.id
     LEFT JOIN geo_entities ON
     geo_entities.id = tmp_lc.party_id
+    LEFT JOIN geo_entity_types ON
+    geo_entity_types.id = geo_entities.geo_entity_type_id
     LEFT JOIN annotations ON
     annotations.id = listing_changes.annotation_id
     LEFT JOIN annotations hash_annotations ON

--- a/db/mviews/007a_rebuild_cites_species_listing_mview.sql
+++ b/db/mviews/007a_rebuild_cites_species_listing_mview.sql
@@ -68,6 +68,7 @@ SELECT
       END
       || CASE
           WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          ELSE ''
       END
       ORDER BY listing_changes_mview.species_listing_name
     ),

--- a/db/mviews/007b_rebuild_eu_species_listing_mview.sql
+++ b/db/mviews/007b_rebuild_eu_species_listing_mview.sql
@@ -67,6 +67,7 @@ SELECT
       END
       || CASE
           WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          ELSE ''
       END
       ORDER BY listing_changes_mview.species_listing_name
     ),

--- a/db/mviews/007c_rebuild_cms_species_listing_mview.sql
+++ b/db/mviews/007c_rebuild_cms_species_listing_mview.sql
@@ -51,6 +51,7 @@ SELECT
       END
       || CASE
           WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          ELSE ''
       END
       ORDER BY listing_changes_mview.species_listing_name
     ),

--- a/db/views/api_cites_listing_changes_view/20141223171144.sql
+++ b/db/views/api_cites_listing_changes_view/20141223171144.sql
@@ -1,0 +1,133 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'DELETION'
+      OR listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL'
+    THEN FALSE
+    ELSE listing_changes_mview.is_current
+  END AS is_current,
+  listing_changes_mview.effective_at,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_en,
+      NULL
+    )::api_geo_entity
+  ) AS party_en,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_es,
+      NULL
+    )::api_geo_entity
+  ) AS party_es,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_fr,
+      NULL
+    )::api_geo_entity
+  ) AS party_fr,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+        WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+        ELSE strip_tags(listing_changes_mview.short_note_en)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+      END
+    )::api_annotation
+  ) AS annotation_en,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+        WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+        ELSE strip_tags(listing_changes_mview.short_note_es)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+      END
+    )::api_annotation
+  ) AS annotation_es,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+        WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+        ELSE strip_tags(listing_changes_mview.short_note_fr)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+      END
+    )::api_annotation
+  ) AS annotation_fr,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_en)
+    )::api_annotation
+  ) AS hash_annotation_en,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_es)
+    )::api_annotation
+  ) AS hash_annotation_es,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_fr)
+    )::api_annotation
+  ) AS hash_annotation_fr,
+
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM cites_listing_changes_mview listing_changes_mview
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_cites_listing_changes_view/20141228224334.sql
+++ b/db/views/api_cites_listing_changes_view/20141228224334.sql
@@ -1,0 +1,199 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'DELETION'
+      OR listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL'
+    THEN FALSE
+    ELSE listing_changes_mview.is_current
+  END AS is_current,
+  listing_changes_mview.effective_at::DATE,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'ADDITION' THEN '+'
+    WHEN listing_changes_mview.change_type_name = 'DELETION' THEN '-'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION' THEN 'R+'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL' THEN 'R-'
+    ELSE ''
+  END AS change_type,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_en,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_en,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_es,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_es,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_fr,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_fr,
+  CASE
+    WHEN listing_changes_mview.auto_note_en IS NULL
+      AND listing_changes_mview.inherited_full_note_en IS NULL
+      AND listing_changes_mview.inherited_short_note_en IS NULL
+      AND listing_changes_mview.full_note_en IS NULL
+      AND listing_changes_mview.short_note_en IS NULL
+      AND listing_changes_mview.nomenclature_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+            WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+            ELSE strip_tags(listing_changes_mview.short_note_en)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          END
+        )::api_annotation
+      )
+  END AS annotation_en,
+  CASE
+    WHEN listing_changes_mview.auto_note_es IS NULL
+      AND listing_changes_mview.inherited_full_note_es IS NULL
+      AND listing_changes_mview.inherited_short_note_es IS NULL
+      AND listing_changes_mview.full_note_es IS NULL
+      AND listing_changes_mview.short_note_es IS NULL
+      AND listing_changes_mview.nomenclature_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+            WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+            ELSE strip_tags(listing_changes_mview.short_note_es)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          END
+        )::api_annotation
+      )
+  END AS annotation_es,
+  CASE
+    WHEN listing_changes_mview.auto_note_fr IS NULL
+      AND listing_changes_mview.inherited_full_note_fr IS NULL
+      AND listing_changes_mview.inherited_short_note_fr IS NULL
+      AND listing_changes_mview.full_note_fr IS NULL
+      AND listing_changes_mview.short_note_fr IS NULL
+      AND listing_changes_mview.nomenclature_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+            WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+            ELSE strip_tags(listing_changes_mview.short_note_fr)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+          END
+        )::api_annotation
+      )
+  END AS annotation_fr,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_en)
+        )::api_annotation
+      )
+  END AS hash_annotation_en,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_es)
+        )::api_annotation
+      )
+  END AS hash_annotation_es,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_fr)
+        )::api_annotation
+      )
+  END AS hash_annotation_fr,
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM cites_listing_changes_mview listing_changes_mview
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_cites_listing_changes_view/20141230193844.sql
+++ b/db/views/api_cites_listing_changes_view/20141230193844.sql
@@ -1,0 +1,187 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'DELETION'
+      OR listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL'
+    THEN FALSE
+    ELSE listing_changes_mview.is_current
+  END AS is_current,
+  listing_changes_mview.effective_at::DATE,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'ADDITION' THEN '+'
+    WHEN listing_changes_mview.change_type_name = 'DELETION' THEN '-'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION' THEN 'R+'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL' THEN 'R-'
+    ELSE ''
+  END AS change_type,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_en,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_en,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_es,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_es,
+  CASE
+    WHEN party_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_fr,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_fr,
+  CASE
+    WHEN listing_changes_mview.auto_note_en IS NULL
+      AND listing_changes_mview.inherited_full_note_en IS NULL
+      AND listing_changes_mview.inherited_short_note_en IS NULL
+      AND listing_changes_mview.full_note_en IS NULL
+      AND listing_changes_mview.short_note_en IS NULL
+      AND listing_changes_mview.nomenclature_note_en IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+        WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+        WHEN LENGTH(listing_changes_mview.short_note_en) > 0 THEN strip_tags(listing_changes_mview.short_note_en)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+        ELSE ''
+      END
+  END AS annotation_en,
+  CASE
+    WHEN listing_changes_mview.auto_note_es IS NULL
+      AND listing_changes_mview.inherited_full_note_es IS NULL
+      AND listing_changes_mview.inherited_short_note_es IS NULL
+      AND listing_changes_mview.full_note_es IS NULL
+      AND listing_changes_mview.short_note_es IS NULL
+      AND listing_changes_mview.nomenclature_note_es IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+        WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+        WHEN LENGTH(listing_changes_mview.short_note_es) > 0 THEN strip_tags(listing_changes_mview.short_note_es)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+        ELSE ''
+      END
+  END AS annotation_es,
+  CASE
+    WHEN listing_changes_mview.auto_note_fr IS NULL
+      AND listing_changes_mview.inherited_full_note_fr IS NULL
+      AND listing_changes_mview.inherited_short_note_fr IS NULL
+      AND listing_changes_mview.full_note_fr IS NULL
+      AND listing_changes_mview.short_note_fr IS NULL
+      AND listing_changes_mview.nomenclature_note_fr IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+        WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+        WHEN LENGTH(listing_changes_mview.short_note_fr) > 0 THEN strip_tags(listing_changes_mview.short_note_fr)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+        ELSE ''
+      END
+  END AS annotation_fr,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_en)
+        )::api_annotation
+      )
+  END AS hash_annotation_en,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_es)
+        )::api_annotation
+      )
+  END AS hash_annotation_es,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_fr)
+        )::api_annotation
+      )
+  END AS hash_annotation_fr,
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM cites_listing_changes_mview listing_changes_mview
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_cites_quotas_view.sql
+++ b/db/views/api_cites_quotas_view.sql
@@ -1,0 +1,41 @@
+DROP VIEW IF EXISTS api_cites_quotas_view;
+CREATE VIEW api_cites_quotas_view AS
+SELECT
+  trade_restrictions.type,
+  trade_restrictions.taxon_concept_id,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  trade_restrictions.notes,
+  trade_restrictions.url,
+  trade_restrictions.start_date,
+  trade_restrictions.publication_date,
+  trade_restrictions.is_current,
+  trade_restrictions.geo_entity_id,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entities.name_es,
+      geo_entities.name_fr,
+      ''
+    )::api_geo_entity
+  ) AS geo_entity,
+  trade_restrictions.unit_id,
+  units.name_en AS unit_name,
+  CASE WHEN trade_restrictions.quota = -1 THEN NULL ELSE trade_restrictions.quota END AS quota,
+  trade_restrictions.public_display,
+  trade_restrictions.nomenclature_note_en,
+  trade_restrictions.nomenclature_note_fr,
+  trade_restrictions.nomenclature_note_es
+  FROM trade_restrictions
+  JOIN geo_entities ON geo_entities.id = trade_restrictions.geo_entity_id
+  LEFT JOIN taxon_concepts ON taxon_concepts.id = trade_restrictions.taxon_concept_id
+  LEFT JOIN trade_codes units ON units.id = trade_restrictions.unit_id AND units.type = 'Unit'
+  WHERE trade_restrictions.type IN ('Quota');

--- a/db/views/api_cites_quotas_view.sql
+++ b/db/views/api_cites_quotas_view.sql
@@ -22,13 +22,47 @@ SELECT
       geo_entities.id,
       geo_entities.iso_code2,
       geo_entities.name_en,
-      geo_entities.name_es,
-      geo_entities.name_fr,
-      ''
+      geo_entity_types.name
     )::api_geo_entity
-  ) AS geo_entity,
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
   trade_restrictions.unit_id,
-  units.name_en AS unit_name,
+  ROW_TO_JSON(
+    ROW(
+      units.id,
+      units.code,
+      units.name_en
+    )::api_trade_code
+  ) AS unit_en,
+  ROW_TO_JSON(
+    ROW(
+      units.id,
+      units.code,
+      units.name_es
+    )::api_trade_code
+  ) AS unit_es,
+  ROW_TO_JSON(
+    ROW(
+      units.id,
+      units.code,
+      units.name_fr
+    )::api_trade_code
+  ) AS unit_fr,
   CASE WHEN trade_restrictions.quota = -1 THEN NULL ELSE trade_restrictions.quota END AS quota,
   trade_restrictions.public_display,
   trade_restrictions.nomenclature_note_en,
@@ -36,6 +70,7 @@ SELECT
   trade_restrictions.nomenclature_note_es
   FROM trade_restrictions
   JOIN geo_entities ON geo_entities.id = trade_restrictions.geo_entity_id
+  JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
   LEFT JOIN taxon_concepts ON taxon_concepts.id = trade_restrictions.taxon_concept_id
   LEFT JOIN trade_codes units ON units.id = trade_restrictions.unit_id AND units.type = 'Unit'
   WHERE trade_restrictions.type IN ('Quota');

--- a/db/views/api_cites_quotas_view/20141223160054.sql
+++ b/db/views/api_cites_quotas_view/20141223160054.sql
@@ -1,5 +1,3 @@
-DROP VIEW IF EXISTS api_cites_quotas_view;
-CREATE VIEW api_cites_quotas_view AS
 SELECT
   trade_restrictions.type,
   trade_restrictions.taxon_concept_id,

--- a/db/views/api_cites_quotas_view/20141228101341.sql
+++ b/db/views/api_cites_quotas_view/20141228101341.sql
@@ -1,0 +1,125 @@
+WITH cites_quotas AS (
+  SELECT
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.url,
+    tr.start_date,
+    tr.publication_date::DATE,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.unit_id,
+    CASE WHEN tr.quota = -1 THEN NULL ELSE tr.quota END AS quota,
+    tr.public_display,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+  FROM trade_restrictions tr
+  WHERE tr.type IN ('Quota')
+), cites_quotas_with_taxon_concept AS (
+  SELECT tr.*,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  ARRAY[]::INT[] AS matching_taxon_concept_ids
+  FROM cites_quotas tr
+  JOIN taxon_concepts ON taxon_concepts.id = tr.taxon_concept_id
+  WHERE taxon_concept_id IS NOT NULL
+), cites_quotas_without_taxon_concept AS (
+  SELECT tr.*,
+    NULL::JSON AS taxon_concept,
+    ARRAY_AGG_NOTNULL(
+      distributions.taxon_concept_id
+    ) AS matching_taxon_concept_ids
+  FROM cites_quotas tr
+  JOIN distributions ON distributions.geo_entity_id = tr.geo_entity_id
+  WHERE tr.taxon_concept_id IS NULL
+  GROUP BY
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.url,
+    tr.start_date,
+    tr.publication_date,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.unit_id,
+    tr.quota,
+    tr.public_display,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+), all_cites_quotas AS (
+  SELECT * FROM cites_quotas_with_taxon_concept
+  UNION ALL
+  SELECT * FROM cites_quotas_without_taxon_concept
+)
+SELECT tr. *,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.id,
+          units.code,
+          units.name_en
+        )::api_trade_code
+      )
+  END AS unit_en,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.id,
+          units.code,
+          units.name_es
+        )::api_trade_code
+      )
+  END AS unit_es,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.id,
+          units.code,
+          units.name_fr
+        )::api_trade_code
+      )
+  END AS unit_fr
+FROM all_cites_quotas tr
+JOIN geo_entities ON geo_entities.id = tr.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+LEFT JOIN trade_codes units ON units.id = tr.unit_id AND units.type = 'Unit';

--- a/db/views/api_cites_quotas_view/20141230193844.sql
+++ b/db/views/api_cites_quotas_view/20141230193844.sql
@@ -1,0 +1,119 @@
+WITH cites_quotas AS (
+  SELECT
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.url,
+    tr.start_date,
+    tr.publication_date::DATE,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.unit_id,
+    CASE WHEN tr.quota = -1 THEN NULL ELSE tr.quota END AS quota,
+    tr.public_display,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+  FROM trade_restrictions tr
+  WHERE tr.type IN ('Quota')
+), cites_quotas_with_taxon_concept AS (
+  SELECT tr.*,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  ARRAY[]::INT[] AS matching_taxon_concept_ids
+  FROM cites_quotas tr
+  JOIN taxon_concepts ON taxon_concepts.id = tr.taxon_concept_id
+  WHERE taxon_concept_id IS NOT NULL
+), cites_quotas_without_taxon_concept AS (
+  SELECT tr.*,
+    NULL::JSON AS taxon_concept,
+    ARRAY_AGG_NOTNULL(
+      distributions.taxon_concept_id
+    ) AS matching_taxon_concept_ids
+  FROM cites_quotas tr
+  JOIN distributions ON distributions.geo_entity_id = tr.geo_entity_id
+  WHERE tr.taxon_concept_id IS NULL
+  GROUP BY
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.url,
+    tr.start_date,
+    tr.publication_date,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.unit_id,
+    tr.quota,
+    tr.public_display,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+), all_cites_quotas AS (
+  SELECT * FROM cites_quotas_with_taxon_concept
+  UNION ALL
+  SELECT * FROM cites_quotas_without_taxon_concept
+)
+SELECT tr. *,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.code,
+          units.name_en
+        )::api_trade_code
+      )
+  END AS unit_en,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.code,
+          units.name_es
+        )::api_trade_code
+      )
+  END AS unit_es,
+  CASE
+    WHEN unit_id IS NULL THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          units.code,
+          units.name_fr
+        )::api_trade_code
+      )
+  END AS unit_fr
+FROM all_cites_quotas tr
+JOIN geo_entities ON geo_entities.id = tr.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+LEFT JOIN trade_codes units ON units.id = tr.unit_id AND units.type = 'Unit';

--- a/db/views/api_cites_suspensions_view.sql
+++ b/db/views/api_cites_suspensions_view.sql
@@ -1,0 +1,46 @@
+DROP VIEW IF EXISTS api_cites_suspensions_view;
+CREATE VIEW api_cites_suspensions_view AS
+SELECT
+  trade_restrictions.type,
+  trade_restrictions.taxon_concept_id,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  trade_restrictions.notes,
+  trade_restrictions.start_date,
+  trade_restrictions.end_date,
+  trade_restrictions.is_current,
+  trade_restrictions.geo_entity_id,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entities.name_es,
+      geo_entities.name_fr,
+      ''
+    )::api_geo_entity
+  ) AS geo_entity,
+  trade_restrictions.start_notification_id,
+  ROW_TO_JSON(
+    ROW(
+      events.name,
+      events.effective_at,
+      events.url
+    )::api_event
+  ) AS start_notification,
+  trade_restrictions.end_notification_id,
+  trade_restrictions.nomenclature_note_en,
+  trade_restrictions.nomenclature_note_fr,
+  trade_restrictions.nomenclature_note_es
+FROM trade_restrictions
+JOIN geo_entities ON geo_entities.id = trade_restrictions.geo_entity_id
+JOIN events ON events.id = trade_restrictions.start_notification_id
+  AND events.type IN ('CitesSuspensionNotification')
+LEFT JOIN taxon_concepts ON taxon_concepts.id = trade_restrictions.taxon_concept_id
+WHERE trade_restrictions.type IN ('CitesSuspension');

--- a/db/views/api_cites_suspensions_view.sql
+++ b/db/views/api_cites_suspensions_view.sql
@@ -21,11 +21,25 @@ SELECT
       geo_entities.id,
       geo_entities.iso_code2,
       geo_entities.name_en,
-      geo_entities.name_es,
-      geo_entities.name_fr,
-      ''
+      geo_entity_types.name
     )::api_geo_entity
-  ) AS geo_entity,
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
   trade_restrictions.start_notification_id,
   ROW_TO_JSON(
     ROW(
@@ -40,6 +54,7 @@ SELECT
   trade_restrictions.nomenclature_note_es
 FROM trade_restrictions
 JOIN geo_entities ON geo_entities.id = trade_restrictions.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
 JOIN events ON events.id = trade_restrictions.start_notification_id
   AND events.type IN ('CitesSuspensionNotification')
 LEFT JOIN taxon_concepts ON taxon_concepts.id = trade_restrictions.taxon_concept_id

--- a/db/views/api_cites_suspensions_view/20141223160054.sql
+++ b/db/views/api_cites_suspensions_view/20141223160054.sql
@@ -1,5 +1,3 @@
-DROP VIEW IF EXISTS api_cites_suspensions_view;
-CREATE VIEW api_cites_suspensions_view AS
 SELECT
   trade_restrictions.type,
   trade_restrictions.taxon_concept_id,

--- a/db/views/api_cites_suspensions_view/20141228094935.sql
+++ b/db/views/api_cites_suspensions_view/20141228094935.sql
@@ -1,0 +1,97 @@
+WITH cites_suspensions AS (
+  SELECT
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.start_date::DATE,
+    tr.end_date::DATE,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.start_notification_id,
+    tr.end_notification_id,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+  FROM trade_restrictions tr
+  WHERE tr.type IN ('CitesSuspension')
+), cites_suspensions_with_taxon_concept AS (
+  SELECT tr.*,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  ARRAY[]::INT[] AS matching_taxon_concept_ids
+  FROM cites_suspensions tr
+  JOIN taxon_concepts ON taxon_concepts.id = tr.taxon_concept_id
+  WHERE taxon_concept_id IS NOT NULL
+), cites_suspensions_without_taxon_concept AS (
+  SELECT tr.*,
+    NULL::JSON AS taxon_concept,
+    ARRAY_AGG_NOTNULL(
+      distributions.taxon_concept_id
+    ) AS matching_taxon_concept_ids
+  FROM cites_suspensions tr
+  JOIN distributions ON distributions.geo_entity_id = tr.geo_entity_id
+  WHERE tr.taxon_concept_id IS NULL
+  GROUP BY
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.start_date,
+    tr.end_date,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.start_notification_id,
+    tr.end_notification_id,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+), all_cites_suspensions AS (
+  SELECT * FROM cites_suspensions_with_taxon_concept
+  UNION ALL
+  SELECT * FROM cites_suspensions_without_taxon_concept
+)
+SELECT
+  tr.*,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.id,
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
+  ROW_TO_JSON(
+    ROW(
+      events.name,
+      events.effective_at::DATE,
+      events.url
+    )::api_event
+  ) AS start_notification
+FROM all_cites_suspensions tr
+JOIN geo_entities ON geo_entities.id = tr.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN events ON events.id = tr.start_notification_id
+  AND events.type IN ('CitesSuspensionNotification');

--- a/db/views/api_cites_suspensions_view/20141230193844.sql
+++ b/db/views/api_cites_suspensions_view/20141230193844.sql
@@ -1,0 +1,94 @@
+WITH cites_suspensions AS (
+  SELECT
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.start_date::DATE,
+    tr.end_date::DATE,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.start_notification_id,
+    tr.end_notification_id,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+  FROM trade_restrictions tr
+  WHERE tr.type IN ('CitesSuspension')
+), cites_suspensions_with_taxon_concept AS (
+  SELECT tr.*,
+  ROW_TO_JSON(
+    ROW(
+      taxon_concept_id,
+      taxon_concepts.full_name,
+      taxon_concepts.author_year,
+      taxon_concepts.data->'rank_name'
+    )::api_taxon_concept
+  ) AS taxon_concept,
+  ARRAY[]::INT[] AS matching_taxon_concept_ids
+  FROM cites_suspensions tr
+  JOIN taxon_concepts ON taxon_concepts.id = tr.taxon_concept_id
+  WHERE taxon_concept_id IS NOT NULL
+), cites_suspensions_without_taxon_concept AS (
+  SELECT tr.*,
+    NULL::JSON AS taxon_concept,
+    ARRAY_AGG_NOTNULL(
+      distributions.taxon_concept_id
+    ) AS matching_taxon_concept_ids
+  FROM cites_suspensions tr
+  JOIN distributions ON distributions.geo_entity_id = tr.geo_entity_id
+  WHERE tr.taxon_concept_id IS NULL
+  GROUP BY
+    tr.id,
+    tr.type,
+    tr.taxon_concept_id,
+    tr.notes,
+    tr.start_date,
+    tr.end_date,
+    tr.is_current,
+    tr.geo_entity_id,
+    tr.start_notification_id,
+    tr.end_notification_id,
+    tr.nomenclature_note_en,
+    tr.nomenclature_note_fr,
+    tr.nomenclature_note_es
+), all_cites_suspensions AS (
+  SELECT * FROM cites_suspensions_with_taxon_concept
+  UNION ALL
+  SELECT * FROM cites_suspensions_without_taxon_concept
+)
+SELECT
+  tr.*,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
+  ROW_TO_JSON(
+    ROW(
+      events.name,
+      events.effective_at::DATE,
+      events.url
+    )::api_event
+  ) AS start_notification
+FROM all_cites_suspensions tr
+JOIN geo_entities ON geo_entities.id = tr.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN events ON events.id = tr.start_notification_id
+  AND events.type IN ('CitesSuspensionNotification');

--- a/db/views/api_common_names_view/20141223160054.sql
+++ b/db/views/api_common_names_view/20141223160054.sql
@@ -1,0 +1,4 @@
+SELECT taxon_commons.id, taxon_concept_id, languages.iso_code1, common_names.name
+FROM taxon_commons
+JOIN common_names ON common_names.id = taxon_commons.common_name_id
+JOIN languages ON languages.id = common_names.language_id;

--- a/db/views/api_distributions_view/20141223160054.sql
+++ b/db/views/api_distributions_view/20141223160054.sql
@@ -1,0 +1,20 @@
+SELECT
+  d.id,
+  d.taxon_concept_id,
+  g.name_en,
+  g.name_es,
+  g.name_fr,
+  g.iso_code2,
+  gt.name AS geo_entity_type,
+  ARRAY_AGG_NOTNULL(tags.name ORDER BY tags.name) AS tags,
+  ARRAY_AGG_NOTNULL(r.citation ORDER BY r.citation) AS citations,
+  d.created_at,
+  d.updated_at
+FROM distributions d
+JOIN geo_entities g ON g.id = d.geo_entity_id
+JOIN geo_entity_types gt ON gt.id = g.geo_entity_type_id
+LEFT JOIN taggings ON taggings.taggable_type='Distribution' AND taggings.taggable_id=d.id
+LEFT JOIN tags on tags.id = taggings.tag_id
+LEFT JOIN distribution_references dr ON dr.distribution_id = d.id
+LEFT JOIN "references" r ON r.id = dr.reference_id
+GROUP BY d.id, g.name_en, g.name_es, g.name_fr, g.iso_code2, gt.name;

--- a/db/views/api_eu_decisions_view.sql
+++ b/db/views/api_eu_decisions_view.sql
@@ -1,0 +1,100 @@
+DROP VIEW IF EXISTS api_eu_decisions_view;
+CREATE VIEW api_eu_decisions_view AS
+SELECT
+eu_decisions.type,
+eu_decisions.taxon_concept_id,
+ROW_TO_JSON(
+ ROW(
+   taxon_concept_id,
+   taxon_concepts.full_name,
+   taxon_concepts.author_year,
+   taxon_concepts.data->'rank_name'
+ )::api_taxon_concept
+) AS taxon_concept,
+eu_decisions.notes,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.start_date
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN start_event.effective_at
+END AS start_date,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.is_current
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN
+    CASE
+      WHEN start_event.effective_at <= current_date AND start_event.is_current = true
+        AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+      THEN TRUE
+      ELSE
+        FALSE
+    END
+END AS is_current,
+eu_decisions.geo_entity_id,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.id,
+    geo_entities.iso_code2,
+    geo_entities.name_en,
+    geo_entities.name_es,
+    geo_entities.name_fr,
+    ''
+  )::api_geo_entity
+) AS geo_entity,
+eu_decisions.start_event_id,
+ROW_TO_JSON(
+  ROW(
+    start_event.name,
+    start_event.effective_at,
+    start_event.url
+  )::api_event
+) AS start_event,
+eu_decisions.end_event_id,
+ROW_TO_JSON(
+  ROW(
+    end_event.name,
+    end_event.effective_at,
+    end_event.url
+  )::api_event
+) AS end_event,
+eu_decisions.term_id,
+ROW_TO_JSON(
+  ROW(
+    terms.id,
+    terms.code,
+    terms.name_en,
+    terms.name_es,
+    terms.name_fr
+  )::api_trade_code
+) AS term,
+ ROW_TO_JSON(
+  ROW(
+    sources.id,
+    sources.code,
+    sources.name_en,
+    sources.name_es,
+    sources.name_fr
+  )::api_trade_code
+) AS source,
+eu_decisions.source_id,
+eu_decisions.eu_decision_type_id,
+ROW_TO_JSON(
+  ROW(
+    eu_decision_types.id,
+    eu_decision_types.name,
+    eu_decision_types.tooltip,
+    eu_decision_types.decision_type
+  )::api_eu_decision_type
+) AS eu_decision_type,
+eu_decisions.nomenclature_note_en,
+eu_decisions.nomenclature_note_fr,
+eu_decisions.nomenclature_note_es
+FROM eu_decisions
+JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN trade_codes terms ON terms.id = eu_decisions.term_id AND terms.type = 'Term'
+LEFT JOIN trade_codes sources ON sources.id = eu_decisions.source_id AND sources.type = 'Source'
+LEFT JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id;

--- a/db/views/api_eu_decisions_view.sql
+++ b/db/views/api_eu_decisions_view.sql
@@ -37,11 +37,25 @@ ROW_TO_JSON(
     geo_entities.id,
     geo_entities.iso_code2,
     geo_entities.name_en,
-    geo_entities.name_es,
-    geo_entities.name_fr,
-    ''
+    geo_entity_types.name
   )::api_geo_entity
-) AS geo_entity,
+) AS geo_entity_en,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.id,
+    geo_entities.iso_code2,
+    geo_entities.name_es,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_es,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.id,
+    geo_entities.iso_code2,
+    geo_entities.name_fr,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_fr,
 eu_decisions.start_event_id,
 ROW_TO_JSON(
   ROW(
@@ -63,20 +77,44 @@ ROW_TO_JSON(
   ROW(
     terms.id,
     terms.code,
-    terms.name_en,
-    terms.name_es,
+    terms.name_en
+  )::api_trade_code
+) AS term_en,
+ROW_TO_JSON(
+  ROW(
+    terms.id,
+    terms.code,
+    terms.name_es
+  )::api_trade_code
+) AS term_es,
+ROW_TO_JSON(
+  ROW(
+    terms.id,
+    terms.code,
     terms.name_fr
   )::api_trade_code
-) AS term,
- ROW_TO_JSON(
+) AS term_fr,
+ROW_TO_JSON(
   ROW(
     sources.id,
     sources.code,
-    sources.name_en,
-    sources.name_es,
+    sources.name_en
+  )::api_trade_code
+) AS source_en,
+ROW_TO_JSON(
+  ROW(
+    sources.id,
+    sources.code,
+    sources.name_es
+  )::api_trade_code
+) AS source_es,
+ROW_TO_JSON(
+  ROW(
+    sources.id,
+    sources.code,
     sources.name_fr
   )::api_trade_code
-) AS source,
+) AS source_fr,
 eu_decisions.source_id,
 eu_decisions.eu_decision_type_id,
 ROW_TO_JSON(
@@ -92,6 +130,7 @@ eu_decisions.nomenclature_note_fr,
 eu_decisions.nomenclature_note_es
 FROM eu_decisions
 JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
 JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
 LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
 LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id

--- a/db/views/api_eu_decisions_view/20141223160054.sql
+++ b/db/views/api_eu_decisions_view/20141223160054.sql
@@ -1,5 +1,3 @@
-DROP VIEW IF EXISTS api_eu_decisions_view;
-CREATE VIEW api_eu_decisions_view AS
 SELECT
 eu_decisions.type,
 eu_decisions.taxon_concept_id,

--- a/db/views/api_eu_decisions_view/20141230193844.sql
+++ b/db/views/api_eu_decisions_view/20141230193844.sql
@@ -1,0 +1,127 @@
+SELECT
+eu_decisions.type,
+eu_decisions.taxon_concept_id,
+ROW_TO_JSON(
+ ROW(
+   taxon_concept_id,
+   taxon_concepts.full_name,
+   taxon_concepts.author_year,
+   taxon_concepts.data->'rank_name'
+ )::api_taxon_concept
+) AS taxon_concept,
+eu_decisions.notes,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.start_date::DATE
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN start_event.effective_at::DATE
+END AS start_date,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.is_current
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN
+    CASE
+      WHEN start_event.effective_at <= current_date AND start_event.is_current = true
+        AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+      THEN TRUE
+      ELSE
+        FALSE
+    END
+END AS is_current,
+eu_decisions.geo_entity_id,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_en,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_en,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_es,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_es,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_fr,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_fr,
+eu_decisions.start_event_id,
+ROW_TO_JSON(
+  ROW(
+    start_event.name,
+    start_event.effective_at::DATE,
+    start_event.url
+  )::api_event
+) AS start_event,
+eu_decisions.end_event_id,
+ROW_TO_JSON(
+  ROW(
+    end_event.name,
+    end_event.effective_at::DATE,
+    end_event.url
+  )::api_event
+) AS end_event,
+eu_decisions.term_id,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_en
+  )::api_trade_code
+) AS term_en,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_es
+  )::api_trade_code
+) AS term_es,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_fr
+  )::api_trade_code
+) AS term_fr,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_en
+  )::api_trade_code
+) AS source_en,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_es
+  )::api_trade_code
+) AS source_es,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_fr
+  )::api_trade_code
+) AS source_fr,
+eu_decisions.source_id,
+eu_decisions.eu_decision_type_id,
+ROW_TO_JSON(
+  ROW(
+    eu_decision_types.name,
+    eu_decision_types.tooltip,
+    eu_decision_types.decision_type
+  )::api_eu_decision_type
+) AS eu_decision_type,
+eu_decisions.nomenclature_note_en,
+eu_decisions.nomenclature_note_fr,
+eu_decisions.nomenclature_note_es
+FROM eu_decisions
+JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN trade_codes terms ON terms.id = eu_decisions.term_id AND terms.type = 'Term'
+LEFT JOIN trade_codes sources ON sources.id = eu_decisions.source_id AND sources.type = 'Source'
+LEFT JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id;

--- a/db/views/api_eu_listing_changes_view/20141223171144.sql
+++ b/db/views/api_eu_listing_changes_view/20141223171144.sql
@@ -1,0 +1,136 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  ROW_TO_JSON(
+    ROW(
+      events.description,
+      events.effective_at,
+      events.url
+    )::api_event
+  ) AS eu_regulation,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  listing_changes_mview.is_current,
+  listing_changes_mview.effective_at,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_en,
+      NULL
+    )::api_geo_entity
+  ) AS party_en,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_es,
+      NULL
+    )::api_geo_entity
+  ) AS party_es,
+  ROW_TO_JSON(
+    ROW(
+      party_id,
+      party_iso_code,
+      party_full_name_fr,
+      NULL
+    )::api_geo_entity
+  ) AS party_fr,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+        WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+        ELSE strip_tags(listing_changes_mview.short_note_en)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+      END
+    )::api_annotation
+  ) AS annotation_en,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+        WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+        ELSE strip_tags(listing_changes_mview.short_note_es)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+      END
+    )::api_annotation
+  ) AS annotation_es,
+  ROW_TO_JSON(
+    ROW(
+      NULL,
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+        WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+        ELSE strip_tags(listing_changes_mview.short_note_fr)
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+      END
+    )::api_annotation
+  ) AS annotation_fr,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_en)
+    )::api_annotation
+  ) AS hash_annotation_en,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_es)
+    )::api_annotation
+  ) AS hash_annotation_es,
+  ROW_TO_JSON(
+    ROW(
+      listing_changes_mview.hash_ann_symbol,
+      strip_tags(listing_changes_mview.hash_full_note_fr)
+    )::api_annotation
+  ) AS hash_annotation_fr,
+
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM eu_listing_changes_mview listing_changes_mview
+JOIN events ON events.id = listing_changes_mview.event_id
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_eu_listing_changes_view/20141228224334.sql
+++ b/db/views/api_eu_listing_changes_view/20141228224334.sql
@@ -1,0 +1,205 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  ROW_TO_JSON(
+    ROW(
+      events.description,
+      events.effective_at,
+      events.url
+    )::api_event
+  ) AS eu_regulation,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  listing_changes_mview.is_current,
+  listing_changes_mview.effective_at::DATE,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'ADDITION' THEN '+'
+    WHEN listing_changes_mview.change_type_name = 'DELETION' THEN '-'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION' THEN 'R+'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL' THEN 'R-'
+    ELSE ''
+  END AS change_type,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_en,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_en,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_es,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_es,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_id,
+          party_iso_code,
+          party_full_name_fr,
+          NULL
+        )::api_geo_entity
+      )
+  END AS party_fr,
+  CASE
+    WHEN listing_changes_mview.auto_note_en IS NULL
+      AND listing_changes_mview.inherited_full_note_en IS NULL
+      AND listing_changes_mview.inherited_short_note_en IS NULL
+      AND listing_changes_mview.full_note_en IS NULL
+      AND listing_changes_mview.short_note_en IS NULL
+      AND listing_changes_mview.nomenclature_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+            WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+            ELSE strip_tags(listing_changes_mview.short_note_en)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          END
+        )::api_annotation
+      )
+  END AS annotation_en,
+  CASE
+    WHEN listing_changes_mview.auto_note_es IS NULL
+      AND listing_changes_mview.inherited_full_note_es IS NULL
+      AND listing_changes_mview.inherited_short_note_es IS NULL
+      AND listing_changes_mview.full_note_es IS NULL
+      AND listing_changes_mview.short_note_es IS NULL
+      AND listing_changes_mview.nomenclature_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+            WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+            ELSE strip_tags(listing_changes_mview.short_note_es)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+          END
+        )::api_annotation
+      )
+  END AS annotation_es,
+  CASE
+    WHEN listing_changes_mview.auto_note_fr IS NULL
+      AND listing_changes_mview.inherited_full_note_fr IS NULL
+      AND listing_changes_mview.inherited_short_note_fr IS NULL
+      AND listing_changes_mview.full_note_fr IS NULL
+      AND listing_changes_mview.short_note_fr IS NULL
+      AND listing_changes_mview.nomenclature_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          NULL,
+          CASE
+            WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+            ELSE ''
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+            WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+            WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+            ELSE strip_tags(listing_changes_mview.short_note_fr)
+          END
+          || CASE
+            WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+          END
+        )::api_annotation
+      )
+  END AS annotation_fr,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_en)
+        )::api_annotation
+      )
+  END AS hash_annotation_en,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_es)
+        )::api_annotation
+      )
+  END AS hash_annotation_es,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_fr)
+        )::api_annotation
+      )
+  END AS hash_annotation_fr,
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM eu_listing_changes_mview listing_changes_mview
+JOIN events ON events.id = listing_changes_mview.event_id
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_eu_listing_changes_view/20141230193844.sql
+++ b/db/views/api_eu_listing_changes_view/20141230193844.sql
@@ -1,0 +1,193 @@
+SELECT
+  listing_changes_mview.id,
+  event_id,
+  ROW_TO_JSON(
+    ROW(
+      events.description,
+      events.effective_at,
+      events.url
+    )::api_event
+  ) AS eu_regulation,
+  taxon_concept_id,
+  original_taxon_concept_id,
+  listing_changes_mview.is_current,
+  listing_changes_mview.effective_at::DATE,
+  listing_changes_mview.species_listing_name,
+  listing_changes_mview.change_type_name,
+  CASE
+    WHEN listing_changes_mview.change_type_name = 'ADDITION' THEN '+'
+    WHEN listing_changes_mview.change_type_name = 'DELETION' THEN '-'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION' THEN 'R+'
+    WHEN listing_changes_mview.change_type_name = 'RESERVATION_WITHDRAWAL' THEN 'R-'
+    ELSE ''
+  END AS change_type,
+  listing_changes_mview.inclusion_taxon_concept_id,
+  listing_changes_mview.party_id,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_en,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_en,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_es,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_es,
+  CASE
+    WHEN listing_changes_mview.party_id IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          party_iso_code,
+          party_full_name_fr,
+          geo_entity_type
+        )::api_geo_entity
+      )
+  END AS party_fr,
+  CASE
+    WHEN listing_changes_mview.auto_note_en IS NULL
+      AND listing_changes_mview.inherited_full_note_en IS NULL
+      AND listing_changes_mview.inherited_short_note_en IS NULL
+      AND listing_changes_mview.full_note_en IS NULL
+      AND listing_changes_mview.short_note_en IS NULL
+      AND listing_changes_mview.nomenclature_note_en IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_en) > 0 THEN '[' || listing_changes_mview.auto_note_en || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_en)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_en) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_en)
+        WHEN LENGTH(listing_changes_mview.full_note_en) > 0 THEN strip_tags(listing_changes_mview.full_note_en)
+        WHEN LENGTH(listing_changes_mview.short_note_en) > 0 THEN strip_tags(listing_changes_mview.short_note_en)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+        ELSE ''
+      END
+  END AS annotation_en,
+  CASE
+    WHEN listing_changes_mview.auto_note_es IS NULL
+      AND listing_changes_mview.inherited_full_note_es IS NULL
+      AND listing_changes_mview.inherited_short_note_es IS NULL
+      AND listing_changes_mview.full_note_es IS NULL
+      AND listing_changes_mview.short_note_es IS NULL
+      AND listing_changes_mview.nomenclature_note_es IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_es) > 0 THEN '[' || listing_changes_mview.auto_note_es || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_es)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_es) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_es)
+        WHEN LENGTH(listing_changes_mview.full_note_es) > 0 THEN strip_tags(listing_changes_mview.full_note_es)
+        WHEN LENGTH(listing_changes_mview.short_note_es) > 0 THEN strip_tags(listing_changes_mview.short_note_es)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_en) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_en)
+        ELSE ''
+      END
+  END AS annotation_es,
+  CASE
+    WHEN listing_changes_mview.auto_note_fr IS NULL
+      AND listing_changes_mview.inherited_full_note_fr IS NULL
+      AND listing_changes_mview.inherited_short_note_fr IS NULL
+      AND listing_changes_mview.full_note_fr IS NULL
+      AND listing_changes_mview.short_note_fr IS NULL
+      AND listing_changes_mview.nomenclature_note_fr IS NULL
+    THEN NULL
+    ELSE
+      CASE
+        WHEN LENGTH(listing_changes_mview.auto_note_fr) > 0 THEN '[' || listing_changes_mview.auto_note_fr || '] '
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.inherited_full_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_full_note_fr)
+        WHEN LENGTH(listing_changes_mview.inherited_short_note_fr) > 0 THEN strip_tags(listing_changes_mview.inherited_short_note_fr)
+        WHEN LENGTH(listing_changes_mview.full_note_fr) > 0 THEN strip_tags(listing_changes_mview.full_note_fr)
+        WHEN LENGTH(listing_changes_mview.short_note_fr) > 0 THEN strip_tags(listing_changes_mview.short_note_fr)
+        ELSE ''
+      END
+      || CASE
+        WHEN LENGTH(listing_changes_mview.nomenclature_note_fr) > 0 THEN strip_tags(listing_changes_mview.nomenclature_note_fr)
+        ELSE ''
+      END
+  END AS annotation_fr,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_en IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_en)
+        )::api_annotation
+      )
+  END AS hash_annotation_en,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_es IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_parent_symbol || ' ' || listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_es)
+        )::api_annotation
+      )
+  END AS hash_annotation_es,
+  CASE
+    WHEN listing_changes_mview.hash_ann_symbol IS NULL
+      AND listing_changes_mview.hash_full_note_fr IS NULL
+    THEN NULL::JSON
+    ELSE
+      ROW_TO_JSON(
+        ROW(
+          listing_changes_mview.hash_ann_symbol,
+          strip_tags(listing_changes_mview.hash_full_note_fr)
+        )::api_annotation
+      )
+  END AS hash_annotation_fr,
+  listing_changes_mview.show_in_history,
+  listing_changes_mview.full_note_en,
+  listing_changes_mview.short_note_en,
+  listing_changes_mview.auto_note_en,
+  listing_changes_mview.hash_full_note_en,
+  listing_changes_mview.hash_ann_parent_symbol,
+  listing_changes_mview.hash_ann_symbol,
+  listing_changes_mview.inherited_full_note_en,
+  listing_changes_mview.inherited_short_note_en,
+  listing_changes_mview.nomenclature_note_en,
+  listing_changes_mview.nomenclature_note_fr,
+  listing_changes_mview.nomenclature_note_es,
+  CASE
+    WHEN change_type_name = 'ADDITION' THEN 0
+    WHEN change_type_name = 'RESERVATION' THEN 1
+    WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
+    WHEN change_type_name = 'DELETION' THEN 3
+  END AS change_type_order
+FROM eu_listing_changes_mview listing_changes_mview
+JOIN events ON events.id = listing_changes_mview.event_id
+WHERE "listing_changes_mview"."show_in_history";

--- a/db/views/api_taxon_concepts_view/20141223160054.sql
+++ b/db/views/api_taxon_concepts_view/20141223160054.sql
@@ -1,0 +1,79 @@
+SELECT
+  tc.id,
+  tc.parent_id,
+  taxonomies.name,
+  CASE WHEN taxonomies.name = 'CITES_EU' THEN TRUE ELSE FALSE END AS taxonomy_is_cites_eu,
+  tc.full_name,
+  tc.author_year,
+  'A' AS name_status,
+  ranks.name AS rank,
+  tc.taxonomic_position,
+  ROW_TO_JSON(
+    ROW(
+      tc.data->'kingdom_name',
+      tc.data->'phylum_name',
+      tc.data->'class_name',
+      tc.data->'order_name',
+      tc.data->'family_name'
+    )::higher_taxa
+  ) AS higher_taxa,
+  ARRAY_TO_JSON(
+    ARRAY_AGG_NOTNULL(
+      ROW(
+        synonyms.id, synonyms.full_name, synonyms.author_year
+      )::simple_taxon_concept
+    )
+  ) AS synonyms,
+  NULL AS accepted_names,
+  tc.created_at,
+  tc.updated_at
+FROM taxon_concepts tc
+JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
+JOIN ranks ON ranks.id = tc.rank_id
+LEFT JOIN taxon_relationships tr
+  ON tr.taxon_concept_id = tc.id
+LEFT JOIN taxon_relationship_types trt
+  ON trt.id = tr.taxon_relationship_type_id AND trt.name = 'HAS_SYNONYM'
+LEFT JOIN taxon_concepts synonyms
+  ON synonyms.id = tr.other_taxon_concept_id
+WHERE tc.name_status = 'A'
+GROUP BY tc.id, tc.parent_id, taxonomies.name, tc.full_name, tc.author_year, ranks.name,
+tc.taxonomic_position,
+tc.created_at, tc.updated_at
+
+UNION ALL
+
+SELECT
+  tc.id,
+  NULL AS parent_id,
+  taxonomies.name,
+  CASE WHEN taxonomies.name = 'CITES' THEN TRUE ELSE FALSE END AS taxonomy_is_cites_eu,
+  tc.full_name,
+  tc.author_year,
+  'S' AS name_status,
+  ranks.name AS rank,
+  NULL AS taxonomic_position,
+  NULL::JSON AS higher_taxa,
+  NULL AS synonyms,
+  ARRAY_TO_JSON(
+    ARRAY_AGG_NOTNULL(
+      ROW(
+        accepted_names.id, accepted_names.full_name, accepted_names.author_year
+      )::simple_taxon_concept
+    )
+  ) AS accepted_names,
+  tc.created_at,
+  tc.updated_at
+FROM taxon_concepts tc
+JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
+JOIN ranks ON ranks.id = tc.rank_id
+JOIN taxon_relationships tr
+  ON tr.other_taxon_concept_id = tc.id
+JOIN taxon_relationship_types trt
+  ON trt.id = tr.taxon_relationship_type_id AND trt.name = 'HAS_SYNONYM'
+JOIN taxon_concepts accepted_names
+  ON accepted_names.id = tr.taxon_concept_id
+WHERE tc.name_status = 'S'
+GROUP BY tc.id, tc.parent_id, taxonomies.name, tc.full_name, tc.author_year, ranks.name,
+tc.taxonomic_position,
+tc.created_at, tc.updated_at;

--- a/db/views/api_taxon_concepts_view/20141223160054.sql
+++ b/db/views/api_taxon_concepts_view/20141223160054.sql
@@ -15,13 +15,13 @@ SELECT
       tc.data->'class_name',
       tc.data->'order_name',
       tc.data->'family_name'
-    )::higher_taxa
+    )::api_higher_taxa
   ) AS higher_taxa,
   ARRAY_TO_JSON(
     ARRAY_AGG_NOTNULL(
       ROW(
-        synonyms.id, synonyms.full_name, synonyms.author_year
-      )::simple_taxon_concept
+        synonyms.id, synonyms.full_name, synonyms.author_year, synonyms.data->'rank_name'
+      )::api_taxon_concept
     )
   ) AS synonyms,
   NULL AS accepted_names,
@@ -58,8 +58,8 @@ SELECT
   ARRAY_TO_JSON(
     ARRAY_AGG_NOTNULL(
       ROW(
-        accepted_names.id, accepted_names.full_name, accepted_names.author_year
-      )::simple_taxon_concept
+        accepted_names.id, accepted_names.full_name, accepted_names.author_year, accepted_names.data->'rank_name'
+      )::api_taxon_concept
     )
   ) AS accepted_names,
   tc.created_at,

--- a/db/views/eu_decisions_view/20150107171940.sql
+++ b/db/views/eu_decisions_view/20150107171940.sql
@@ -1,0 +1,81 @@
+SELECT
+  taxon_concept_id,
+  taxon_concepts.taxonomic_position,
+  (taxon_concepts.data->'kingdom_id')::INT AS kingdom_id,
+  (taxon_concepts.data->'phylum_id')::INT AS phylum_id,
+  (taxon_concepts.data->'class_id')::INT AS class_id,
+  (taxon_concepts.data->'order_id')::INT AS order_id,
+  (taxon_concepts.data->'family_id')::INT AS family_id,
+  taxon_concepts.data->'kingdom_name' AS kingdom_name,
+  taxon_concepts.data->'phylum_name' AS phylum_name,
+  taxon_concepts.data->'class_name' AS class_name,
+  taxon_concepts.data->'order_name' AS order_name,
+  taxon_concepts.data->'family_name' AS family_name,
+  taxon_concepts.data->'genus_name' AS genus_name,
+  LOWER(taxon_concepts.data->'species_name') AS species_name,
+  LOWER(taxon_concepts.data->'subspecies_name') AS subspecies_name,
+  taxon_concepts.full_name AS full_name,
+  taxon_concepts.data->'rank_name' AS rank_name,
+  eu_decisions.start_date,
+  TO_CHAR(eu_decisions.start_date, 'DD/MM/YYYY') AS start_date_formatted,
+  geo_entity_id,
+  geo_entities.name_en AS party,
+  CASE
+    WHEN eu_decision_types.name ~* '^i+\)'
+    THEN '(No opinion) ' || eu_decision_types.name
+    ELSE eu_decision_types.name
+  END AS decision_type_for_display,
+  eu_decision_types.decision_type AS decision_type,
+  sources.name_en AS source_name,
+  sources.code || ' - ' || sources.name_en AS source_code_and_name,
+  terms.name_en AS term_name,
+  eu_decisions.notes,
+  start_event.name AS start_event_name,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN TRUE
+    ELSE FALSE
+  END AS is_valid,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN 'Valid'
+    ELSE 'Not Valid'
+  END AS is_valid_for_display,
+  CASE
+    WHEN eu_decisions.type = 'EuOpinion'
+      THEN eu_decisions.start_date
+    WHEN eu_decisions.type = 'EuSuspension'
+      THEN start_event.effective_at
+  END AS ordering_date,
+  CASE
+    WHEN LENGTH(eu_decisions.notes) > 0 THEN strip_tags(eu_decisions.notes)
+    ELSE ''
+  END
+  || CASE
+    WHEN LENGTH(eu_decisions.nomenclature_note_en) > 0 THEN E'\n' || strip_tags(eu_decisions.nomenclature_note_en)
+    ELSE ''
+  END AS full_note_en
+FROM eu_decisions
+JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+LEFT JOIN trade_codes sources ON sources.type = 'Source' AND sources.id = eu_decisions.source_id
+LEFT JOIN trade_codes terms ON terms.type = 'Term' AND terms.id = eu_decisions.term_id;


### PR DESCRIPTION
Adds SQL views for CITES and EU legislation, which are going to be used to return information both to Species+ and the API. Requires careful checking whether the Species+ content is not altered as a result.