### PR TITLE
Replace non-breaking spaces in uploaded taxon names

### DIFF
--- a/db/functions/squish/20150401123614.sql
+++ b/db/functions/squish/20150401123614.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION squish(TEXT) RETURNS TEXT
+  LANGUAGE SQL IMMUTABLE
+  AS $$
+    SELECT BTRIM(
+      regexp_replace(
+        regexp_replace($1, U&'\00A0', ' ', 'g'),
+        E'\\s+', ' ', 'g'
+      )
+    );
+  $$;
+
+COMMENT ON FUNCTION squish(TEXT) IS
+  'Squishes whitespace characters in a string';

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -27,15 +27,6 @@ CREATE OR REPLACE FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255)
 COMMENT ON FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255)) IS
   'Returns an array of rank names above the given rank (sorted lowest first).';
 
-CREATE OR REPLACE FUNCTION squish(TEXT) RETURNS TEXT
-  LANGUAGE SQL IMMUTABLE
-  AS $$
-    SELECT BTRIM(regexp_replace($1, E'\\s+', ' ', 'g'));
-  $$;
-
-COMMENT ON FUNCTION squish(TEXT) IS
-  'Squishes whitespace characters in a string';
-
 CREATE OR REPLACE FUNCTION squish_null(TEXT) RETURNS TEXT
   LANGUAGE SQL IMMUTABLE
   AS $$
@@ -44,11 +35,6 @@ CREATE OR REPLACE FUNCTION squish_null(TEXT) RETURNS TEXT
 
 COMMENT ON FUNCTION squish_null(TEXT) IS
   'Squishes whitespace characters in a string and returns null for empty string';
-
---TODO remove in the future, after this has been ran on production
-DROP FUNCTION IF EXISTS sanitize_species_name(TEXT);
-
-
 
 CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255)) RETURNS VARCHAR(255)
   LANGUAGE sql IMMUTABLE

--- a/db/migrate/20150401123614_squish_should_remove_non_breaking_spaces.rb
+++ b/db/migrate/20150401123614_squish_should_remove_non_breaking_spaces.rb
@@ -1,0 +1,8 @@
+class SquishShouldRemoveNonBreakingSpaces < ActiveRecord::Migration
+  def up
+    execute function_sql('20150401123614', 'squish')
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
When uploading an annual report in the trade admin interface, replace non-breaking spaces in taxon names with regular spaces in order to prevent from raising primary errors on unrecognised taxon names.