### PR TITLE
Elibrary viewer role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,8 +57,4 @@ class ApplicationController < ActionController::Base
     admin_root_path
   end
 
-  def verify_manager
-    redirect_to signed_in_root_path(current_user),
-      :alert => "You are not authorized to access the trade admin page" unless current_user.is_admin?
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,23 +7,23 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     rescue_path = if request.referrer && request.referrer != request.url
                     request.referer
-                  elsif current_user.is_api?
-                    root_path
-                  else
+                  elsif current_user.is_manager_or_contributor?
                     signed_in_root_path(current_user)
+                  else
+                    root_path
                   end
 
-    redirect_to rescue_path, 
-      :alert => if current_user.is_api?
-                  "You must log out of Species+ API before you can log into this site"
-                else
-                  case exception.action
-                    when :destroy
-                      "You are not authorized to destroy that record"
-                    else
-                      exception.message
-                  end
+    redirect_to rescue_path,
+      alert:  if current_user.is_manager_or_contributor?
+                case exception.action
+                  when :destroy
+                    "You are not authorised to destroy that record"
+                  else
+                    exception.message
                 end
+              else
+                "You are not authorised to access this page"
+              end
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
     rescue_path = if request.referrer && request.referrer != request.url
                     request.referer
                   elsif current_user.is_manager_or_contributor?
-                    signed_in_root_path(current_user)
+                    admin_root_path
                   else
                     root_path
                   end
@@ -49,12 +49,17 @@ class ApplicationController < ActionController::Base
     }
   end
 
-  def after_sign_out_path_for(resource_or_scope)
-    admin_root_path
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) ||
+      if resource.is_manager_or_contributor?
+        admin_root_path
+      else
+        super
+      end
   end
 
-  def signed_in_root_path(resource_or_scope)
-    admin_root_path
+  def after_sign_out_path_for(scope)
+    request.referrer
   end
 
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -23,6 +23,14 @@ class RegistrationsController < Devise::RegistrationsController
 
   private
 
+  def after_update_path_for(resource)
+    if resource.is_manager_or_contributor?
+      admin_root_path
+    else
+      super
+    end
+  end
+
   # check if we need password to update user data
   # ie if password or email was changed
   # extend this as needed

--- a/app/controllers/trade_controller.rb
+++ b/app/controllers/trade_controller.rb
@@ -5,6 +5,12 @@ class TradeController < ApplicationController
 
   private
 
+  def verify_manager
+    unless current_user.is_manager?
+      redirect_to signed_in_root_path(current_user)
+    end
+  end
+
   def search_params
     (params[:filters] || params).permit(
       {:taxon_concepts_ids => []},

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -51,12 +51,8 @@ class Ability
         Trade::Shipment, Trade::Permit, Trade::AnnualReportUpload,
         Trade::ValidationRule
       ]
-    elsif user.is_elibrary_user?
+    elsif !user.is_manager_or_contributor?
       cannot :manage, :all
-      can :read, Document
-    elsif user.is_api_user?
-      cannot :manage, :all
-      can :read, Document, is_public: true
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,7 +31,7 @@ class Ability
 
     user ||= User.new
 
-    if user.is_admin?
+    if user.is_manager?
       can :manage, :all
     elsif user.is_contributor?
       can [:autocomplete, :read], :all
@@ -51,9 +51,12 @@ class Ability
         Trade::Shipment, Trade::Permit, Trade::AnnualReportUpload,
         Trade::ValidationRule
       ]
-    elsif user.is_api?
+    elsif user.is_elibrary_user?
       cannot :manage, :all
+      can :read, Document
+    elsif user.is_api_user?
+      cannot :manage, :all
+      can :read, Document, is_public: true
     end
-    
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,19 @@ class User < ActiveRecord::Base
     :remember_me, :role, :terms_and_conditions, :is_cites_authority,
     :organisation, :geo_entity_id
 
+  MANAGER = 'admin'
+  CONTRIBUTOR = 'default' # nonsense
+  ELIBRARY_USER = 'elibrary'
+  API_USER = 'api'
+  ROLES = [MANAGER, CONTRIBUTOR, ELIBRARY_USER, API_USER]
+  NON_ADMIN_ROLES = [ELIBRARY_USER, API_USER]
+  ROLES_FOR_DISPLAY = {
+    MANAGER => 'Manager',
+    CONTRIBUTOR => 'Contributor',
+    ELIBRARY_USER => 'E-library User',
+    API_USER => 'API User'
+  }
+
   has_many :ahoy_visits, dependent: :nullify, class_name: 'Ahoy::Visit'
   has_many :ahoy_events, dependent: :nullify, class_name: 'Ahoy::Event'
   has_many :api_requests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,8 +51,7 @@ class User < ActiveRecord::Base
 
   validates :email, :uniqueness => true, :presence => true
   validates :name, :presence => true
-  validates :role, inclusion: { in: ['default', 'admin', 'api'] },
-                   presence: true
+  validates :role, inclusion: { in: ROLES }, presence: true
   validates :organisation, presence: true
   before_create :set_default_role
 
@@ -69,14 +68,7 @@ class User < ActiveRecord::Base
   end
 
   def role_for_display
-    case self.role
-    when 'default'
-      "Contributor"
-    when 'admin'
-      "Manager"
-    when 'api'
-      "API User"
-    end
+    ROLES_FOR_DISPLAY[self.role] || '(empty)'
   end
 
   def last_30_days_api_requests

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,16 +55,24 @@ class User < ActiveRecord::Base
   validates :organisation, presence: true
   before_create :set_default_role
 
+  def is_manager?
+    self.role == MANAGER
+  end
+
   def is_contributor?
-    self.role == 'default'
+    self.role == CONTRIBUTOR
   end
 
-  def is_admin?
-    self.role == 'admin'
+  def is_elibrary_user?
+    self.role == ELIBRARY_USER
   end
 
-  def is_api?
-    self.role == 'api'
+  def is_api_user?
+    self.role == API_USER
+  end
+
+  def is_manager_or_contributor?
+    is_manager? || is_contributor?
   end
 
   def role_for_display

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.text_field :email %>
     </div>
   </div>
-  <% if @user.new_record? || @user == current_user || current_user.is_admin? %>
+  <% if @user.new_record? || @user == current_user || current_user.is_manager? %>
     <div class="control-group">
       <label class="control-label">Password</label>
       <div class="controls">
@@ -49,7 +49,7 @@
       %>
     </div>
   </div>
-  <% if current_user.is_admin? %>
+  <% if current_user.is_manager? %>
     <div class="control-group">
       <label class="control-label">Role</label>
       <div class="controls">

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -53,9 +53,7 @@
     <div class="control-group">
       <label class="control-label">Role</label>
       <div class="controls">
-        <%= f.select :role,
-          [["Contributor", "default"],["Manager", "admin"],["API User", "api"]]
-        %>
+        <%= f.select :role, User::ROLES_FOR_DISPLAY.to_a.map(&:reverse) %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_topbar.html.erb
+++ b/app/views/shared/_topbar.html.erb
@@ -5,20 +5,16 @@
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </a>
-    <% if current_user && current_user.is_api? %>
-      <%= link_to "Species+ Admin", api_dashboard_path, :class => "brand" %>
-    <% else %>
+    <% if current_user %>
       <%= link_to "Species+ Admin", admin_root_path, :class => "brand" %>
     <% end %>
     <div class="nav-collapse">
       <ul class="nav">
-        <% if current_user && current_user.is_api? %>
-          <li class="<%= if controller_name == 'taxon_concepts' then 'active' end%>"><a href="/api/dashboard">Home</a></li>
-        <% else %>
+        <% if current_user %>
           <li class="<%= if controller_name == 'taxon_concepts' then 'active' end%>"><a href="/admin">Home</a></li>
         <% end %>
         
-        <% if current_user && current_user.is_admin? %>
+        <% if current_user && current_user.is_manager? %>
           <% controller_matches = ["taxonomies", "ranks", "designations", "change_types",
               "species_listings", "geo_entities", "languages", "tags", "purposes", "sources",
               "terms", "units"] %>
@@ -133,11 +129,11 @@
           </li>
         <% end %>
 
-        <% if current_user && !current_user.is_api? %>
+        <% if current_user %>
           <li class="<%= if controller_name == 'references' then 'active' end%>"><%= link_to 'References', admin_references_path %></li>
         <% end %>
 
-        <% if current_user && current_user.is_admin? %>
+        <% if current_user && current_user.is_manager? %>
           <% controller_matches = ["cites_suspensions"] %>
           <li class="dropdown <%= if controller_matches.include?(controller_name) then 'active' end %>">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -163,31 +159,29 @@
             </ul>
           </li>
         <% end %>
+        
+        <% if current_user && current_user.is_manager_or_contributor? %>
+          <% controller_matches = ["exports"] %>
+          <li class="dropdown <%= if controller_matches.include?(controller_name) then 'active' end %>">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+              Stats & Downloads
+              <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+              <li><%= link_to 'Data Downloads', admin_exports_path %></li>
+              <li><%= link_to 'Species DB Statistics', admin_stats_path %></li>
+              <li><%= link_to 'Trade DB Statistics', trade_stats_path %></li>
+              <li><%= link_to 'IUCN Taxon Mapping', admin_iucn_mappings_path %></li>
+              <li><%= link_to 'CMS Taxon Mapping', admin_cms_mappings_path %></li>
+              <li><%= link_to 'Species+ Events Tracking', admin_ahoy_events_path %></li>
+              <li><%= link_to 'Species+ Visits Tracking', admin_ahoy_visits_path %></li>
+              <li><%= link_to 'Species+ Activity Page', activities_path %></li>
 
-        <% controller_matches = ["exports"] %>
-        <li class="dropdown <%= if controller_matches.include?(controller_name) then 'active' end %>">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-            Stats & Downloads
-            <b class="caret"></b>
-          </a>
-          <ul class="dropdown-menu">
-            <li><%= link_to 'Data Downloads', admin_exports_path %></li>
-            <li><%= link_to 'Species DB Statistics', admin_stats_path %></li>
-            <li><%= link_to 'Trade DB Statistics', trade_stats_path %></li>
-            <li><%= link_to 'IUCN Taxon Mapping', admin_iucn_mappings_path %></li>
-            <li><%= link_to 'CMS Taxon Mapping', admin_cms_mappings_path %></li>
-            <li><%= link_to 'Species+ Events Tracking', admin_ahoy_events_path %></li>
-            <li><%= link_to 'Species+ Visits Tracking', admin_ahoy_visits_path %></li>
-            <li><%= link_to 'Species+ Activity Page', activities_path %></li>
-
-            <% if current_user && current_user.is_admin? %>
-              <li><%= link_to 'API Usage', api_usage_overview_path %></li>
-            <% end %>
-          </ul>
-        </li>
-        <% if user_signed_in? and current_user.is_api? %>
-          <li><%= link_to 'API Documentation', apipie_apipie_path %></li>
-          <li><a href="#">API Tokens</a></li>
+              <% if current_user && current_user.is_manager? %>
+                <li><%= link_to 'API Usage', api_usage_overview_path %></li>
+              <% end %>
+            </ul>
+          </li>
         <% end %>
         <% if user_signed_in? %>
           <li class="dropdown">
@@ -197,7 +191,7 @@
             <ul class="dropdown-menu">
               <li><%= link_to "Log out #{current_user.name}", destroy_user_session_path, :method => :delete %></li>
               <li><%= link_to "Account", edit_user_registration_path(current_user) %></li>
-              <% if current_user.is_admin? %>
+              <% if current_user.is_manager? %>
                 <li><%= link_to 'Manage Users', admin_users_path %></li>
               <% end %>
             </ul>

--- a/spec/controllers/admin/taxon_concepts_controller_spec.rb
+++ b/spec/controllers/admin/taxon_concepts_controller_spec.rb
@@ -93,6 +93,22 @@ describe Admin::TaxonConceptsController do
     end
   end
 
+  describe "when E-library Viewer" do
+    login_elibrary_viewer
+    let(:taxon_concept) { create(:taxon_concept) }
+
+    it "redirects to root path" do
+      get :index
+      response.should redirect_to(root_path)
+    end
+
+    it "redirects to root path and doesn't delete" do
+      delete :destroy, :id => taxon_concept.id
+      response.should redirect_to(root_path)
+      TaxonConcept.where(:id => taxon_concept.id).size.should == 1
+    end
+  end
+
   describe "XHR GET JSON autocomplete" do
     let!(:taxon_concept){
       create(:taxon_concept,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     email { "#{name}@test.pl" }
     password 'asdfasdf'
     password_confirmation { password }
-    role 'admin'
+    role User::MANAGER
     is_cites_authority false
     organisation 'WCMC'
   end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     filename { Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec', 'support', 'annual_report_upload_exporter.csv')) }
     event
     type 'Document'
+    is_public false
 
     factory :review_of_significant_trade, class: Document::ReviewOfSignificantTrade do
       type 'Document::ReviewOfSignificantTrade'

--- a/spec/integration/login_spec.rb
+++ b/spec/integration/login_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe "Home page", type: :request do
+  it "redirects Data Manager to admin root path" do
+    user = create(:user, role: User::MANAGER)
+    post "/users/sign_in", user: {email: user.email, password: user.password}
+    assert_redirected_to admin_root_path
+  end
+  it "redirects Data Contributor to admin root path" do
+    user = create(:user, role: User::CONTRIBUTOR)
+    post "/users/sign_in", user: {email: user.email, password: user.password}
+    assert_redirected_to admin_root_path
+  end
+  it "redirects E-library Viewer to public root path" do
+    user = create(:user, role: User::ELIBRARY_USER)
+    post "/users/sign_in", user: {email: user.email, password: user.password}
+    assert_redirected_to root_path
+  end
+  it "redirects API User to public root path" do
+    user = create(:user, role: User::API_USER)
+    post "/users/sign_in", user: {email: user.email, password: user.password}
+    assert_redirected_to root_path
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,8 +48,6 @@ describe User do
   describe "abilities" do
     subject(:ability){ Ability.new(user) }
     let(:user){ nil }
-    let(:private_document){ create(:document, is_public: false) }
-    let(:public_document){ create(:document, is_public: true) }
 
     context "when is a Data Manager" do
       let(:user){ create(:user, role: User::MANAGER) }
@@ -66,20 +64,12 @@ describe User do
 
     context "when is a E-library Viewer" do
       let(:user){ create(:user, role: User::ELIBRARY_USER) }
-      it{ should_not be_able_to(:create, Document) }
-      it{ should_not be_able_to(:update, Document) }
-      it{ should_not be_able_to(:destroy, Document) }
-      it{ should be_able_to(:read, private_document) }
-      it{ should be_able_to(:read, public_document) }
+      it{ should_not be_able_to(:manage, TaxonConcept) }
     end
 
     context "when is an API User" do
       let(:user){ create(:user, role: User::API_USER) }
-      it{ should_not be_able_to(:create, Document) }
-      it{ should_not be_able_to(:update, Document) }
-      it{ should_not be_able_to(:destroy, Document) }
-      it{ should_not be_able_to(:read, private_document) }
-      it{ should be_able_to(:read, public_document) }
+      it{ should_not be_able_to(:manage, TaxonConcept) }
     end
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,14 +2,21 @@ module ControllerMacros
   def login_admin
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      sign_in @user || FactoryGirl.create(:user)
+      sign_in @user || FactoryGirl.create(:user, role: User::MANAGER)
     end
   end
 
   def login_contributor
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      sign_in FactoryGirl.create(:user, role: 'default')
+      sign_in FactoryGirl.create(:user, role: User::CONTRIBUTOR)
+    end
+  end
+
+  def login_elibrary_viewer
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sign_in FactoryGirl.create(:user, role: User::ELIBRARY_USER)
     end
   end
 end


### PR DESCRIPTION
Adds a new role for E-library Viewers. Those are users who after login will be able to access all documents in the S+ documents search / documents tab on Taxon Concept page. Users who are not logged in as well as API users should not be able to access documents where `is_public=false`

For now there is no logic around access to documents in place, but the workflows of signing in / signing out are prepared for the new user role when login / logout functionality is added to S+. Atm the "admin login page" can be used to log in as an E-library Viewer for testing purposes (to log out you need to e.g. delete the session cookie in the browser)