### PR TITLE
Speed up API taxon concept references call / Species+ references page

### DIFF
--- a/db/functions/higher_or_equal_ranks_names/20150402111503.sql
+++ b/db/functions/higher_or_equal_ranks_names/20150402111503.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255))
+  RETURNS TEXT[]
+  LANGUAGE sql IMMUTABLE
+  AS $$
+    WITH ranks_in_order(row_no, rank_name) AS (
+      SELECT ROW_NUMBER() OVER(), *
+      FROM UNNEST(ARRAY[
+      'VARIETY', 'SUBSPECIES', 'SPECIES', 'GENUS', 'SUBFAMILY',
+      'FAMILY', 'ORDER', 'CLASS', 'PHYLUM', 'KINGDOM'
+      ])
+    )
+    SELECT ARRAY_AGG(rank_name) FROM ranks_in_order
+    WHERE row_no >= (SELECT row_no FROM ranks_in_order WHERE rank_name = $1);
+  $$;
+
+COMMENT ON FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255)) IS
+  'Returns an array of rank names above the given rank (sorted lowest first).';

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -9,23 +9,14 @@ AS $FUNCTION$
     );
 $FUNCTION$;
 
-CREATE OR REPLACE FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255))
-  RETURNS TEXT[]
-  LANGUAGE sql IMMUTABLE
+CREATE OR REPLACE FUNCTION squish_null(TEXT) RETURNS TEXT
+  LANGUAGE SQL IMMUTABLE
   AS $$
-    WITH ranks_in_order(row_no, rank_name) AS (
-      SELECT ROW_NUMBER() OVER(), *
-      FROM UNNEST(ARRAY[
-      'VARIETY', 'SUBSPECIES', 'SPECIES', 'GENUS', 'SUBFAMILY',
-      'FAMILY', 'ORDER', 'CLASS', 'PHYLUM', 'KINGDOM'
-      ])
-    )
-    SELECT ARRAY_AGG(rank_name) FROM ranks_in_order
-    WHERE row_no >= (SELECT row_no FROM ranks_in_order WHERE rank_name = $1);
+    SELECT CASE WHEN SQUISH($1) = '' THEN NULL ELSE SQUISH($1) END;
   $$;
 
-COMMENT ON FUNCTION higher_or_equal_ranks_names(in_rank_name VARCHAR(255)) IS
-  'Returns an array of rank names above the given rank (sorted lowest first).';
+COMMENT ON FUNCTION squish_null(TEXT) IS
+  'Squishes whitespace characters in a string and returns null for empty string';
 
 CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255)) RETURNS VARCHAR(255)
   LANGUAGE sql IMMUTABLE

--- a/db/migrate/20150402111503_create_higher_or_equal_rank_names_function.rb
+++ b/db/migrate/20150402111503_create_higher_or_equal_rank_names_function.rb
@@ -1,0 +1,8 @@
+class CreateHigherOrEqualRankNamesFunction < ActiveRecord::Migration
+  def up
+    execute function_sql('20150402111503', 'higher_or_equal_ranks_names')
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20150402111504_create_taxon_concepts_and_ancestors_view.rb
+++ b/db/migrate/20150402111504_create_taxon_concepts_and_ancestors_view.rb
@@ -1,0 +1,12 @@
+class CreateTaxonConceptsAndAncestorsView < ActiveRecord::Migration
+  def up
+    execute "DROP MATERIALIZED VIEW IF EXISTS taxon_concept_and_ancestors_mview"
+    execute "CREATE MATERIALIZED VIEW taxon_concepts_and_ancestors_mview AS #{view_sql('20150402111504', 'taxon_concepts_and_ancestors_mview')}"
+    execute "CREATE UNIQUE INDEX ON taxon_concepts_and_ancestors_mview(ancestor_taxon_concept_id, taxon_concept_id)"
+    execute "CREATE INDEX ON taxon_concepts_and_ancestors_mview(taxonomy_id)"
+  end
+
+  def down
+    execute "DROP MATERIALIZED VIEW IF EXISTS taxon_concept_and_ancestors_mview"
+  end
+end

--- a/db/migrate/20150402131608_speed_up_api_taxon_references_view.rb
+++ b/db/migrate/20150402131608_speed_up_api_taxon_references_view.rb
@@ -1,0 +1,11 @@
+class SpeedUpApiTaxonReferencesView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_taxon_references_view"
+    execute "CREATE VIEW api_taxon_references_view AS #{view_sql('20150402131608', 'api_taxon_references_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_taxon_references_view"
+    execute "CREATE VIEW api_taxon_references_view AS #{view_sql('20150302082111', 'api_taxon_references_view')}"
+  end
+end

--- a/db/migrate/20150421112808_create_unique_index_on_taxon_concept_references.rb
+++ b/db/migrate/20150421112808_create_unique_index_on_taxon_concept_references.rb
@@ -1,0 +1,40 @@
+class CreateUniqueIndexOnTaxonConceptReferences < ActiveRecord::Migration
+  def up
+    sql =<<-SQL
+  WITH duplicated_taxon_concept_references AS (
+    SELECT primary_id, cnt, UNNEST(ids) AS id FROM (
+      SELECT MIN(id) AS primary_id, COUNT(*) AS cnt, ARRAY_AGG_NOTNULL(id) AS ids
+      FROM taxon_concept_references
+      GROUP BY taxon_concept_id, reference_id
+      HAVING COUNT(*) > 1
+    ) s
+  ), duplicates_to_delete AS (
+    SELECT tcr.* FROM taxon_concept_references tcr
+    JOIN duplicated_taxon_concept_references d
+    ON tcr.id = d.id
+    WHERE primary_id != d.id
+  )
+  DELETE FROM taxon_concept_references
+  USING duplicates_to_delete
+  WHERE taxon_concept_references.id = duplicates_to_delete.id
+  SQL
+    # remove duplicates
+    execute sql
+
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id"
+
+    add_index "taxon_concept_references", ["taxon_concept_id", "reference_id"],
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id",
+      unique: true
+
+  end
+
+  def down
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id"
+
+    add_index "taxon_concept_references", ["taxon_concept_id", "reference_id"],
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id"
+  end
+end

--- a/db/migrate/20150427111732_create_more_indexes_on_taxon_concept_references.rb
+++ b/db/migrate/20150427111732_create_more_indexes_on_taxon_concept_references.rb
@@ -1,0 +1,11 @@
+class CreateMoreIndexesOnTaxonConceptReferences < ActiveRecord::Migration
+  def up
+    add_index "taxon_concept_references", ["is_standard", "is_cascaded", "taxon_concept_id"],
+      name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded"
+  end
+
+  def down
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded"
+  end
+end

--- a/db/mviews/002_rebuild_taxonomy_taxon_concepts_and_ancestors_mview.sql
+++ b/db/mviews/002_rebuild_taxonomy_taxon_concepts_and_ancestors_mview.sql
@@ -1,48 +1,4 @@
-CREATE OR REPLACE FUNCTION rebuild_taxonomy_taxon_concepts_and_ancestors_mview(taxonomy taxonomies) RETURNS void
-  LANGUAGE plpgsql STRICT
-  AS $$
-  DECLARE
-    tc_table_name TEXT;
-    sql TEXT;
-  BEGIN
-    SELECT LOWER(taxonomy.name) || '_taxon_concepts_and_ancestors_mview' INTO tc_table_name;
-
-    EXECUTE 'DROP TABLE IF EXISTS ' || tc_table_name || ' CASCADE';
-
-    -- This query took like half a day to get right, so maybe it deserves a comment.
-    -- It uses a sql procedure (ary_higher_or_equal_ranks_names) to return all ranks above
-    -- the current taxon concept and then from those ranks get at actual ancestor ids.
-    -- The reason for doing it that way is to make use of ancestor data which we already store
-    -- for every taxon concept in columns named 'name_of_rank_id'.
-    -- We also want to know the tree distance between the current taxon concept and any
-    -- of its ancestors.
-    -- So we call the higher_or_equal_ranks_names procedure for every taxon concept,
-    -- and the only way to parametrise it correctly is to call it in the select clause.
-    -- Because it returns an array of ranks, and what we want is a set of (taxon concept, ancestor, distance),
-    -- we then go through the UNNEST thing in order to arrive at separate rows per ancestor.
-    -- In order to know the distance it is enough to know the index of the ancestor in the originally
-    -- returned array, because it is already sorted accordingly. That's what GENERATE_SUBSCRIPTS does.
-    -- Quite surprisingly, this worked.
-
-    sql := 'CREATE TEMP TABLE ' || tc_table_name || ' AS
-    SELECT id AS taxon_concept_id,
-    (
-      data->(LOWER(UNNEST(higher_or_equal_ranks_names(data->''rank_name''))) || ''_id'')
-    )::INT AS ancestor_taxon_concept_id,
-    GENERATE_SUBSCRIPTS(higher_or_equal_ranks_names(data->''rank_name''), 1) - 1 AS tree_distance
-    FROM taxon_concepts
-    WHERE name_status IN (''A'', ''N'') AND taxonomy_id = ' || taxonomy.id;
-
-    EXECUTE sql;
-
-    EXECUTE 'CREATE INDEX ON ' || tc_table_name || ' (ancestor_taxon_concept_id)';
-    
-    PERFORM rebuild_taxonomy_tmp_taxon_concepts_mview(taxonomy);
-  END
-  $$;
-
-COMMENT ON FUNCTION rebuild_taxonomy_taxon_concepts_and_ancestors_mview(taxonomy taxonomies) IS
-  'Procedure to create a helper table with all taxon - ancestor pairs in a given taxonomy.';
+DROP FUNCTION IF EXISTS rebuild_taxonomy_taxon_concepts_and_ancestors_mview(taxonomy taxonomies);
 
 CREATE OR REPLACE FUNCTION rebuild_taxonomy_tmp_taxon_concepts_mview(taxonomy taxonomies) RETURNS void
   LANGUAGE plpgsql STRICT
@@ -51,6 +7,10 @@ CREATE OR REPLACE FUNCTION rebuild_taxonomy_tmp_taxon_concepts_mview(taxonomy ta
     tc_table_name TEXT;
     sql TEXT;
   BEGIN
+    EXECUTE 'CREATE OR REPLACE VIEW ' || LOWER(taxonomy.name) || '_taxon_concepts_and_ancestors_view AS
+    SELECT * FROM taxon_concepts_and_ancestors_mview
+    WHERE taxonomy_id = ' || taxonomy.id;
+
     SELECT LOWER(taxonomy.name) || '_tmp_taxon_concepts_mview' INTO tc_table_name;
 
     EXECUTE 'DROP TABLE IF EXISTS ' || tc_table_name || ' CASCADE';

--- a/db/mviews/003_rebuild_designation_all_listing_changes_mview.sql
+++ b/db/mviews/003_rebuild_designation_all_listing_changes_mview.sql
@@ -17,7 +17,7 @@
     SELECT listing_changes_mview_name('tmp', designation.name, events_ids)
     INTO tmp_lc_table_name;
 
-    SELECT LOWER(taxonomy.name) || '_taxon_concepts_and_ancestors_mview' INTO tc_table_name;
+    SELECT LOWER(taxonomy.name) || '_taxon_concepts_and_ancestors_view' INTO tc_table_name;
 
     EXECUTE 'DROP TABLE IF EXISTS ' || tmp_lc_table_name || ' CASCADE';
 

--- a/db/mviews/006_rebuild_listing_changes_mview.sql
+++ b/db/mviews/006_rebuild_listing_changes_mview.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION rebuild_cites_eu_taxon_concepts_and_ancestors_mview()
   BEGIN
     SELECT * INTO taxonomy FROM taxonomies WHERE name = 'CITES_EU';
     IF FOUND THEN
-      PERFORM rebuild_taxonomy_taxon_concepts_and_ancestors_mview(taxonomy);
+      PERFORM rebuild_taxonomy_tmp_taxon_concepts_mview(taxonomy);
     END IF;
   END;
   $$;
@@ -19,7 +19,7 @@ CREATE OR REPLACE FUNCTION rebuild_cms_taxon_concepts_and_ancestors_mview() RETU
   BEGIN
     SELECT * INTO taxonomy FROM taxonomies WHERE name = 'CMS';
     IF FOUND THEN
-      PERFORM rebuild_taxonomy_taxon_concepts_and_ancestors_mview(taxonomy);
+      PERFORM rebuild_taxonomy_tmp_taxon_concepts_mview(taxonomy);
     END IF;
   END;
   $$;

--- a/db/plpgsql/002_rebuild_taxonomy.sql
+++ b/db/plpgsql/002_rebuild_taxonomy.sql
@@ -300,6 +300,7 @@ CREATE OR REPLACE FUNCTION rebuild_taxonomy() RETURNS void
   AS $$
   BEGIN
     PERFORM rebuild_taxonomy_for_node(NULL);
+    REFRESH MATERIALIZED VIEW taxon_concepts_and_ancestors_mview;
   END;
   $$;
 

--- a/db/views/api_taxon_references_view/20150402131608.sql
+++ b/db/views/api_taxon_references_view/20150402131608.sql
@@ -1,0 +1,58 @@
+WITH cascaded_tc_refs AS (
+  SELECT tc_refs_1.id,
+    tc.taxon_concept_id,
+    tc.ancestor_taxon_concept_id AS original_taxon_concept_id,
+    tc_refs_1.excluded_taxon_concepts_ids,
+    tc_refs_1.reference_id,
+    tc_refs_1.is_standard,
+    tc_refs_1.is_cascaded
+  FROM taxon_concept_references tc_refs_1
+    JOIN taxon_concepts_and_ancestors_mview tc ON tc_refs_1.is_standard AND tc_refs_1.is_cascaded AND tc.ancestor_taxon_concept_id = tc_refs_1.taxon_concept_id
+), cascaded_tc_refs_without_exclusions AS (
+  SELECT cascaded_tc_refs.id,
+    cascaded_tc_refs.taxon_concept_id,
+    cascaded_tc_refs.original_taxon_concept_id,
+    cascaded_tc_refs.excluded_taxon_concepts_ids,
+    cascaded_tc_refs.reference_id,
+    cascaded_tc_refs.is_standard,
+    cascaded_tc_refs.is_cascaded
+  FROM cascaded_tc_refs
+  JOIN taxon_concepts tc ON cascaded_tc_refs.taxon_concept_id = tc.id
+  WHERE cascaded_tc_refs.excluded_taxon_concepts_ids IS NULL
+  OR NOT ARRAY[
+    (tc.data->'kingdom_id')::INT,
+    (tc.data->'phylum_id')::INT,
+    (tc.data->'class_id')::INT,
+    (tc.data->'order_id')::INT,
+    (tc.data->'family_id')::INT,
+    (tc.data->'subfamily_id')::INT,
+    (tc.data->'genus_id')::INT,
+    (tc.data->'species_id')::INT
+  ] && cascaded_tc_refs.excluded_taxon_concepts_ids
+), tc_refs AS (
+  SELECT cascaded_tc_refs_without_exclusions.id,
+    cascaded_tc_refs_without_exclusions.taxon_concept_id,
+    cascaded_tc_refs_without_exclusions.original_taxon_concept_id,
+    cascaded_tc_refs_without_exclusions.excluded_taxon_concepts_ids,
+    cascaded_tc_refs_without_exclusions.reference_id,
+    cascaded_tc_refs_without_exclusions.is_standard
+  FROM cascaded_tc_refs_without_exclusions
+UNION ALL
+  SELECT taxon_concept_references.id,
+    taxon_concept_references.taxon_concept_id,
+    taxon_concept_references.taxon_concept_id,
+    taxon_concept_references.excluded_taxon_concepts_ids,
+    taxon_concept_references.reference_id,
+    taxon_concept_references.is_standard
+  FROM taxon_concept_references
+  WHERE NOT (taxon_concept_references.is_standard AND taxon_concept_references.is_cascaded)
+)
+SELECT tc_refs.id,
+  tc_refs.taxon_concept_id,
+  tc_refs.original_taxon_concept_id,
+  tc_refs.excluded_taxon_concepts_ids,
+  tc_refs.reference_id,
+  tc_refs.is_standard,
+  "references".citation
+FROM tc_refs
+JOIN "references" ON "references".id = tc_refs.reference_id;

--- a/db/views/taxon_concepts_and_ancestors_mview/20150402111504.sql
+++ b/db/views/taxon_concepts_and_ancestors_mview/20150402111504.sql
@@ -1,0 +1,36 @@
+SELECT id AS taxon_concept_id, taxonomy_id,
+(
+  data->(LOWER(UNNEST(higher_or_equal_ranks_names(data->'rank_name'))) || '_id')
+)::INT AS ancestor_taxon_concept_id,
+GENERATE_SUBSCRIPTS(higher_or_equal_ranks_names(data->'rank_name'), 1) - 1 AS tree_distance
+FROM taxon_concepts
+WHERE name_status IN ('A', 'N', 'H');
+
+-- This query took like half a day to get right, so maybe it deserves a comment.
+-- It uses a sql procedure (ary_higher_or_equal_ranks_names) to return all ranks above
+-- the current taxon concept and then from those ranks get at actual ancestor ids.
+-- The reason for doing it that way is to make use of ancestor data which we already store
+-- for every taxon concept in columns named 'name_of_rank_id'.
+-- We also want to know the tree distance between the current taxon concept and any
+-- of its ancestors.
+-- So we call the higher_or_equal_ranks_names procedure for every taxon concept,
+-- and the only way to parametrise it correctly is to call it in the select clause.
+-- Because it returns an array of ranks, and what we want is a set of (taxon concept, ancestor, distance),
+-- we then go through the UNNEST thing in order to arrive at separate rows per ancestor.
+-- In order to know the distance it is enough to know the index of the ancestor in the originally
+-- returned array, because it is already sorted accordingly. That's what GENERATE_SUBSCRIPTS does.
+-- Quite surprisingly, this worked.
+-- This query took like half a day to get right, so maybe it deserves a comment.
+-- It uses a sql procedure (ary_higher_or_equal_ranks_names) to return all ranks above
+-- the current taxon concept and then from those ranks get at actual ancestor ids.
+-- The reason for doing it that way is to make use of ancestor data which we already store
+-- for every taxon concept in columns named 'name_of_rank_id'.
+-- We also want to know the tree distance between the current taxon concept and any
+-- of its ancestors.
+-- So we call the higher_or_equal_ranks_names procedure for every taxon concept,
+-- and the only way to parametrise it correctly is to call it in the select clause.
+-- Because it returns an array of ranks, and what we want is a set of (taxon concept, ancestor, distance),
+-- we then go through the UNNEST thing in order to arrive at separate rows per ancestor.
+-- In order to know the distance it is enough to know the index of the ancestor in the originally
+-- returned array, because it is already sorted accordingly. That's what GENERATE_SUBSCRIPTS does.
+-- Quite surprisingly, this worked.


### PR DESCRIPTION
The objective was to get rid of the slow recursive query that cascades through standard references and replace it with a faster query that fetches all descendants in one join. The existing `taxon_concepts_and_ancestors` temporary table could be used for that purpose, but it had to be extracted into a materialized view first (the view definition cannot depend on a temp table or regular table that gets dropped / recreated during the rebuild process; the refresh operation on a materialised view does not affect definitions of dependencies). A number of changes had to follow to facilitate the extraction of the materialised view.

In addition, new indexes were created on the taxon_concepts_references table.

NOTE: requires `rake db:migrate`