### PR TITLE
added ability to bulk update shipments with blank value for non-required fields

### DIFF
--- a/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
@@ -161,13 +161,17 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
       )
 
     updateBatch: ->
+      updates = @get('batchUpdateParams').export()
+      if Object.keys(updates).length == 0
+        alert("No changes detected.")
+        return false
       if confirm("This will update " + @get('total') + " shipments. Are you sure?")
         $.ajax(
           url: '/trade/shipments/update_batch'
           type: 'POST'
           data:
             filters: @get('controllers.search.searchParams')
-            updates: @get('batchUpdateParams').export()
+            updates: updates
         )
         .done( (data) =>
           @flashSuccess(message: 'Successfully updated ' + data.rows + ' shipments.')

--- a/app/assets/javascripts/trade/models/shipment_batch_update.js.coffee
+++ b/app/assets/javascripts/trade/models/shipment_batch_update.js.coffee
@@ -11,12 +11,37 @@ Trade.ShipmentBatchUpdate = Ember.Object.extend
   exporter: null
   countryOfOrigin: null
   reporterType: null
+  importPermitNumber: null
+  exportPermitNumber: null
+  originPermitNumber: null
+  countryOfOriginBlank: false
+  unitBlank: false
+  sourceBlank: false
+  purposeBlank: false
+  importPermitNumberBlank: false
+  exportPermitNumberBlank: false
+  originPermitNumberBlank: false
 
   columns: (->
     [
       'taxonConceptId', 'reportedTaxonConceptId', 'appendix', 'year',
       'term', 'unit', 'purpose', 'source',
-      'importer', 'exporter', 'countryOfOrigin', 'reporterType'
+      'importer', 'exporter', 'countryOfOrigin', 'reporterType',
+      'importPermitNumber', 'exportPermitNumber', 'originPermitNumber'
+    ]
+  ).property()
+
+  nullableColumns: (->
+    [
+      'countryOfOrigin', 'unit', 'source', 'purpose',
+      'importPermitNumber', 'exportPermitNumber', 'originPermitNumber'
+    ]
+  ).property()
+
+  columnsToExportAsIds: (->
+    [
+      'term', 'unit', 'purpose', 'source',
+      'importer', 'exporter', 'countryOfOrigin'
     ]
   ).property()
 
@@ -28,13 +53,18 @@ Trade.ShipmentBatchUpdate = Ember.Object.extend
   export: ->
     result = {}
     @get('columns').forEach( (c) =>
-      property_value = @get(c)
-      if property_value
-        property_name = c.decamelize()
-        if typeof property_value == 'object'
-          result[property_name + '_id'] = property_value.get('id')
-        else
-          result[property_name] = property_value
+      propertyValue = @get(c)
+      propertyNameForBackend = c.decamelize()
+      if @get('columnsToExportAsIds').contains(c)
+        propertyNameForBackend += '_id'
+      if propertyValue
+        if @get('columnsToExportAsIds').contains(c)
+          propertyValue = propertyValue.get('id')
+        result[propertyNameForBackend] = propertyValue
+      if @get('nullableColumns').contains(c)
+        blankPropertyName = c + 'Blank'
+        if @get(blankPropertyName)
+          result[propertyNameForBackend] = null
     )
     result
 

--- a/app/assets/javascripts/trade/templates/search/batch_form.handlebars
+++ b/app/assets/javascripts/trade/templates/search/batch_form.handlebars
@@ -81,6 +81,10 @@
             optionLabelPath="content.code"
             selectionBinding="currentShipment.unit"
           }}
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.unitBlank"}}
+            blank
+          </label>
         </div>
         <div class="attribute-area left">
           <p>Purpose Code</p>
@@ -91,6 +95,10 @@
               optionLabelPath="content.code"
               selectionBinding="currentShipment.purpose"
             }}
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.purposeBlank"}}
+            blank
+          </label>
         </div>
         <div class="attribute-area left">
           <p>Source Code</p>
@@ -101,6 +109,10 @@
               optionLabelPath="content.code"
               selectionBinding="currentShipment.source"
             }}
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.sourceBlank"}}
+            blank
+          </label>
         </div>
       </div>
 
@@ -137,6 +149,10 @@
               optionLabelPath="content.name"
               selectionBinding="currentShipment.countryOfOrigin"
             }}
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.countryOfOriginBlank"}}
+            blank
+          </label>
         </div>
         <div class="attribute-area left">
           <p>Reporter type</p>
@@ -147,6 +163,34 @@
             }}
         </div>
       </div>
+
+      <div class="heading">
+        Permit numbers
+      </div>
+      <div class="inner">
+        <div class="attribute-area left">
+          <p>Import Permit</p>
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.importPermitNumberBlank"}}
+            blank
+          </label>
+        </div>
+        <div class="attribute-area left">
+          <p>Exporter Permit</p>
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.exportPermitNumberBlank"}}
+            blank
+          </label>
+        </div>
+        <div class="attribute-area left">
+          <p>Origin Permit</p>
+          <label class="blank-checkbox">
+            {{view Ember.Checkbox checkedBinding="currentShipment.originPermitNumberBlank"}}
+            blank
+          </label>
+        </div>
+      </div>
+
 
     </fieldset>
   </form>

--- a/app/assets/stylesheets/trade/shipments.scss
+++ b/app/assets/stylesheets/trade/shipments.scss
@@ -289,6 +289,10 @@ div.popup-holder01 {
       input {
         width: 175px;
       }
+      input[type="checkbox"] {
+        width: 50px;
+        margin: 0;
+      }
       select {
         width: 190px;
         margin: 0;

--- a/app/controllers/trade/shipments_controller.rb
+++ b/app/controllers/trade/shipments_controller.rb
@@ -71,25 +71,26 @@ private
       :country_of_origin_id,
       :purpose_id,
       :source_id,
-      :year
+      :year,
+      :import_permit_number,
+      :export_permit_number,
+      :origin_permit_number
     ]
   end
 
   def shipment_params
     params.require(:shipment).permit(
       *(shipment_attributes + [
-        :import_permit_number,
-        :export_permit_number,
-        :origin_permit_number,
         :ignore_warnings
       ])
     )
   end
 
   def batch_update_params
-    res = params.permit(
+    update_params = params.permit(
       :updates => shipment_attributes
-    ).delete(:updates)
+    )
+    res = update_params && update_params.delete('updates') || {}
     reporter_type = res.delete(:reporter_type)
     unless reporter_type.blank?
       res[:reported_by_exporter] = Trade::Shipment.reporter_type_to_reported_by_exporter(reporter_type)

--- a/app/controllers/trade/shipments_controller.rb
+++ b/app/controllers/trade/shipments_controller.rb
@@ -91,6 +91,7 @@ private
       :updates => shipment_attributes
     )
     res = update_params && update_params.delete('updates') || {}
+    res.each { |k, v| res[k] = nil if v.blank? }
     reporter_type = res.delete(:reporter_type)
     unless reporter_type.blank?
       res[:reported_by_exporter] = Trade::Shipment.reporter_type_to_reported_by_exporter(reporter_type)

--- a/app/models/trade/batch_update.rb
+++ b/app/models/trade/batch_update.rb
@@ -13,6 +13,7 @@ class Trade::BatchUpdate
   end
 
   def execute(update_params)
+    return 0 unless update_params.keys.size > 0
     affected_shipments = nil
     Trade::Shipment.transaction do
       affected_shipments = @shipments.count


### PR DESCRIPTION
The idea is to be able to update a batch of shipments by setting a given property to empty value (for example country of origin); this was not possible to do using the batch update tool, because leaving the field empty signified "do not update this value"; therefore, a "blank" check box was added to those fields where blank option is allowed.