### PR TITLE
Import suspensions

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_cites_suspensions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_cites_suspensions.handlebars
@@ -21,7 +21,10 @@
           <td>
             {{suspension.start_date}}
           </td>
-          <td>{{suspension.geo_entity.name}}</td>
+          <td>
+            {{suspension.geo_entity.name}}<br>
+            <i>{{#if suspension.applies_to_import}}(import){{/if}}</i>
+          </td>
           <td>
             <a class="legal-links" href="{{unbound suspension.start_notification.url}}">
               {{suspension.start_notification.name}}
@@ -62,7 +65,10 @@
               <td>
                 {{suspension.start_date}}
               </td>
-              <td>{{suspension.geo_entity.name}}</td>
+              <td>
+                {{suspension.geo_entity.name}}<br>
+                <i>{{#if suspension.applies_to_import}}(import){{/if}}</i>
+              </td>
               <td>
                 <a class="legal-links" href="{{unbound suspension.start_notification.url}}">
                   {{suspension.start_notification.name}}

--- a/app/models/cites_suspension.rb
+++ b/app/models/cites_suspension.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 class CitesSuspension < TradeRestriction

--- a/app/models/cites_suspension.rb
+++ b/app/models/cites_suspension.rb
@@ -31,7 +31,8 @@
 
 class CitesSuspension < TradeRestriction
   attr_accessible :start_notification_id, :end_notification_id,
-    :cites_suspension_confirmations_attributes
+    :cites_suspension_confirmations_attributes,
+    :applies_to_import
   belongs_to :taxon_concept
   belongs_to :start_notification, :class_name => 'CitesSuspensionNotification'
   belongs_to :end_notification, :class_name => 'CitesSuspensionNotification'

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 class Quota < TradeRestriction

--- a/app/models/trade_restriction.rb
+++ b/app/models/trade_restriction.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 require 'digest/sha1'

--- a/app/models/trade_restriction_observer.rb
+++ b/app/models/trade_restriction_observer.rb
@@ -3,12 +3,16 @@ class TradeRestrictionObserver < ActiveRecord::Observer
   def after_save(trade_restriction)
     if trade_restriction.taxon_concept.nil?
       touch_taxa_with_applicable_distribution(trade_restriction)
+    else
+      touch_descendants(trade_restriction)
     end
   end
 
-  def after_destroy(trade_restriction)
+  def before_destroy(trade_restriction)
     if trade_restriction.taxon_concept.nil?
       touch_taxa_with_applicable_distribution(trade_restriction)
+    else
+      touch_descendants(trade_restriction)
     end
   end
 
@@ -24,6 +28,26 @@ class TradeRestrictionObserver < ActiveRecord::Observer
       :updated_by_id => trade_restriction.updated_by_id,
       :geo_entity_id => [
         trade_restriction.geo_entity_id, trade_restriction.geo_entity_id_was
+      ].compact.uniq
+    ])
+    TaxonConcept.connection.execute update_stmt
+  end
+
+  def touch_descendants(trade_restriction)
+    update_stmt = TaxonConcept.send(:sanitize_sql_array, [
+      "UPDATE taxon_concepts
+      SET dependents_updated_at = NOW(), dependents_updated_by_id = :updated_by_id
+      WHERE data IS NOT NULL
+      AND ARRAY[
+        (data->'species_id')::INT,
+        (data->'genus_id')::INT,
+        (data->'subfamily_id')::INT,
+        (data->'family_id')::INT,
+        (data->'order_id')::INT
+      ] && ARRAY[:taxon_concept_id] ",
+      :updated_by_id => trade_restriction.updated_by_id,
+      :taxon_concept_id => [
+        trade_restriction.taxon_concept_id, trade_restriction.taxon_concept_id_was
       ].compact.uniq
     ])
     TaxonConcept.connection.execute update_stmt

--- a/app/serializers/species/cites_suspension_serializer.rb
+++ b/app/serializers/species/cites_suspension_serializer.rb
@@ -3,6 +3,7 @@ class Species::CitesSuspensionSerializer < ActiveModel::Serializer
     :is_current, :subspecies_info, :nomenclature_note_en, :nomenclature_note_fr,
     :nomenclature_note_es,
     :geo_entity,
+    :applies_to_import,
     :start_notification
 
   def geo_entity

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -12,13 +12,13 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
   def quotas
     Quota.from('api_cites_quotas_view trade_restrictions').
       where("
-            trade_restrictions.taxon_concept_id IN (?)
+            trade_restrictions.taxon_concept_id IN (:object_and_children)
             OR (
-              (trade_restrictions.taxon_concept_id IN (?) OR trade_restrictions.taxon_concept_id IS NULL)
+              (trade_restrictions.taxon_concept_id IN (:ancestors) OR trade_restrictions.taxon_concept_id IS NULL)
               AND trade_restrictions.geo_entity_id IN
-                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = ?)
+                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = :taxon_concept_id)
             )
-      ", object_and_children, ancestors, object.id).
+      ", object_and_children: object_and_children, ancestors: ancestors, taxon_concept_id: object.id).
       select(<<-SQL
               trade_restrictions.notes,
               trade_restrictions.url,
@@ -53,13 +53,14 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
   def cites_suspensions
     CitesSuspension.from('api_cites_suspensions_view trade_restrictions').
       where("
-            trade_restrictions.taxon_concept_id IN (?)
+            trade_restrictions.taxon_concept_id IN (:object_and_children)
             OR (
-              (trade_restrictions.taxon_concept_id IN (?) OR trade_restrictions.taxon_concept_id IS NULL)
+              (trade_restrictions.taxon_concept_id IN (:ancestors) OR trade_restrictions.taxon_concept_id IS NULL)
               AND trade_restrictions.geo_entity_id IN
-                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = ?)
+                (SELECT geo_entity_id FROM distributions WHERE distributions.taxon_concept_id = :taxon_concept_id)
             )
-      ", object_and_children, ancestors, object.id).
+            OR (trade_restrictions.geo_entity_id IS NULL AND trade_restrictions.taxon_concept_id IN (:ancestors))
+      ", object_and_children: object_and_children, ancestors: ancestors, taxon_concept_id: object.id).
       select(<<-SQL
               trade_restrictions.notes,
               trade_restrictions.start_date,

--- a/app/views/admin/cites_suspensions/_form_shared.html.erb
+++ b/app/views/admin/cites_suspensions/_form_shared.html.erb
@@ -17,6 +17,20 @@
   </div>
 
   <div class="control-group">
+    <%= f.label :applies_to_import, "Applies to import into country", :class => 'control-label'%>
+    <div class="controls">
+      <%= f.check_box :applies_to_import %>
+  <span>
+    <a data-placement="right" data-toggle="tooltip" href="#" rel="tooltip"
+      data-original-title="This setting will cascade an 'import' suspension to all descendants of a taxon concept regardless of distribution."
+    >
+      <i class="icon-info-sign"></i>
+    </a>
+  </span>
+    </div>
+  </div>
+
+  <div class="control-group">
     <%= f.label :start_notification_id, "Start notification", :class => 'control-label' %>
     <div class="controls">
       <%= f.select :start_notification_id,

--- a/app/views/admin/cites_suspensions/_list.html.erb
+++ b/app/views/admin/cites_suspensions/_list.html.erb
@@ -18,7 +18,10 @@
       <td><%= suspension.year %></td>
       <td><%= suspension.publication_date_formatted %></td>
       <td><%= true_false_icon(suspension.is_current) %></td>
-      <td><%= suspension.geo_entity && suspension.geo_entity.iso_code2 %></td>
+      <td>
+        <%= '[IMPORT]' if suspension.applies_to_import %>
+        <%= suspension.geo_entity && suspension.geo_entity.iso_code2 %>
+      </td>
       <td><%= suspension.purposes && suspension.purposes.map(&:code).join(', ') %></td>
       <td><%= suspension.terms && suspension.terms.map(&:code).join(', ') %></td>
       <td><%= suspension.sources && suspension.sources.map(&:code).join(', ') %></td>

--- a/app/views/admin/taxon_cites_suspensions/_list.html.erb
+++ b/app/views/admin/taxon_cites_suspensions/_list.html.erb
@@ -17,7 +17,10 @@
       <td><%= suspension.year %></td>
       <td><%= suspension.start_notification && suspension.start_date_formatted %></td>
       <td><%= suspension.end_notification && suspension.end_date_formatted %></td>
-      <td><%= suspension.geo_entity && suspension.geo_entity.name_en %></td>
+      <td>
+        <%= '[IMPORT]' if suspension.applies_to_import %>
+        <%= suspension.geo_entity && suspension.geo_entity.name_en %>
+      </td>
       <td><%= suspension.purposes && suspension.purposes.map(&:code).join(', ') %></td>
       <td><%= suspension.terms && suspension.terms.map(&:code).join(', ') %></td>
       <td><%= suspension.sources && suspension.sources.map(&:code).join(', ') %></td>

--- a/db/migrate/20150518120700_add_applies_to_import_to_trade_restrictions.rb
+++ b/db/migrate/20150518120700_add_applies_to_import_to_trade_restrictions.rb
@@ -1,0 +1,5 @@
+class AddAppliesToImportToTradeRestrictions < ActiveRecord::Migration
+  def change
+    add_column :trade_restrictions, :applies_to_import, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20150518122737_add_applies_to_import_to_api_cites_suspensions_view.rb
+++ b/db/migrate/20150518122737_add_applies_to_import_to_api_cites_suspensions_view.rb
@@ -1,0 +1,11 @@
+class AddAppliesToImportToApiCitesSuspensionsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_cites_suspensions_view"
+    execute "CREATE VIEW api_cites_suspensions_view AS #{view_sql('20150518122737', 'api_cites_suspensions_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_cites_suspensions_view"
+    execute "CREATE VIEW api_cites_suspensions_view AS #{view_sql('20150512124835', 'api_cites_suspensions_view')}"
+  end
+end

--- a/db/migrate/20150518131629_add_higher_taxa_ids_to_api_taxon_concepts_view.rb
+++ b/db/migrate/20150518131629_add_higher_taxa_ids_to_api_taxon_concepts_view.rb
@@ -1,0 +1,11 @@
+class AddHigherTaxaIdsToApiTaxonConceptsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_taxon_concepts_view"
+    execute "CREATE VIEW api_taxon_concepts_view AS #{view_sql('20150518131629', 'api_taxon_concepts_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_taxon_concepts_view"
+    execute "CREATE VIEW api_taxon_concepts_view AS #{view_sql('20150324114546', 'api_taxon_concepts_view')}"
+  end
+end

--- a/db/views/api_cites_suspensions_view/20150518122737.sql
+++ b/db/views/api_cites_suspensions_view/20150518122737.sql
@@ -1,0 +1,72 @@
+SELECT
+  tr.*,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_en,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_en,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_es,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_es,
+  ROW_TO_JSON(
+    ROW(
+      geo_entities.iso_code2,
+      geo_entities.name_fr,
+      geo_entity_types.name
+    )::api_geo_entity
+  ) AS geo_entity_fr,
+  ROW_TO_JSON(
+    ROW(
+      events.name,
+      events.effective_at::DATE,
+      events.url
+    )::api_event
+  ) AS start_notification
+FROM (
+  SELECT * FROM (
+    SELECT tr.*,
+      CASE
+      WHEN tr.taxon_concept_id IS NOT NULL THEN
+        ROW_TO_JSON(
+          ROW(
+            tr.taxon_concept_id,
+            taxon_concepts.full_name,
+            taxon_concepts.author_year,
+            taxon_concepts.data->'rank_name'
+          )::api_taxon_concept
+        )
+      ELSE
+        NULL::JSON
+      END AS taxon_concept
+    FROM (
+      SELECT
+        tr.id,
+        tr.type,
+        tr.taxon_concept_id,
+        tr.notes,
+        tr.start_date::DATE,
+        tr.end_date::DATE,
+        tr.is_current,
+        tr.geo_entity_id,
+        tr.applies_to_import,
+        tr.start_notification_id,
+        tr.end_notification_id,
+        tr.nomenclature_note_en,
+        tr.nomenclature_note_fr,
+        tr.nomenclature_note_es
+      FROM trade_restrictions tr
+      WHERE tr.type IN ('CitesSuspension')
+    ) tr
+    LEFT JOIN taxon_concepts ON taxon_concepts.id = tr.taxon_concept_id
+  ) cites_suspensions_without_taxon_concept
+) tr
+LEFT JOIN geo_entities ON geo_entities.id = tr.geo_entity_id
+LEFT JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN events ON events.id = tr.start_notification_id
+  AND events.type IN ('CitesSuspensionNotification');

--- a/db/views/api_taxon_concepts_view/20150518131629.sql
+++ b/db/views/api_taxon_concepts_view/20150518131629.sql
@@ -1,0 +1,145 @@
+SELECT
+  tc.id,
+  tc.parent_id,
+  taxonomies.name,
+  CASE WHEN taxonomies.name = 'CITES_EU' THEN TRUE ELSE FALSE END AS taxonomy_is_cites_eu,
+  tc.full_name,
+  tc.author_year,
+  'A' AS name_status,
+  ranks.name AS rank,
+  tc.taxonomic_position,
+  tc.listing->'cites_listing' AS cites_listing,
+  tc.data->'kingdom_name' AS kingdom_name,
+  tc.data->'phylum_name' AS phylum_name,
+  tc.data->'class_name' AS class_name,
+  tc.data->'order_name' AS order_name,
+  tc.data->'family_name' AS family_name,
+  tc.data->'genus_name' AS genus_name,
+  tc.data->'kingdom_id' AS kingdom_id,
+  tc.data->'phylum_id' AS phylum_id,
+  tc.data->'class_id' AS class_id,
+  tc.data->'order_id' AS order_id,
+  tc.data->'family_id' AS family_id,
+  tc.data->'subfamily_id' AS subfamily_id,
+  tc.data->'genus_id' AS genus_id,
+  ROW_TO_JSON(
+    ROW(
+      tc.data->'kingdom_name',
+      tc.data->'phylum_name',
+      tc.data->'class_name',
+      tc.data->'order_name',
+      tc.data->'family_name'
+    )::api_higher_taxa
+  ) AS higher_taxa,
+  ARRAY_TO_JSON(
+    ARRAY_AGG_NOTNULL(
+      ROW(
+        synonyms.id, synonyms.full_name, synonyms.author_year, synonyms.data->'rank_name'
+      )::api_taxon_concept
+    )
+  ) AS synonyms,
+  NULL AS accepted_names,
+  tc.created_at,
+  tc.updated_at,
+  TRUE AS active
+FROM taxon_concepts tc
+JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
+JOIN ranks ON ranks.id = tc.rank_id
+LEFT JOIN taxon_relationships tr
+  ON tr.taxon_concept_id = tc.id
+LEFT JOIN taxon_relationship_types trt
+  ON trt.id = tr.taxon_relationship_type_id AND trt.name = 'HAS_SYNONYM'
+LEFT JOIN taxon_concepts synonyms
+  ON synonyms.id = tr.other_taxon_concept_id AND synonyms.taxonomy_id = taxonomies.id
+WHERE tc.name_status = 'A'
+GROUP BY tc.id, tc.parent_id, taxonomies.name, tc.full_name, tc.author_year, ranks.name,
+tc.taxonomic_position,
+tc.created_at, tc.updated_at
+
+UNION ALL
+
+SELECT
+  tc.id,
+  NULL AS parent_id,
+  taxonomies.name,
+  CASE WHEN taxonomies.name = 'CITES_EU' THEN TRUE ELSE FALSE END AS taxonomy_is_cites_eu,
+  tc.full_name,
+  tc.author_year,
+  'S' AS name_status,
+  ranks.name AS rank,
+  NULL AS taxonomic_position,
+  NULL AS cites_listing,
+  NULL AS kingdom_name,
+  NULL AS phylum_name,
+  NULL AS class_name,
+  NULL AS order_name,
+  NULL AS family_name,
+  NULL AS genus_name,
+  NULL AS kingdom_id,
+  NULL AS phylum_id,
+  NULL AS class_id,
+  NULL AS order_id,
+  NULL AS family_id,
+  NULL AS subfamily_id,
+  NULL AS genus_id,
+  NULL::JSON AS higher_taxa,
+  NULL AS synonyms,
+  ARRAY_TO_JSON(
+    ARRAY_AGG_NOTNULL(
+      ROW(
+        accepted_names.id, accepted_names.full_name, accepted_names.author_year, accepted_names.data->'rank_name'
+      )::api_taxon_concept
+    )
+  ) AS accepted_names,
+  tc.created_at,
+  tc.updated_at,
+  TRUE AS active
+FROM taxon_concepts tc
+JOIN taxonomies ON taxonomies.id = tc.taxonomy_id
+JOIN ranks ON ranks.id = tc.rank_id
+JOIN taxon_relationships tr
+  ON tr.other_taxon_concept_id = tc.id
+JOIN taxon_relationship_types trt
+  ON trt.id = tr.taxon_relationship_type_id AND trt.name = 'HAS_SYNONYM'
+JOIN taxon_concepts accepted_names
+  ON accepted_names.id = tr.taxon_concept_id AND accepted_names.taxonomy_id = taxonomies.id
+WHERE tc.name_status = 'S'
+GROUP BY tc.id, tc.parent_id, taxonomies.name, tc.full_name, tc.author_year, ranks.name,
+tc.taxonomic_position,
+tc.created_at, tc.updated_at
+
+UNION ALL
+
+SELECT
+  taxon_concept_id,
+  NULL AS parent_id,
+  taxonomy_name,
+  CASE WHEN taxonomy_name = 'CITES_EU' THEN TRUE ELSE FALSE END AS taxonomy_is_cites_eu,
+  full_name,
+  author_year,
+  name_status,
+  rank_name,
+  NULL AS taxonomic_position,
+  NULL AS cites_listing,
+  NULL AS kingdom_name,
+  NULL AS phylum_name,
+  NULL AS class_name,
+  NULL AS order_name,
+  NULL AS family_name,
+  NULL AS genus_name,
+  NULL AS kingdom_id,
+  NULL AS phylum_id,
+  NULL AS class_id,
+  NULL AS order_id,
+  NULL AS family_id,
+  NULL AS subfamily_id,
+  NULL AS genus_id,
+  NULL::JSON AS higher_taxa,
+  NULL AS synonyms,
+  NULL AS accepted_names,
+  created_at,
+  created_at,
+  FALSE AS active -- deleted taxa
+  FROM taxon_concept_versions
+  WHERE event = 'destroy' AND name_status IN ('A', 'S')
+;

--- a/spec/models/cites_suspension_spec.rb
+++ b/spec/models/cites_suspension_spec.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 require 'spec_helper'

--- a/spec/models/quota_spec.rb
+++ b/spec/models/quota_spec.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 require 'spec_helper'

--- a/spec/models/trade_restriction_spec.rb
+++ b/spec/models/trade_restriction_spec.rb
@@ -23,10 +23,11 @@
 #  original_id                 :integer
 #  updated_by_id               :integer
 #  created_by_id               :integer
-#  nomenclature_note_en        :text
 #  internal_notes              :text
+#  nomenclature_note_en        :text
 #  nomenclature_note_es        :text
 #  nomenclature_note_fr        :text
+#  applies_to_import           :boolean          default(FALSE), not null
 #
 
 require 'spec_helper'


### PR DESCRIPTION
This ensures that:
* CITES suspensions defined at higher taxonomic levels without geo entity cascade to descendants; for example, a suspension for family Cetaceae (no geo entity) should cascade to _Eubalaena australis_ and show up in S+ in the suspensions section
* CITES suspensions defined with "applies_to_import" flag set cascade to descendants regardless of their distribution; for example, a suspension for family Rhinocerotidae (Australia, import) should cascade to _Diceros bicornis_ and show up in S+ in the suspensions section with an 'import' tag

Requires `rake db:migrate`