### PR TITLE
Release 0.9.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+### 0.9.4.1 (2015-03-16)
+**Species+ Admin**
+* tracking dependents_updated_by_id
+* copying exclusions to EU listings
+**Trade**
+* automatically expand the shipment year range
+
+### 0.9.4 (2015-03-11)
+**Species+ Admin:**
+* fixes to T -> S and T -> A nomenclature changes processing
+* fix for inherited standard reference flag
+**Species+:**
+* geo entity auto complete matches on parts of name
+* calculation of original start date for current EU suspensions
+* linking EU Opinions to SRG events
+**Trade Admin:**
+* fixes to Trade Admin interface
+* ability to bulk update some shipment fields with blank value
+* speed improvements to permit number auto complete
+
 ### 0.9.2 (2015-01-15)
 **Species+ Admin:**
 * API tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 0.9.4.1 (2015-03-16)
+### 0.9.4.1 (2015-03-19)
 **Species+ Admin**
 * tracking dependents_updated_by_id
 * copying exclusions to EU listings
+
 **Trade**
 * automatically expand the shipment year range
 

--- a/app/controllers/cites_trade/home_controller.rb
+++ b/app/controllers/cites_trade/home_controller.rb
@@ -1,6 +1,7 @@
 class CitesTrade::HomeController < CitesTradeController
 
   def index
+    @years = (1975..Trade::Shipment.maximum('year')).to_a.reverse
   end
 
   def download

--- a/app/models/checklist/csv/index.rb
+++ b/app/models/checklist/csv/index.rb
@@ -24,7 +24,7 @@ class Checklist::Csv::Index < Checklist::Index
       :introduced_uncertain_distribution, :reintroduced_distribution,
       :extinct_distribution, :extinct_uncertain_distribution,
       :uncertain_distribution
-    ]
+    ].compact
   end
 
   def listing_changes_csv_columns

--- a/app/models/cites_suspension_observer.rb
+++ b/app/models/cites_suspension_observer.rb
@@ -1,36 +1,7 @@
-class CitesSuspensionObserver < ActiveRecord::Observer
-
-  def after_save(cites_suspension)
-    if cites_suspension.taxon_concept
-      cites_suspension.taxon_concept.touch
-    elsif cites_suspension.taxon_concept_id_was != cites_suspension.taxon_concept_id
-      TaxonConcept.find(cites_suspension.taxon_concept_id_was).touch
-    else
-      touch_taxa_with_applicable_distribution(cites_suspension)
-    end
-  end
+class CitesSuspensionObserver < TradeRestrictionObserver
 
   def after_destroy(cites_suspension)
-    if cites_suspension.taxon_concept
-      cites_suspension.taxon_concept.touch
-    else
-      touch_taxa_with_applicable_distribution(cites_suspension)
-    end
     DownloadsCacheCleanupWorker.perform_async(:cites_suspensions)
-  end
-
-  def touch_taxa_with_applicable_distribution(cites_suspension)
-    update_stmt = TaxonConcept.send(:sanitize_sql_array, [
-      "UPDATE taxon_concepts
-      SET updated_at = NOW()
-      FROM distributions
-      WHERE distributions.taxon_concept_id = taxon_concepts.id
-      AND distributions.geo_entity_id IN (:geo_entity_id)",
-      :geo_entity_id => [
-        cites_suspension.geo_entity_id, cites_suspension.geo_entity_id_was
-      ].compact.uniq
-    ])
-    TaxonConcept.connection.execute update_stmt
   end
 
 end

--- a/app/models/quota_observer.rb
+++ b/app/models/quota_observer.rb
@@ -1,4 +1,4 @@
-class QuotaObserver < ActiveRecord::Observer
+class QuotaObserver < TradeRestrictionObserver
 
   def after_destroy(quota)
     DownloadsCacheCleanupWorker.perform_async(:quotas)

--- a/app/models/species/orphaned_taxon_concepts_export.rb
+++ b/app/models/species/orphaned_taxon_concepts_export.rb
@@ -21,7 +21,8 @@ private
     columns = [
       :id, :legacy_id, :full_name, :author_year, :rank_name, :name_status,
       :taxonomy_name, :internal_notes,
-      :created_at, :created_by, :updated_at, :dependents_updated_at, :updated_by
+      :created_at, :created_by, :updated_at, :updated_by,
+      :dependents_updated_at, :dependents_updated_by
     ]
   end
 
@@ -29,8 +30,8 @@ private
     headers = [
       'Id', 'Legacy id', 'Scientific Name', 'Author', 'Rank', 'Name status',
       'Taxonomy', 'Internal notes',
-      'Date added', 'Added by', 'Taxon Concept updated date',
-      'Taxon Concept associations updated date', 'Updated by'
+      'Date added', 'Added by', 'Taxon Concept updated date', 'Updated by',
+      'Associations updated date', 'Associations updated by'
     ]
   end
 

--- a/app/models/species/synonyms_and_trade_names_export.rb
+++ b/app/models/species/synonyms_and_trade_names_export.rb
@@ -26,7 +26,8 @@ private
       :accepted_kingdom_name, :accepted_phylum_name, :accepted_class_name,
       :accepted_order_name, :accepted_family_name, :accepted_genus_name,
       :taxonomy_name, :internal_notes,
-      :created_at, :created_by, :updated_at, :dependents_updated_at, :updated_by
+      :created_at, :created_by, :updated_at, :updated_by,
+      :dependents_updated_at, :dependents_updated_by
     ]
   end
 
@@ -39,8 +40,8 @@ private
       'Kingdom_Accepted', 'Phylum_Accepted', 'Class_Accepted',
       'Order_Accepted', 'Family_Accepted', 'Genus_Accepted',
       'Taxonomy', 'Internal notes',
-      'Date added', 'Added by', 'Taxon Concept updated date',
-      'Taxon Concept associations updated date', 'Updated by'
+      'Date added', 'Added by', 'Taxon Concept updated date', 'Updated by',
+      'Associations updated date', 'Associations updated by'
     ]
   end
 

--- a/app/models/species/taxon_concepts_names_export.rb
+++ b/app/models/species/taxon_concepts_names_export.rb
@@ -22,7 +22,8 @@ private
       :id, :legacy_id, :kingdom_name, :phylum_name, :class_name, :order_name, :family_name,
       :genus_name, :species_name, :full_name, :author_year, :rank_name, :name_status,
       :taxonomy_name, :internal_notes,
-      :created_at, :created_by, :updated_at, :dependents_updated_at, :updated_by
+      :created_at, :created_by, :updated_at, :updated_by,
+      :dependents_updated_at, :dependents_updated_by
     ]
   end
 
@@ -31,8 +32,8 @@ private
       'Id', 'Legacy id', 'Kingdom', 'Phylum', 'Class', 'Order', 'Family',
       'Genus', 'Species', 'Scientific Name', 'Author', 'Rank', 'Name status',
       'Taxonomy', 'Internal notes',
-      'Date added', 'Added by', 'Taxon Concept updated date',
-      'Taxon Concept associations updated date', 'Updated by'
+      'Date added', 'Added by', 'Taxon Concept updated date', 'Updated by',
+      'Associations updated date', 'Associations updated by'
     ]
   end
 

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -50,6 +50,7 @@ class TaxonConcept < ActiveRecord::Base
 
   has_one :m_taxon_concept, :foreign_key => :id
 
+  belongs_to :dependents_updater, foreign_key: :dependents_updated_by_id, class_name: User
   belongs_to :parent, :class_name => 'TaxonConcept'
   has_many :children, class_name: 'TaxonConcept', foreign_key: :parent_id, conditions: {name_status: ['A', 'N']}
   belongs_to :rank

--- a/app/models/trade/shipments_gross_exports_export.rb
+++ b/app/models/trade/shipments_gross_exports_export.rb
@@ -105,15 +105,15 @@ private
     # the categories query returns values by which to pivot (years)
     categories_sql = 'SELECT * FROM UNNEST(ARRAY[?])'
     categories_sql = ActiveRecord::Base.send(:sanitize_sql_array, [categories_sql, years.map(&:to_i)])
-    year_columns = years_columns.map{ |y| "#{y} numeric"}.join(', ')
+    ct_columns = [
+      'row_name TEXT[]',
+      report_crosstab_columns.map.each_with_index{ |c, i| "#{sql_crosstab_columns[i]} #{crosstab_columns[c][:pg_type]}"},
+      years_columns.map{ |y| "#{y} numeric"}
+    ].flatten.join(', ')
     # a set returning query requires that output columns are specified
     <<-SQL
       SELECT * FROM CROSSTAB('#{source_sql}', '#{categories_sql}')
-      AS ct(
-        row_name TEXT[],
-        #{report_crosstab_columns.map.each_with_index{ |c, i| "#{sql_crosstab_columns[i]} #{crosstab_columns[c][:pg_type]}"}.join(', ')},
-        #{year_columns}
-      )
+      AS ct(#{ct_columns})
     SQL
   end
 

--- a/app/models/trade_restriction_observer.rb
+++ b/app/models/trade_restriction_observer.rb
@@ -1,0 +1,32 @@
+class TradeRestrictionObserver < ActiveRecord::Observer
+
+  def after_save(trade_restriction)
+    if trade_restriction.taxon_concept.nil?
+      touch_taxa_with_applicable_distribution(trade_restriction)
+    end
+  end
+
+  def after_destroy(trade_restriction)
+    if trade_restriction.taxon_concept.nil?
+      touch_taxa_with_applicable_distribution(trade_restriction)
+    end
+  end
+
+  private
+
+  def touch_taxa_with_applicable_distribution(trade_restriction)
+    update_stmt = TaxonConcept.send(:sanitize_sql_array, [
+      "UPDATE taxon_concepts
+      SET dependents_updated_at = NOW(), dependents_updated_by_id = :updated_by_id
+      FROM distributions
+      WHERE distributions.taxon_concept_id = taxon_concepts.id
+      AND distributions.geo_entity_id IN (:geo_entity_id)",
+      :updated_by_id => trade_restriction.updated_by_id,
+      :geo_entity_id => [
+        trade_restriction.geo_entity_id, trade_restriction.geo_entity_id_was
+      ].compact.uniq
+    ])
+    TaxonConcept.connection.execute update_stmt
+  end
+
+end

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -11,7 +11,7 @@
   <dl class="pull-right well well-small dl-horizontal">
     <dt>Created:</dt><dd><%= @taxon_concept.created_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.creator.try(:name) || "DATA_IMPORT" %>)</dd>
     <dt>Updated:</dt><dd><%= @taxon_concept.updated_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.updater.try(:name) || "DATA_IMPORT" %>)</dd>
-    <dt>Associations updated:</dt><dd><%= @taxon_concept.dependents_updated_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.dependents_updater.try(:name) || "DATA_IMPORT" %>)</dd>
+    <dt>Associations updated:</dt><dd><%= @taxon_concept.dependents_updated_at && @taxon_concept.dependents_updated_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.dependents_updater.try(:name) || "DATA_IMPORT" %>)</dd>
   </dl>
   <%= link_to edit_icon, edit_admin_taxon_concept_url(@taxon_concept), :remote => true %>
   <% if can? :destroy, @taxon_concept %>

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -8,10 +8,11 @@
       %>
     </span>
   </h1>
-  <span class="pull-right">
-    Created by <%= @taxon_concept.creator.try(:name) || "DATA_IMPORT" %> on <%= @taxon_concept.created_at.strftime("%d/%m/%Y") %> <br />
-    Last updated by <%= @taxon_concept.updater.try(:name) || "DATA_IMPORT" %> on <%= @taxon_concept.updated_at.strftime("%d/%m/%Y") %>
-  </span>
+  <dl class="pull-right well well-small dl-horizontal">
+    <dt>Created:</dt><dd><%= @taxon_concept.created_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.creator.try(:name) || "DATA_IMPORT" %>)</dd>
+    <dt>Updated:</dt><dd><%= @taxon_concept.updated_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.updater.try(:name) || "DATA_IMPORT" %>)</dd>
+    <dt>Associations updated:</dt><dd><%= @taxon_concept.dependents_updated_at.strftime("%d/%m/%Y") %> (<%= @taxon_concept.dependents_updater.try(:name) || "DATA_IMPORT" %>)</dd>
+  </dl>
   <%= link_to edit_icon, edit_admin_taxon_concept_url(@taxon_concept), :remote => true %>
   <% if can? :destroy, @taxon_concept %>
     <%= link_to delete_icon, admin_taxon_concept_url(@taxon_concept), 

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -62,89 +62,9 @@
             <img src="/assets/cites_trade/information3.gif" class="qtipify" title="<%= t('year_tip') %> " />
           </div>
           <%= t('from') %>
-          <select name="time_range_start" id="qryFrom">
-            <option selected value="2013">2013</option>
-            <option  value="2012">2012</option>
-            <option  value="2011">2011</option>
-            <option  value="2010">2010</option>
-            <option  value="2009">2009</option>
-            <option  value="2008">2008</option>
-            <option  value="2007">2007</option>
-            <option  value="2006">2006</option>
-            <option  value="2005">2005</option>
-            <option  value="2004">2004</option>
-            <option  value="2003">2003</option>
-            <option  value="2002">2002</option>
-            <option  value="2001">2001</option>
-            <option  value="2000">2000</option>
-            <option  value="1999">1999</option>
-            <option  value="1998">1998</option>
-            <option  value="1997">1997</option>
-            <option  value="1996">1996</option>
-            <option  value="1995">1995</option>
-            <option  value="1994">1994</option>
-            <option  value="1993">1993</option>
-            <option  value="1992">1992</option>
-            <option  value="1991">1991</option>
-            <option  value="1990">1990</option>
-            <option  value="1989">1989</option>
-            <option  value="1988">1988</option>
-            <option  value="1987">1987</option>
-            <option  value="1986">1986</option>
-            <option  value="1985">1985</option>
-            <option  value="1984">1984</option>
-            <option  value="1983">1983</option>
-            <option  value="1982">1982</option>
-            <option  value="1981">1981</option>
-            <option  value="1980">1980</option>
-            <option  value="1979">1979</option>
-            <option  value="1978">1978</option>
-            <option  value="1977">1977</option>
-            <option  value="1976">1976</option>
-            <option  value="1975">1975</option>
-          </select> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+          <%= select_tag 'time_range_start', options_for_select(@years, @years.first), id: "qryFrom" %> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
           <%= t('to') %>
-          <select name="time_range_end" id="qryTo">
-            <option selected value="2013">2013</option>
-            <option  value="2012">2012</option>
-            <option  value="2011">2011</option>
-            <option  value="2010">2010</option>
-            <option  value="2009">2009</option>
-            <option  value="2008">2008</option>
-            <option  value="2007">2007</option>
-            <option  value="2006">2006</option>
-            <option  value="2005">2005</option>
-            <option  value="2004">2004</option>
-            <option  value="2003">2003</option>
-            <option  value="2002">2002</option>
-            <option  value="2001">2001</option>
-            <option  value="2000">2000</option>
-            <option  value="1999">1999</option>
-            <option  value="1998">1998</option>
-            <option  value="1997">1997</option>
-            <option  value="1996">1996</option>
-            <option  value="1995">1995</option>
-            <option  value="1994">1994</option>
-            <option  value="1993">1993</option>
-            <option  value="1992">1992</option>
-            <option  value="1991">1991</option>
-            <option  value="1990">1990</option>
-            <option  value="1989">1989</option>
-            <option  value="1988">1988</option>
-            <option  value="1987">1987</option>
-            <option  value="1986">1986</option>
-            <option  value="1985">1985</option>
-            <option  value="1984">1984</option>
-            <option  value="1983">1983</option>
-            <option  value="1982">1982</option>
-            <option  value="1981">1981</option>
-            <option  value="1980">1980</option>
-            <option  value="1979">1979</option>
-            <option  value="1978">1978</option>
-            <option  value="1977">1977</option>
-            <option  value="1976">1976</option>
-            <option  value="1975">1975</option>
-          </select>
+          <%= select_tag 'time_range_end', options_for_select(@years, @years.first), id: "qryTo" %>
           <span class="information qtipify" title="<%= t('year_text') %>">&nbsp;</span>
         </div>
         <div id="tabs-exp">

--- a/app/views/layouts/cites_trade.html.erb
+++ b/app/views/layouts/cites_trade.html.erb
@@ -3,6 +3,9 @@
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta itemprop="description" content="<%= t('cites_description') %>" />
+  <meta name="description" content="<%= t('cites_description') %>" />
+  <meta itemprop="name" content="<%= t('cites_title') %>">
   <%= stylesheet_link_tag "cites_trade" %>
   <%= javascript_include_tag "cites_trade" %>
   <script>

--- a/app/workers/download_worker.rb
+++ b/app/workers/download_worker.rb
@@ -34,10 +34,10 @@ class DownloadWorker
 
       @download.save!
     rescue => msg
-      ExceptionNotifier.notify_exception(msg)
-      puts "Failed: #{msg}"
-      puts "### Backtrace ###"
-      puts msg.backtrace
+      ExceptionNotifier.notify_exception(msg) if defined? ExceptionNotifier
+      logger.warn "Failed: #{msg}"
+      logger.warn "### Backtrace ###"
+      logger.warn msg.backtrace
       @download.status = "failed"
       @download.save!
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@
 
 en:
   cites_title: "CITES Trade Database"
+  cites_description: "The CITES Trade Database, managed by the UNEP World Conservation Monitoring Centre (UNEP-WCMC) on behalf of the CITES Secretariat"
   cites_sub_title: "Please enter your search below"
   errors:
     no_data_1: "Your query has returned no data"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,6 @@
 es:
   cites_title: "Base de Datos sobre el Comercio CITES"
+  cites_description: "La Base de datos sobre el comercio CITES, administrada por el PNUMA Centro de Monitoreo de la Conservación Mundial (PNUMA-CMCM) en nombre de la Secretaría CITES."
   cites_sub_title: "Por favor introduzca sus criterios de búsqueda más abajo"
   errors:
     no_data_1: "Su consulta ha devuelto ningún dato"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,6 @@
 fr:
   cites_title: "Base de Données sur le Commerce CITES"
+  cites_description: "La base de données sur le commerce CITES, gérée par le Centre mondial de surveillance continue de la conservation de la nature du PNUE (PNUE-WCMC) au nom du Secrétariat CITES"
   cites_sub_title: "S'il vous plaît entrer votre recherche ci-dessous"
   errors:
     no_data_1: "Votre recherche n'a retourné aucune donnée"

--- a/db/migrate/20150304104013_add_dependents_updated_by_id_to_taxon_concepts.rb
+++ b/db/migrate/20150304104013_add_dependents_updated_by_id_to_taxon_concepts.rb
@@ -1,0 +1,7 @@
+class AddDependentsUpdatedByIdToTaxonConcepts < ActiveRecord::Migration
+  def change
+    add_column :taxon_concepts, :dependents_updated_by_id, :integer
+    add_foreign_key :taxon_concepts, :users, name: 'taxon_concepts_dependents_updated_by_id_fk',
+      column: 'dependents_updated_by_id'
+  end
+end

--- a/db/migrate/20150310140649_add_dependents_updated_by_id_to_internal_download_views.rb
+++ b/db/migrate/20150310140649_add_dependents_updated_by_id_to_internal_download_views.rb
@@ -1,0 +1,19 @@
+class AddDependentsUpdatedByIdToInternalDownloadViews < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS taxon_concepts_names_view"
+    execute "CREATE VIEW taxon_concepts_names_view AS #{view_sql('20150310140649', 'taxon_concepts_names_view')}"
+    execute "DROP VIEW IF EXISTS synonyms_and_trade_names_view"
+    execute "CREATE VIEW synonyms_and_trade_names_view AS #{view_sql('20150310140649', 'synonyms_and_trade_names_view')}"
+    execute "DROP VIEW IF EXISTS orphaned_taxon_concepts_view"
+    execute "CREATE VIEW orphaned_taxon_concepts_view AS #{view_sql('20150310140649', 'orphaned_taxon_concepts_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS taxon_concepts_names_view"
+    execute "CREATE VIEW taxon_concepts_names_view AS #{view_sql('20150126125749', 'taxon_concepts_names_view')}"
+    execute "DROP VIEW IF EXISTS synonyms_and_trade_names_view"
+    execute "CREATE VIEW synonyms_and_trade_names_view AS #{view_sql('20150126125749', 'synonyms_and_trade_names_view')}"
+    execute "DROP VIEW IF EXISTS orphaned_taxon_concepts_view"
+    execute "CREATE VIEW orphaned_taxon_concepts_view AS #{view_sql('20150126125749', 'orphaned_taxon_concepts_view')}"
+  end
+end

--- a/db/plpgsql/010_copy_listing_changes_across_events.sql
+++ b/db/plpgsql/010_copy_listing_changes_across_events.sql
@@ -7,7 +7,22 @@ CREATE OR REPLACE FUNCTION copy_listing_changes_across_events(
       to_event events%ROWTYPE;
     BEGIN
     SELECT INTO to_event * FROM events WHERE id = to_event_id;
-    WITH copied_annotations AS (
+
+
+    WITH event_lcs AS (
+      SELECT *
+      FROM listing_changes
+      WHERE event_id = from_event_id
+    ), exclusions AS (
+      SELECT listing_changes.*
+      FROM event_lcs
+      JOIN listing_changes
+      ON event_lcs.id = listing_changes.parent_id
+    ), lcs_to_copy AS (
+      SELECT * FROM event_lcs
+      UNION
+      SELECT * FROM exclusions
+    ), copied_annotations AS (
       -- copy regular annotations
       INSERT INTO annotations (
         symbol, parent_symbol,
@@ -22,9 +37,8 @@ CREATE OR REPLACE FUNCTION copy_listing_changes_across_events(
         display_in_index, display_in_footnote,
         current_date, current_date, original.id
       FROM annotations original
-      INNER JOIN listing_changes
-        ON listing_changes.annotation_id = original.id
-          AND listing_changes.event_id = from_event_id
+      INNER JOIN lcs_to_copy lc
+        ON lc.annotation_id = original.id
       RETURNING id, original_id
     ), copied_hash_annotations AS (
       -- copy hash annotations
@@ -41,9 +55,8 @@ CREATE OR REPLACE FUNCTION copy_listing_changes_across_events(
         display_in_index, display_in_footnote,
         current_date, current_date, original.id
       FROM annotations original
-      INNER JOIN listing_changes
-        ON listing_changes.hash_annotation_id = original.id
-          AND listing_changes.event_id = from_event_id
+      JOIN lcs_to_copy lc
+        ON lc.hash_annotation_id = original.id
       RETURNING id, original_id
     ), copied_listing_changes AS (
       -- copy listing_changes
@@ -57,15 +70,29 @@ CREATE OR REPLACE FUNCTION copy_listing_changes_across_events(
         original.taxon_concept_id, to_event.id, to_event.effective_at, to_event.is_current,
         current_date, current_date, original.id,
         events.created_by_id, events.updated_by_id
-      FROM listing_changes original
+      FROM event_lcs original
       LEFT JOIN copied_annotations
         ON original.annotation_id = copied_annotations.original_id
       LEFT JOIN copied_hash_annotations
         ON original.hash_annotation_id = copied_hash_annotations.original_id
       JOIN events
         ON events.id = to_event_id
-      WHERE original.event_id = from_event_id
-      RETURNING id, original_id
+      RETURNING id, original_id, created_at, created_by_id, updated_at, updated_by_id
+    ), copied_exclusions AS (
+      INSERT INTO listing_changes (
+        change_type_id, species_listing_id, annotation_id, hash_annotation_id,
+        parent_id, taxon_concept_id, event_id, effective_at, is_current,
+        created_at, updated_at, original_id, created_by_id, updated_by_id
+      )
+      SELECT original.change_type_id, original.species_listing_id,
+        NULL, NULL, copied_listing_changes.id,
+        original.taxon_concept_id, NULL, to_event.effective_at, to_event.is_current,
+        copied_listing_changes.created_at, copied_listing_changes.updated_at, original.id,
+        copied_listing_changes.created_by_id, copied_listing_changes.updated_by_id
+      FROM exclusions original
+      JOIN copied_listing_changes
+      ON copied_listing_changes.original_id = original.parent_id
+      RETURNING id, original_id, created_at, created_by_id, updated_at, updated_by_id
     )
     INSERT INTO listing_distributions (
       listing_change_id, geo_entity_id, is_party, created_at, updated_at
@@ -73,8 +100,15 @@ CREATE OR REPLACE FUNCTION copy_listing_changes_across_events(
     SELECT copied_listing_changes.id, original.geo_entity_id, original.is_party,
       current_date, current_date
     FROM listing_distributions original
-    INNER JOIN copied_listing_changes
-      ON copied_listing_changes.original_id = original.listing_change_id;
+    JOIN copied_listing_changes
+      ON copied_listing_changes.original_id = original.listing_change_id
+    UNION
+    SELECT copied_exclusions.id, original.geo_entity_id, original.is_party,
+      current_date, current_date
+    FROM listing_distributions original
+    JOIN copied_exclusions
+      ON copied_exclusions.original_id = original.listing_change_id;
+
     END;
   $$;
 

--- a/db/views/orphaned_taxon_concepts_view/20150310140649.sql
+++ b/db/views/orphaned_taxon_concepts_view/20150310140649.sql
@@ -1,0 +1,48 @@
+SELECT
+  tc.name_status,
+  tc.id,
+  tc.legacy_id,
+  tc.legacy_trade_code,
+  tc.data->'rank_name' AS rank_name,
+  tc.full_name,
+  tc.author_year,
+  taxonomies.id AS taxonomy_id,
+  taxonomies.name AS taxonomy_name,
+  ARRAY_TO_STRING(
+    ARRAY[
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
+    ],
+    E'\n'
+  ) AS internal_notes,
+  to_char(tc.created_at, 'DD/MM/YYYY') AS created_at,
+  uc.name AS created_by,
+  to_char(tc.updated_at, 'DD/MM/YYYY') AS updated_at,
+  uu.name AS updated_by,
+  to_char(tc.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  uud.name AS dependents_updated_by
+FROM taxon_concepts tc
+JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
+LEFT JOIN taxon_relationships tr1 ON tr1.taxon_concept_id = tc.id
+LEFT JOIN taxon_relationships tr2 ON tr2.other_taxon_concept_id = tc.id
+LEFT JOIN taxon_concepts children ON children.parent_id = tc.id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = tc.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = tc.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = tc.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
+LEFT JOIN users uc ON tc.created_by_id = uc.id
+LEFT JOIN users uu ON tc.updated_by_id = uu.id
+LEFT JOIN users uud ON tc.dependents_updated_by_id = uud.id
+WHERE tc.parent_id IS NULL
+  AND tr1.id IS NULL
+  AND tr2.id IS NULL
+  AND children.id IS NULL;

--- a/db/views/orphaned_taxon_concepts_view/20150310140649.sql
+++ b/db/views/orphaned_taxon_concepts_view/20150310140649.sql
@@ -16,11 +16,11 @@ SELECT
     ],
     E'\n'
   ) AS internal_notes,
-  to_char(tc.created_at, 'DD/MM/YYYY') AS created_at,
+  to_char(tc.created_at, 'DD/MM/YYYY HH24:MI') AS created_at,
   uc.name AS created_by,
-  to_char(tc.updated_at, 'DD/MM/YYYY') AS updated_at,
+  to_char(tc.updated_at, 'DD/MM/YYYY HH24:MI') AS updated_at,
   uu.name AS updated_by,
-  to_char(tc.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  to_char(tc.dependents_updated_at, 'DD/MM/YYYY HH24:MI') AS dependents_updated_at,
   uud.name AS dependents_updated_by
 FROM taxon_concepts tc
 JOIN taxonomies ON taxonomies.id = tc.taxonomy_id

--- a/db/views/synonyms_and_trade_names_view/20150310140649.sql
+++ b/db/views/synonyms_and_trade_names_view/20150310140649.sql
@@ -1,0 +1,58 @@
+SELECT
+  st.name_status,
+  st.id,
+  st.legacy_id,
+  st.legacy_trade_code,
+  st.data->'rank_name' AS rank_name,
+  st.full_name,
+  st.author_year,
+  a.full_name AS accepted_full_name,
+  a.author_year AS accepted_author_year,
+  a.id AS accepted_id,
+  a.data->'rank_name' AS accepted_rank_name,
+  a.name_status AS accepted_name_status,
+  a.data->'kingdom_name' AS accepted_kingdom_name,
+  a.data->'phylum_name' AS accepted_phylum_name,
+  a.data->'class_name' AS accepted_class_name,
+  a.data->'order_name' AS accepted_order_name,
+  a.data->'family_name' AS accepted_family_name,
+  a.data->'genus_name' AS accepted_genus_name,
+  a.data->'species_name' AS accepted_species_name,
+  taxonomies.id AS taxonomy_id,
+  taxonomies.name AS taxonomy_name,
+  ARRAY_TO_STRING(
+    ARRAY[
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
+    ],
+    E'\n'
+  ) AS internal_notes,
+  to_char(st.created_at, 'DD/MM/YYYY') AS created_at,
+  uc.name AS created_by,
+  to_char(st.updated_at, 'DD/MM/YYYY') AS updated_at,
+  uu.name AS updated_by,
+  to_char(st.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  uud.name AS dependents_updated_by
+FROM taxon_concepts st
+JOIN taxonomies ON taxonomies.id = st.taxonomy_id
+LEFT JOIN taxon_relationships
+ON taxon_relationships.other_taxon_concept_id = st.id
+LEFT JOIN taxon_concepts a
+ON taxon_relationships.taxon_concept_id = a.id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = st.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = st.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = st.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
+LEFT JOIN users uc ON st.created_by_id = uc.id
+LEFT JOIN users uu ON st.updated_by_id = uu.id
+LEFT JOIN users uud ON st.dependents_updated_by_id = uud.id
+WHERE st.name_status IN ('S', 'T');

--- a/db/views/synonyms_and_trade_names_view/20150310140649.sql
+++ b/db/views/synonyms_and_trade_names_view/20150310140649.sql
@@ -28,11 +28,11 @@ SELECT
     ],
     E'\n'
   ) AS internal_notes,
-  to_char(st.created_at, 'DD/MM/YYYY') AS created_at,
+  to_char(st.created_at, 'DD/MM/YYYY HH24:MI') AS created_at,
   uc.name AS created_by,
-  to_char(st.updated_at, 'DD/MM/YYYY') AS updated_at,
+  to_char(st.updated_at, 'DD/MM/YYYY HH24:MI') AS updated_at,
   uu.name AS updated_by,
-  to_char(st.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  to_char(st.dependents_updated_at, 'DD/MM/YYYY HH24:MI') AS dependents_updated_at,
   uud.name AS dependents_updated_by
 FROM taxon_concepts st
 JOIN taxonomies ON taxonomies.id = st.taxonomy_id

--- a/db/views/taxon_concepts_names_view/20150310140649.sql
+++ b/db/views/taxon_concepts_names_view/20150310140649.sql
@@ -23,11 +23,11 @@ SELECT
     ],
     E'\n'
   ) AS internal_notes,
-  to_char(taxon_concepts.created_at, 'DD/MM/YYYY') AS created_at,
+  to_char(taxon_concepts.created_at, 'DD/MM/YYYY HH24:MI') AS created_at,
   uc.name AS created_by,
-  to_char(taxon_concepts.updated_at, 'DD/MM/YYYY') AS updated_at,
+  to_char(taxon_concepts.updated_at, 'DD/MM/YYYY HH24:MI') AS updated_at,
   uu.name AS updated_by,
-  to_char(taxon_concepts.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  to_char(taxon_concepts.dependents_updated_at, 'DD/MM/YYYY HH24:MI') AS dependents_updated_at,
   uud.name AS dependents_updated_by
 FROM taxon_concepts
 JOIN taxonomies ON taxonomies.id = taxon_concepts.taxonomy_id

--- a/db/views/taxon_concepts_names_view/20150310140649.sql
+++ b/db/views/taxon_concepts_names_view/20150310140649.sql
@@ -1,0 +1,48 @@
+SELECT
+  taxon_concepts.id,
+  legacy_id,
+  data->'kingdom_name' AS kingdom_name,
+  data->'phylum_name' AS phylum_name,
+  data->'class_name' AS class_name,
+  data->'order_name' AS order_name,
+  data->'family_name' AS family_name,
+  data->'genus_name' AS genus_name,
+  data->'species_name' AS species_name,
+  full_name,
+  author_year,
+  data->'rank_name' AS rank_name,
+  name_status,
+  taxonomic_position,
+  taxonomy_id,
+  taxonomies.name AS taxonomy_name,
+  ARRAY_TO_STRING(
+    ARRAY[
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
+    ],
+    E'\n'
+  ) AS internal_notes,
+  to_char(taxon_concepts.created_at, 'DD/MM/YYYY') AS created_at,
+  uc.name AS created_by,
+  to_char(taxon_concepts.updated_at, 'DD/MM/YYYY') AS updated_at,
+  uu.name AS updated_by,
+  to_char(taxon_concepts.dependents_updated_at, 'DD/MM/YYYY') AS dependents_updated_at,
+  uud.name AS dependents_updated_by
+FROM taxon_concepts
+JOIN taxonomies ON taxonomies.id = taxon_concepts.taxonomy_id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = taxon_concepts.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = taxon_concepts.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = taxon_concepts.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
+LEFT JOIN users uc ON taxon_concepts.created_by_id = uc.id
+LEFT JOIN users uu ON taxon_concepts.updated_by_id = uu.id
+LEFT JOIN users uud ON taxon_concepts.dependents_updated_by_id = uud.id;

--- a/spec/models/cites_suspension_spec.rb
+++ b/spec/models/cites_suspension_spec.rb
@@ -76,7 +76,7 @@ describe CitesSuspension do
           )
         }
         specify{
-          expect{subject.save}.to change{@taxon_concept.updated_at}
+          expect{subject.save}.to change{@taxon_concept.dependents_updated_at}
         }
       end
       context "when global suspension" do
@@ -89,7 +89,7 @@ describe CitesSuspension do
           )
         }
         specify{
-          expect{subject.save}.to change{@taxon_concept.reload.updated_at}
+          expect{subject.save}.to change{@taxon_concept.reload.dependents_updated_at}
         }
       end
     end
@@ -104,7 +104,7 @@ describe CitesSuspension do
         }
         specify{
           expect{subject.update_attribute(:taxon_concept_id, @another_taxon_concept.id)}.
-            to change{@taxon_concept.updated_at}
+            to change{@taxon_concept.dependents_updated_at}
         }
       end
       context "when global suspension" do
@@ -118,11 +118,11 @@ describe CitesSuspension do
         }
         specify{
           expect{subject.update_attribute(:geo_entity_id, rwanda.id)}.
-            to change{@taxon_concept.reload.updated_at}
+            to change{@taxon_concept.reload.dependents_updated_at}
         }
         specify{
           expect{subject.update_attribute(:geo_entity_id, rwanda.id)}.
-            to change{@another_taxon_concept.reload.updated_at}
+            to change{@another_taxon_concept.reload.dependents_updated_at}
         }
       end
     end
@@ -136,7 +136,7 @@ describe CitesSuspension do
           )
         }
         specify{
-          expect{subject.destroy}.to change{@taxon_concept.updated_at}
+          expect{subject.destroy}.to change{@taxon_concept.dependents_updated_at}
         }
       end
       context "when global suspension" do
@@ -150,7 +150,7 @@ describe CitesSuspension do
         }
         specify{
           expect{subject.destroy}.
-            to change{@taxon_concept.reload.updated_at}
+            to change{@taxon_concept.reload.dependents_updated_at}
         }
       end
     end

--- a/spec/models/cites_suspension_spec.rb
+++ b/spec/models/cites_suspension_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-describe CitesSuspension do
+describe CitesSuspension, sidekiq: :inline do
   let(:tanzania){
     create(
       :geo_entity,
@@ -76,7 +76,7 @@ describe CitesSuspension do
           )
         }
         specify{
-          expect{subject.save}.to change{@taxon_concept.dependents_updated_at}
+          expect{subject.save}.to change{@taxon_concept.reload.dependents_updated_at}
         }
       end
       context "when global suspension" do
@@ -104,7 +104,7 @@ describe CitesSuspension do
         }
         specify{
           expect{subject.update_attribute(:taxon_concept_id, @another_taxon_concept.id)}.
-            to change{@taxon_concept.dependents_updated_at}
+            to change{@taxon_concept.reload.dependents_updated_at}
         }
       end
       context "when global suspension" do
@@ -136,7 +136,7 @@ describe CitesSuspension do
           )
         }
         specify{
-          expect{subject.destroy}.to change{@taxon_concept.dependents_updated_at}
+          expect{subject.destroy}.to change{@taxon_concept.reload.dependents_updated_at}
         }
       end
       context "when global suspension" do

--- a/spec/models/eu_decision_spec.rb
+++ b/spec/models/eu_decision_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe EuDecision do
+describe EuDecision, sidekiq: :inline do
   before do
     @taxon_concept = create(:taxon_concept)
   end

--- a/spec/models/quota_spec.rb
+++ b/spec/models/quota_spec.rb
@@ -31,7 +31,7 @@
 
 require 'spec_helper'
 
-describe Quota do
+describe Quota, sidekiq: :inline do
   before do
     @taxon_concept = create(:taxon_concept)
   end

--- a/spec/models/trade/shipments_gross_exports_export_spec.rb
+++ b/spec/models/trade/shipments_gross_exports_export_spec.rb
@@ -26,6 +26,10 @@ describe Trade::ShipmentsGrossExportsExport do
       subject { Trade::ShipmentsGrossExportsExport.new(:internal => false, :per_page => 3) }
       specify{ subject.query.ntuples.should == 3 }
     end
+    context "when invalid date range" do
+      subject { Trade::ShipmentsGrossExportsExport.new(:internal => false, :time_range_start => 2015, :time_range_end => 2014) }
+      specify{ subject.query.ntuples.should == 0 }
+    end
   end
 
 end

--- a/spec/models/trade/shipments_gross_imports_export_spec.rb
+++ b/spec/models/trade/shipments_gross_imports_export_spec.rb
@@ -26,6 +26,10 @@ describe Trade::ShipmentsGrossImportsExport do
       subject { Trade::ShipmentsGrossImportsExport.new(:internal => false, :per_page => 3) }
       specify{ subject.query.ntuples.should == 3 }
     end
+    context "when invalid date range" do
+      subject { Trade::ShipmentsGrossImportsExport.new(:internal => false, :time_range_start => 2015, :time_range_end => 2014) }
+      specify{ subject.query.ntuples.should == 0 }
+    end
   end
 
 end

--- a/spec/models/trade/shipments_net_exports_export_spec.rb
+++ b/spec/models/trade/shipments_net_exports_export_spec.rb
@@ -26,6 +26,10 @@ describe Trade::ShipmentsNetExportsExport do
       subject { Trade::ShipmentsNetExportsExport.new(:internal => false, :per_page => 3) }
       specify{ subject.query.ntuples.should == 3 }
     end
+    context "when invalid date range" do
+      subject { Trade::ShipmentsNetExportsExport.new(:internal => false, :time_range_start => 2015, :time_range_end => 2014) }
+      specify{ subject.query.ntuples.should == 0 }
+    end
   end
 
 end

--- a/spec/models/trade/shipments_net_imports_export_spec.rb
+++ b/spec/models/trade/shipments_net_imports_export_spec.rb
@@ -26,6 +26,10 @@ describe Trade::ShipmentsNetImportsExport do
       subject { Trade::ShipmentsNetImportsExport.new(:internal => false, :per_page => 3) }
       specify{ subject.query.ntuples.should == 3 }
     end
+    context "when invalid date range" do
+      subject { Trade::ShipmentsNetImportsExport.new(:internal => false, :time_range_start => 2015, :time_range_end => 2014) }
+      specify{ subject.query.ntuples.should == 0 }
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,7 +106,7 @@ end
 
 def build_tc_attributes(*args)
   build_attributes(*args).delete_if do |k, v|
-    %w(data listing notes).include? k
+    %w(data listing notes dependents_updated_at dependents_updated_by_id).include? k
   end
 end
 

--- a/spec/workers/event_listing_changes_copy_worker_spec.rb
+++ b/spec/workers/event_listing_changes_copy_worker_spec.rb
@@ -8,9 +8,24 @@ describe EventListingChangesCopyWorker do
       :is_current => true
     )
   }
+  let(:eu_regulation){
+    create_eu_regulation(
+      :name => 'REGULATION 2.0',
+      :listing_changes_event_id => prev_eu_regulation.id,
+      :designation => eu,
+      :is_current => true
+    )
+  }
+  let(:species){
+    create_cites_eu_species
+  }
+  let(:subspecies){
+    create_cites_eu_subspecies(parent: species)
+  }
   let!(:listing_change){
     create_eu_A_addition(
-      :event_id => prev_eu_regulation.id
+      :event_id => prev_eu_regulation.id,
+      :taxon_concept_id => species.id
     )
   }
 
@@ -29,17 +44,33 @@ describe EventListingChangesCopyWorker do
   end
 
   context "when copy into current regulation" do
-    let(:eu_regulation){
-      create_eu_regulation(
-        :name => 'REGULATION 2.0',
-        :listing_changes_event_id => prev_eu_regulation.id,
-        :designation => eu,
-        :is_current => true
-      )
-    }
     before { EventListingChangesCopyWorker.new.perform(prev_eu_regulation.id, eu_regulation.id) }
     specify { eu_regulation.listing_changes.reload.count.should == 1 }
     specify { eu_regulation.listing_changes.first.is_current.should be_true }
+  end
+
+  context "when exclusion" do
+    let!(:taxonomic_exclusion){
+      create_eu_A_exception(
+        :parent_id => listing_change.id,
+        :taxon_concept_id => subspecies.id
+      )
+    }
+    let!(:geographic_exclusion){
+      create_eu_A_exception(
+        :parent_id => listing_change.id,
+        :taxon_concept_id => species.id
+      )
+    }
+    let!(:exclusion_distribution){
+      create(:listing_distribution, listing_change_id: geographic_exclusion.id)
+    }
+
+    before { EventListingChangesCopyWorker.new.perform(prev_eu_regulation.id, eu_regulation.id) }
+    specify { eu_regulation.listing_changes.reload.count.should == 1 }
+    specify { eu_regulation.listing_changes.first.exclusions.count.should == 2 }
+    specify { eu_regulation.listing_changes.first.taxonomic_exclusions.count.should == 1 }
+    specify { eu_regulation.listing_changes.first.geographic_exclusions.count.should == 1 }
   end
 
 end


### PR DESCRIPTION
### 0.9.4.1 (2015-03-19)
**Species+ Admin**
* tracking dependents_updated_by_id
* copying exclusions to EU listings

**Trade**
* automatically expand the shipment year range

Requires rake db:migrate and clearing the admin downloads (rake downloads:cache:clear)