### PR TITLE
added original start date for current  EU suspensions 

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -9,13 +9,17 @@
         <th class="col2">COUNTRY</th>
         <th class="col2">EU DECISIONS</th>
         <th class="col3">NOTES</th>
-        <th class="col3">DOCUMENT</th>       
+        <th class="col3">DOCUMENT</th>
       </tr>
     </thead>
     <tbody {{bindAttr class="controller.euDecisionsExpanded:historic_expanded"}}>
       {{#each decision in currentEuDecisions}}
         <tr class="current">
-          <td>{{decision.start_date}}</td>
+          <td>{{decision.start_date}}
+            {{#if decision.original_start_date}}
+              <br>(valid since {{decision.original_start_date}})
+            {{/if}}
+          </td>
           <td>{{decision.geo_entity.name}}</td>
           <td>
               {{#if decision.eu_decision_type.description}}

--- a/app/models/species/eu_decisions_export.rb
+++ b/app/models/species/eu_decisions_export.rb
@@ -68,7 +68,7 @@ private
     headers = [
       'Kingdom', 'Phylum', 'Class', 'Order', 'Family',
       'Genus', 'Species', 'Subspecies',
-      'Full Name', 'Rank', 'Date of Decision',  'Party',
+      'Full Name', 'Rank', 'Date of Decision',  'Valid since', 'Party',
       'EU Decision', 'Source',  'Term',
       'Notes', 'Document',  "Valid on Date: #{DateTime.now.strftime('%d/%m/%Y')}"
     ]
@@ -78,7 +78,7 @@ private
     columns = [
       :kingdom_name, :phylum_name, :class_name, :order_name, :family_name,
       :genus_name, :species_name, :subspecies_name,
-      :full_name, :rank_name, :start_date_formatted, :party,
+      :full_name, :rank_name, :start_date_formatted, :original_start_date_formatted, :party,
       :decision_type_for_display, :source_code_and_name, :term_name,
       :full_note_en, :start_event_name, :is_valid_for_display
     ]

--- a/app/serializers/species/eu_decision_serializer.rb
+++ b/app/serializers/species/eu_decision_serializer.rb
@@ -6,7 +6,8 @@ class Species::EuDecisionSerializer < ActiveModel::Serializer
     :geo_entity,
     :start_event,
     :source,
-    :term
+    :term,
+    {:original_start_date_formatted => :original_start_date}
 
   def eu_decision_type
     object['eu_decision_type'] && JSON.parse(object['eu_decision_type'])

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -100,6 +100,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
       select(<<-SQL
               eu_decisions.notes,
               eu_decisions.start_date,
+              v.original_start_date_formatted,
               eu_decisions.is_current,
               eu_decisions.geo_entity_id,
               eu_decisions.start_event_id,
@@ -126,14 +127,10 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               END AS subspecies_info
              SQL
       ).
+      joins('LEFT JOIN eu_suspensions_applicability_view v ON eu_decisions.id = v.id').
       order(<<-SQL
             geo_entity_en->>'name' ASC,
-            CASE
-              WHEN eu_decisions.type = 'EuOpinion'
-                THEN eu_decisions.start_date
-              WHEN eu_decisions.type = 'EuSuspension'
-                THEN (start_event->>'date')::DATE
-            END DESC,
+            start_date DESC,
             subspecies_info DESC
         SQL
       ).all

--- a/db/migrate/20150121232443_add_id_to_api_eu_decisions_view.rb
+++ b/db/migrate/20150121232443_add_id_to_api_eu_decisions_view.rb
@@ -1,0 +1,11 @@
+class AddIdToApiEuDecisionsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20150121232443', 'api_eu_decisions_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20141230193844', 'api_eu_decisions_view')}"
+  end
+end

--- a/db/migrate/20150121234014_create_eu_suspensions_applicability_view.rb
+++ b/db/migrate/20150121234014_create_eu_suspensions_applicability_view.rb
@@ -1,0 +1,10 @@
+class CreateEuSuspensionsApplicabilityView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS eu_suspensions_applicability_view"
+    execute "CREATE VIEW eu_suspensions_applicability_view AS #{view_sql('20150121234014', 'eu_suspensions_applicability_view')}"
+  end
+
+  def down
+    execute "DROP VIEW eu_suspensions_applicability_view"
+  end
+end

--- a/db/migrate/20150122132408_add_original_start_date_to_eu_decisions_view.rb
+++ b/db/migrate/20150122132408_add_original_start_date_to_eu_decisions_view.rb
@@ -1,0 +1,11 @@
+class AddOriginalStartDateToEuDecisionsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS eu_decisions_view"
+    execute "CREATE VIEW eu_decisions_view AS #{view_sql('20150122132408', 'eu_decisions_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS eu_decisions_view"
+    execute "CREATE VIEW eu_decisions_view AS #{view_sql('20150107171940', 'eu_decisions_view')}"
+  end
+end

--- a/db/views/api_eu_decisions_view/20150121232443.sql
+++ b/db/views/api_eu_decisions_view/20150121232443.sql
@@ -1,0 +1,128 @@
+SELECT
+eu_decisions.id,
+eu_decisions.type,
+eu_decisions.taxon_concept_id,
+ROW_TO_JSON(
+ ROW(
+   taxon_concept_id,
+   taxon_concepts.full_name,
+   taxon_concepts.author_year,
+   taxon_concepts.data->'rank_name'
+ )::api_taxon_concept
+) AS taxon_concept,
+eu_decisions.notes,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.start_date::DATE
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN start_event.effective_at::DATE
+END AS start_date,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.is_current
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN
+    CASE
+      WHEN start_event.effective_at <= current_date AND start_event.is_current = true
+        AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+      THEN TRUE
+      ELSE
+        FALSE
+    END
+END AS is_current,
+eu_decisions.geo_entity_id,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_en,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_en,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_es,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_es,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_fr,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_fr,
+eu_decisions.start_event_id,
+ROW_TO_JSON(
+  ROW(
+    start_event.name,
+    start_event.effective_at::DATE,
+    start_event.url
+  )::api_event
+) AS start_event,
+eu_decisions.end_event_id,
+ROW_TO_JSON(
+  ROW(
+    end_event.name,
+    end_event.effective_at::DATE,
+    end_event.url
+  )::api_event
+) AS end_event,
+eu_decisions.term_id,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_en
+  )::api_trade_code
+) AS term_en,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_es
+  )::api_trade_code
+) AS term_es,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_fr
+  )::api_trade_code
+) AS term_fr,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_en
+  )::api_trade_code
+) AS source_en,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_es
+  )::api_trade_code
+) AS source_es,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_fr
+  )::api_trade_code
+) AS source_fr,
+eu_decisions.source_id,
+eu_decisions.eu_decision_type_id,
+ROW_TO_JSON(
+  ROW(
+    eu_decision_types.name,
+    eu_decision_types.tooltip,
+    eu_decision_types.decision_type
+  )::api_eu_decision_type
+) AS eu_decision_type,
+eu_decisions.nomenclature_note_en,
+eu_decisions.nomenclature_note_fr,
+eu_decisions.nomenclature_note_es
+FROM eu_decisions
+JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN trade_codes terms ON terms.id = eu_decisions.term_id AND terms.type = 'Term'
+LEFT JOIN trade_codes sources ON sources.id = eu_decisions.source_id AND sources.type = 'Source'
+LEFT JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id;

--- a/db/views/eu_decisions_view/20150122132408.sql
+++ b/db/views/eu_decisions_view/20150122132408.sql
@@ -1,0 +1,84 @@
+SELECT
+  taxon_concept_id,
+  taxon_concepts.taxonomic_position,
+  (taxon_concepts.data->'kingdom_id')::INT AS kingdom_id,
+  (taxon_concepts.data->'phylum_id')::INT AS phylum_id,
+  (taxon_concepts.data->'class_id')::INT AS class_id,
+  (taxon_concepts.data->'order_id')::INT AS order_id,
+  (taxon_concepts.data->'family_id')::INT AS family_id,
+  taxon_concepts.data->'kingdom_name' AS kingdom_name,
+  taxon_concepts.data->'phylum_name' AS phylum_name,
+  taxon_concepts.data->'class_name' AS class_name,
+  taxon_concepts.data->'order_name' AS order_name,
+  taxon_concepts.data->'family_name' AS family_name,
+  taxon_concepts.data->'genus_name' AS genus_name,
+  LOWER(taxon_concepts.data->'species_name') AS species_name,
+  LOWER(taxon_concepts.data->'subspecies_name') AS subspecies_name,
+  taxon_concepts.full_name AS full_name,
+  taxon_concepts.data->'rank_name' AS rank_name,
+  eu_decisions.start_date,
+  TO_CHAR(eu_decisions.start_date, 'DD/MM/YYYY') AS start_date_formatted,
+  t.original_start_date,
+  TO_CHAR(t.original_start_date, 'DD/MM/YYYY') AS original_start_date_formatted,
+  geo_entity_id,
+  geo_entities.name_en AS party,
+  CASE
+    WHEN eu_decision_types.name ~* '^i+\)'
+    THEN '(No opinion) ' || eu_decision_types.name
+    ELSE eu_decision_types.name
+  END AS decision_type_for_display,
+  eu_decision_types.decision_type AS decision_type,
+  sources.name_en AS source_name,
+  sources.code || ' - ' || sources.name_en AS source_code_and_name,
+  terms.name_en AS term_name,
+  eu_decisions.notes,
+  start_event.name AS start_event_name,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN TRUE
+    ELSE FALSE
+  END AS is_valid,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN 'Valid'
+    ELSE 'Not Valid'
+  END AS is_valid_for_display,
+  CASE
+    WHEN eu_decisions.type = 'EuOpinion'
+      THEN eu_decisions.start_date
+    WHEN eu_decisions.type = 'EuSuspension'
+      THEN start_event.effective_at
+  END AS ordering_date,
+  CASE
+    WHEN LENGTH(eu_decisions.notes) > 0 THEN strip_tags(eu_decisions.notes)
+    ELSE ''
+  END
+  || CASE
+    WHEN LENGTH(eu_decisions.nomenclature_note_en) > 0 THEN E'\n' || strip_tags(eu_decisions.nomenclature_note_en)
+    ELSE ''
+  END AS full_note_en
+FROM eu_decisions
+JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+LEFT JOIN trade_codes sources ON sources.type = 'Source' AND sources.id = eu_decisions.source_id
+LEFT JOIN trade_codes terms ON terms.type = 'Term' AND terms.id = eu_decisions.term_id
+LEFT JOIN eu_suspensions_applicability_view t ON t.id = eu_decisions.id;

--- a/db/views/eu_suspensions_applicability_view/20150121234014.sql
+++ b/db/views/eu_suspensions_applicability_view/20150121234014.sql
@@ -1,0 +1,82 @@
+WITH RECURSIVE eu_decisions_by_date AS (
+  SELECT
+  eu_decisions.id,
+  taxon_concept_id,
+  geo_entity_id,
+  term_id,
+  source_id,
+  start_date,
+  start_event.effective_at AS start_event_date,
+  eu_decisions.end_date,
+  end_event.effective_at AS end_event_date,
+  ROW_NUMBER() OVER (PARTITION BY taxon_concept_id, geo_entity_id, term_id, source_id ORDER BY start_date)
+  FROM eu_decisions
+  LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+  LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+  WHERE eu_decisions.type = 'EuSuspension'
+), eu_decisions_with_end_dates AS (
+  SELECT
+  eu_decisions.id,
+  eu_decisions.taxon_concept_id,
+  eu_decisions.geo_entity_id,
+  eu_decisions.term_id,
+  eu_decisions.source_id,
+  eu_decisions.start_event_date AS start_event_date,
+  CASE
+    -- if the eu decision has a terminating event, use that date
+    WHEN eu_decisions.end_event_date IS NOT NULL
+    THEN eu_decisions.end_event_date
+    -- if there is no terminating event and also no subsequent suspension, this is probably valid
+    WHEN newer_eu_decisions.start_event_date IS NULL
+    THEN NULL
+    -- if there is a subsequent suspension in the following year, it is likely the terminating event
+    WHEN EXTRACT('year' FROM newer_eu_decisions.start_event_date) = (EXTRACT('year' FROM eu_decisions.start_event_date) + 1)
+    THEN newer_eu_decisions.start_event_date
+    -- in 2002 there was no suspension regulation published, leading to this excellent edge case
+    WHEN EXTRACT('year' FROM eu_decisions.start_event_date) = 2001 AND (
+      EXTRACT('year' FROM newer_eu_decisions.start_event_date) = 2001
+      OR EXTRACT('year' FROM newer_eu_decisions.start_event_date) = 2003
+    )
+    THEN newer_eu_decisions.start_event_date
+    -- if there is a subsequent suspension but later than in following year, assume this one terminated by the end of year
+    ELSE (EXTRACT('year' FROM eu_decisions.start_event_date) || '-12-31')::TIMESTAMP
+  END AS end_event_date
+  FROM eu_decisions_by_date eu_decisions
+  LEFT JOIN eu_decisions_by_date newer_eu_decisions
+  ON eu_decisions.taxon_concept_id = newer_eu_decisions.taxon_concept_id
+  AND eu_decisions.geo_entity_id = newer_eu_decisions.geo_entity_id
+  AND (eu_decisions.term_id = newer_eu_decisions.term_id OR eu_decisions.term_id IS NULL AND newer_eu_decisions.term_id IS NULL)
+  AND (eu_decisions.source_id = newer_eu_decisions.source_id OR eu_decisions.source_id IS NULL AND newer_eu_decisions.source_id IS NULL)
+  AND eu_decisions.row_number = (newer_eu_decisions.row_number - 1)
+), eu_decisions_chain AS (
+  SELECT eu_decisions_with_end_dates.*, eu_decisions_with_end_dates.start_event_date AS new_start_event_date
+  FROM eu_decisions_with_end_dates
+  WHERE end_event_date IS NULL
+
+  UNION
+
+  SELECT eu_decisions_chain.id,
+  eu_decisions_chain.taxon_concept_id,
+  eu_decisions_chain.geo_entity_id,
+  eu_decisions_chain.term_id,
+  eu_decisions_chain.source_id,
+  eu_decisions_chain.start_event_date, eu_decisions_chain.end_event_date, eu_decisions_with_end_dates.start_event_date
+  FROM eu_decisions_chain
+  JOIN eu_decisions_with_end_dates
+  ON eu_decisions_chain.taxon_concept_id = eu_decisions_with_end_dates.taxon_concept_id
+  AND eu_decisions_chain.geo_entity_id = eu_decisions_with_end_dates.geo_entity_id
+  AND (
+    eu_decisions_chain.term_id = eu_decisions_with_end_dates.term_id
+    OR eu_decisions_chain.term_id IS NULL AND eu_decisions_with_end_dates.term_id IS NULL
+  )
+  AND (
+    eu_decisions_chain.source_id = eu_decisions_with_end_dates.source_id
+    OR eu_decisions_chain.source_id IS NULL AND eu_decisions_with_end_dates.source_id IS NULL
+  )
+  AND eu_decisions_chain.new_start_event_date = eu_decisions_with_end_dates.end_event_date
+)
+SELECT
+id,
+MIN(new_start_event_date) AS original_start_date,
+TO_CHAR(MIN(new_start_event_date), 'DD/MM/YYYY') AS original_start_date_formatted
+FROM eu_decisions_chain GROUP BY id;


### PR DESCRIPTION
Current EU Suspensions are now displayed with and additional 'valid since' date in Species+ taxon concept pages and in the EU decisions CSV download. The rule for the 'valid since' date is as follows: the earliest suspension for the same taxon, country, term and source combination, which is followed by the same type of suspension in the following year (applies to all years except 2001, because there was no suspension regulation in 2002)

Examples of expected results:
Morelia boeleni Indonesia since 2000
Psittacus erithacus Equatorial Guinea since 2009
Balearica regulorum Tanzania since 2014
Hippopotamus amphibius Togo since 2004


Requires rake db:migrate