### PR TITLE
E-library document import scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /rdoc
 /log/*.log
 /tmp
+/private
 /public/system
 /public/downloads/*.pdf
 #LaTeX

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -48,13 +48,18 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
 
   def show
     @document = Document.find(params[:id])
-    send_file(
-      @document.filename.path,
-        :filename => File.basename(@document.filename.path),
-        :type => @document.filename.content_type,
-        :disposition => 'attachment',
-        :url_based_filename => true
-    )
+    path_to_file = @document.filename.path;
+    if !File.exists?(path_to_file)
+      render :file => "#{Rails.root}/public/404.html", :status => 404
+    else
+      send_file(
+        path_to_file,
+          :filename => File.basename(path_to_file),
+          :type => @document.filename.content_type,
+          :disposition => 'attachment',
+          :url_based_filename => true
+      )
+    end
   end
 
   protected

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -46,6 +46,17 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
     end
   end
 
+  def show
+    @document = Document.find(params[:id])
+    send_file(
+      @document.filename.path,
+        :filename => File.basename(@document.filename.path),
+        :type => @document.filename.content_type,
+        :disposition => 'attachment',
+        :url_based_filename => true
+    )
+  end
+
   protected
 
   def collection

--- a/app/models/cites_ac.rb
+++ b/app/models/cites_ac.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 # Cites Animal Committee

--- a/app/models/cites_cop.rb
+++ b/app/models/cites_cop.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class CitesCop < Event

--- a/app/models/cites_extraordinary_meeting.rb
+++ b/app/models/cites_extraordinary_meeting.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class CitesExtraordinaryMeeting < Event

--- a/app/models/cites_pc.rb
+++ b/app/models/cites_pc.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 # Cites Plant Committee

--- a/app/models/cites_suspension_notification.rb
+++ b/app/models/cites_suspension_notification.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class CitesSuspensionNotification < Event

--- a/app/models/cites_tc.rb
+++ b/app/models/cites_tc.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 # Cites Tech Committee

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document < ActiveRecord::Base

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -64,7 +64,7 @@ class Document < ActiveRecord::Base
   end
 
   def set_title
-    if title.blank? && filename_changed?
+    if title.blank? && filename_changed? && filename.file
       self.title = filename.file.filename.sub(/.\w+$/, '').humanize
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -29,7 +29,8 @@ class Document < ActiveRecord::Base
     :order_within_rank => "documents.date, documents.title, documents.id"
   track_who_does_it
   attr_accessible :event_id, :filename, :date, :type, :title, :is_public,
-    :language_id, :citations_attributes, :number
+    :language_id, :citations_attributes, :number,
+    :sort_index, :discussion_id, :discussion_sort_index
   belongs_to :event
   belongs_to :language
   has_many :citations, class_name: 'DocumentCitation', dependent: :destroy

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document < ActiveRecord::Base

--- a/app/models/document/agenda_items.rb
+++ b/app/models/document/agenda_items.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::AgendaItems < Document

--- a/app/models/document/agenda_items.rb
+++ b/app/models/document/agenda_items.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::AgendaItems < Document

--- a/app/models/document/commission_notes.rb
+++ b/app/models/document/commission_notes.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::CommissionNotes < Document

--- a/app/models/document/commission_notes.rb
+++ b/app/models/document/commission_notes.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::CommissionNotes < Document

--- a/app/models/document/detailed_summary_of_conclusions.rb
+++ b/app/models/document/detailed_summary_of_conclusions.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::DetailedSummaryOfConclusions < Document

--- a/app/models/document/detailed_summary_of_conclusions.rb
+++ b/app/models/document/detailed_summary_of_conclusions.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::DetailedSummaryOfConclusions < Document

--- a/app/models/document/list_of_participants.rb
+++ b/app/models/document/list_of_participants.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::ListOfParticipants < Document

--- a/app/models/document/list_of_participants.rb
+++ b/app/models/document/list_of_participants.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::ListOfParticipants < Document

--- a/app/models/document/meeting_agenda.rb
+++ b/app/models/document/meeting_agenda.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::MeetingAgenda < Document

--- a/app/models/document/meeting_agenda.rb
+++ b/app/models/document/meeting_agenda.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::MeetingAgenda < Document

--- a/app/models/document/ndf_consultation.rb
+++ b/app/models/document/ndf_consultation.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::NdfConsultation < Document

--- a/app/models/document/ndf_consultation.rb
+++ b/app/models/document/ndf_consultation.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::NdfConsultation < Document

--- a/app/models/document/non_detriment_findings.rb
+++ b/app/models/document/non_detriment_findings.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::NonDetrimentFindings < Document

--- a/app/models/document/non_detriment_findings.rb
+++ b/app/models/document/non_detriment_findings.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::NonDetrimentFindings < Document

--- a/app/models/document/proposal.rb
+++ b/app/models/document/proposal.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::Proposal < Document

--- a/app/models/document/proposal.rb
+++ b/app/models/document/proposal.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::Proposal < Document

--- a/app/models/document/range_state_consultation_letter.rb
+++ b/app/models/document/range_state_consultation_letter.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::RangeStateConsultationLetter < Document

--- a/app/models/document/range_state_consultation_letter.rb
+++ b/app/models/document/range_state_consultation_letter.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::RangeStateConsultationLetter < Document

--- a/app/models/document/review_of_significant_trade.rb
+++ b/app/models/document/review_of_significant_trade.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::ReviewOfSignificantTrade < Document

--- a/app/models/document/review_of_significant_trade.rb
+++ b/app/models/document/review_of_significant_trade.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::ReviewOfSignificantTrade < Document

--- a/app/models/document/short_summary_of_conclusions.rb
+++ b/app/models/document/short_summary_of_conclusions.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::ShortSummaryOfConclusions < Document

--- a/app/models/document/short_summary_of_conclusions.rb
+++ b/app/models/document/short_summary_of_conclusions.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::ShortSummaryOfConclusions < Document

--- a/app/models/document/unep_wcmc_report.rb
+++ b/app/models/document/unep_wcmc_report.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 class Document::UnepWcmcReport < Document

--- a/app/models/document/unep_wcmc_report.rb
+++ b/app/models/document/unep_wcmc_report.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 class Document::UnepWcmcReport < Document

--- a/app/models/document_citation.rb
+++ b/app/models/document_citation.rb
@@ -17,6 +17,7 @@ class DocumentCitation < ActiveRecord::Base
   has_many :taxon_concepts, through: :document_citation_taxon_concepts
   has_many :document_citation_geo_entities, dependent: :destroy
   has_many :geo_entities, through: :document_citation_geo_entities
+  belongs_to :document
 
   # the following two amazing methods are here to handle input from select2
   # which in case of ajax populated multiple selects comes as a comma sep list

--- a/app/models/document_citation.rb
+++ b/app/models/document_citation.rb
@@ -2,12 +2,13 @@
 #
 # Table name: document_citations
 #
-#  id            :integer          not null, primary key
-#  document_id   :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id             :integer          not null, primary key
+#  document_id    :integer
+#  created_by_id  :integer
+#  updated_by_id  :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  elib_legacy_id :integer
 #
 
 class DocumentCitation < ActiveRecord::Base

--- a/app/models/document_tag.rb
+++ b/app/models/document_tag.rb
@@ -3,7 +3,7 @@
 # Table name: document_tags
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :text             not null
 #  type       :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/document_tag/discussion.rb
+++ b/app/models/document_tag/discussion.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: document_tags
+#
+#  id         :integer          not null, primary key
+#  name       :text             not null
+#  type       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class DocumentTag::Discussion < DocumentTag
+
+  def self.display_name; 'Discussion'; end
+
+end

--- a/app/models/document_tag/proposal_outcome.rb
+++ b/app/models/document_tag/proposal_outcome.rb
@@ -3,7 +3,7 @@
 # Table name: document_tags
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :text             not null
 #  type       :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/document_tag/review_phase.rb
+++ b/app/models/document_tag/review_phase.rb
@@ -3,7 +3,7 @@
 # Table name: document_tags
 #
 #  id         :integer          not null, primary key
-#  name       :string(255)
+#  name       :text             not null
 #  type       :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/ec_srg.rb
+++ b/app/models/ec_srg.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 # European Commission Scientific Review Group

--- a/app/models/eu_council_regulation.rb
+++ b/app/models/eu_council_regulation.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class EuCouncilRegulation < Event

--- a/app/models/eu_implementing_regulation.rb
+++ b/app/models/eu_implementing_regulation.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class EuImplementingRegulation < Event

--- a/app/models/eu_regulation.rb
+++ b/app/models/eu_regulation.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class EuRegulation < Event

--- a/app/models/eu_suspension_regulation.rb
+++ b/app/models/eu_suspension_regulation.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class EuSuspensionRegulation < Event

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 class Event < ActiveRecord::Base

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -39,7 +39,7 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_white_list
-    %w(jpg jpeg gif png bmp tif tiff ppt pptx xls xlsx rtf txt doc docx pdf)
+    %w(jpg jpeg gif png bmp tif tiff ppt pptx xls xlsx rtf txt doc docx pdf csv tsv odt ods odp)
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -13,7 +13,7 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "#{Rails.root}/private/elibrary/documents/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
@@ -38,9 +38,9 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_white_list
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_white_list
+    %w(jpg jpeg gif png bmp tif tiff ppt pptx xls xlsx rtf txt doc docx pdf)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/document_file_uploader.rb
+++ b/app/uploaders/document_file_uploader.rb
@@ -16,6 +16,10 @@ class DocumentFileUploader < CarrierWave::Uploader::Base
     "#{Rails.root}/private/elibrary/documents/#{model.id}"
   end
 
+  def cache_dir
+    "#{Rails.root}/tmp/private/elibrary/documents/cache/#{model.id}"
+  end
+
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -15,8 +15,14 @@
           options_for_select(
             @events.map { |l| [l.name, l.id] },
             @document.event_id
-          )
+          ), include_blank: true
         %>
+      </div>
+    </div>
+    <div class="control-group">
+      <%= f.label :sort_index, class: 'control-label' %>
+      <div class="controls">
+        <%= f.text_field :sort_index %>
       </div>
     </div>
   <% end %>
@@ -118,6 +124,24 @@
 
     <% end %>
   <% end %>
+
+  <div class="control-group">
+    <%= f.label :discussion_id, class: 'control-label' %>
+    <div class="controls">
+      <%= f.select :discussion_id,
+        options_for_select(DocumentTag::Discussion.order(:name).map { |d| [d.name, d.id] },
+          @document.discussion_id),
+          {include_blank: true, style: 'width: 220px'}
+      %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label :discussion_sort_index, class: 'control-label' %>
+    <div class="controls">
+      <%= f.text_field :discussion_sort_index %>
+    </div>
+  </div>
 
   <div class="control-group">
     <%= f.label :citations, class: 'control-label' %>

--- a/app/views/admin/documents/_list.html.erb
+++ b/app/views/admin/documents/_list.html.erb
@@ -21,7 +21,7 @@
       <% unless @event %>
         <td><%= link_to document.event.name, admin_event_documents_path(document.event) if document.event %></td>
       <% end %>
-      <td><%= link_to document.title, document.becomes(Document).filename.url, {
+      <td><%= link_to document.title, admin_document_url(document), {
         rel: 'tooltip', :'data-title' => document.becomes(Document).filename.url
       } %></td>
       <td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ SAPI::Application.routes.draw do
     resources :cites_extraordinary_meetings
 
     resource :document_batch, :only => [:new, :create]
-    resources :documents, :only => [:index, :create, :edit, :update, :destroy]
+    resources :documents
 
     resources :cites_suspension_notifications
     resources :references, :only => [:index, :create, :update, :destroy] do

--- a/db/migrate/20150714075603_add_fields_to_documents.rb
+++ b/db/migrate/20150714075603_add_fields_to_documents.rb
@@ -1,0 +1,13 @@
+class AddFieldsToDocuments < ActiveRecord::Migration
+  def change
+    exexute 'DROP VIEW documents_view'
+    rename_column :documents, :legacy_id, :elib_legacy_id
+    add_column :documents, :sort_index, :integer
+    add_column :documents, :primary_language_document_id, :integer
+    add_column :documents, :elib_legacy_file_name, :text
+    add_column :documents, :elib_legacy_file_path, :text
+    add_foreign_key :documents, :documents, name: 'documents_primary_language_document_id_fk',
+      column: 'primary_language_document_id'
+    execute "CREATE VIEW documents_view AS #{view_sql('20141223141125', 'documents_view')}"
+  end
+end

--- a/db/migrate/20150714075603_add_fields_to_documents.rb
+++ b/db/migrate/20150714075603_add_fields_to_documents.rb
@@ -5,7 +5,6 @@ class AddFieldsToDocuments < ActiveRecord::Migration
     add_column :documents, :sort_index, :integer
     add_column :documents, :primary_language_document_id, :integer
     add_column :documents, :elib_legacy_file_name, :text
-    add_column :documents, :elib_legacy_file_path, :text
     add_foreign_key :documents, :documents, name: 'documents_primary_language_document_id_fk',
       column: 'primary_language_document_id'
     execute "CREATE VIEW documents_view AS #{view_sql('20141223141125', 'documents_view')}"

--- a/db/migrate/20150714075603_add_fields_to_documents.rb
+++ b/db/migrate/20150714075603_add_fields_to_documents.rb
@@ -1,6 +1,6 @@
 class AddFieldsToDocuments < ActiveRecord::Migration
   def change
-    exexute 'DROP VIEW documents_view'
+    execute 'DROP VIEW documents_view'
     rename_column :documents, :legacy_id, :elib_legacy_id
     add_column :documents, :sort_index, :integer
     add_column :documents, :primary_language_document_id, :integer

--- a/db/migrate/20150717152937_add_elib_legacy_id_to_document_citations.rb
+++ b/db/migrate/20150717152937_add_elib_legacy_id_to_document_citations.rb
@@ -1,0 +1,5 @@
+class AddElibLegacyIdToDocumentCitations < ActiveRecord::Migration
+  def change
+    add_column :document_citations, :elib_legacy_id, :integer
+  end
+end

--- a/db/migrate/20150721121640_add_original_id_to_documents.rb
+++ b/db/migrate/20150721121640_add_original_id_to_documents.rb
@@ -1,0 +1,6 @@
+class AddOriginalIdToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :original_id, :integer
+    add_foreign_key(:documents, :documents, column: :original_id, dependent: :nullify)
+  end
+end

--- a/db/migrate/20150723141854_change_document_tag_name_to_text.rb
+++ b/db/migrate/20150723141854_change_document_tag_name_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeDocumentTagNameToText < ActiveRecord::Migration
+  def up
+    change_column :document_tags, :name, :text, null: false
+  end
+
+  def down
+    change_column :document_tags, :name, :string
+  end
+end

--- a/db/migrate/20150723142812_add_discussion_id_and_sort_order_to_documents.rb
+++ b/db/migrate/20150723142812_add_discussion_id_and_sort_order_to_documents.rb
@@ -1,0 +1,6 @@
+class AddDiscussionIdAndSortOrderToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :discussion_id, :integer
+    add_column :documents, :discussion_sort_index, :integer
+  end
+end

--- a/lib/tasks/elibrary/citations_cop_importer.rb
+++ b/lib/tasks/elibrary/citations_cop_importer.rb
@@ -100,7 +100,7 @@ class Elibrary::CitationsCopImporter < Elibrary::CitationsImporter
 
     sql = <<-SQL
       UPDATE documents
-      SET title = pd.proposal_nature
+      SET title = COALESCE(title, pd.proposal_nature)
       FROM
       proposal_details pd
       WHERE documents.id = pd.document_id;

--- a/lib/tasks/elibrary/citations_cop_importer.rb
+++ b/lib/tasks/elibrary/citations_cop_importer.rb
@@ -86,17 +86,26 @@ class Elibrary::CitationsCopImporter < Elibrary::CitationsImporter
     SQL
     ActiveRecord::Base.connection.execute(sql)
     # in case you need to revert
-    WITH new_docs AS (
-      SELECT * FROM documents WHERE original_id IS NOT NULL
-    ), proposals AS (
-      UPDATE proposal_details
-      SET document_id = d.original_id
-      FROM proposal_details pd
-      JOIN new_docs d ON pd.document_id = d.id
-      WHERE proposal_details.id = pd.id
-    )
-    DELETE FROM documents
-    WHERE original_id IS NOT NULL;
+    # WITH new_docs AS (
+    #   SELECT * FROM documents WHERE original_id IS NOT NULL
+    # ), proposals AS (
+    #   UPDATE proposal_details
+    #   SET document_id = d.original_id
+    #   FROM proposal_details pd
+    #   JOIN new_docs d ON pd.document_id = d.id
+    #   WHERE proposal_details.id = pd.id
+    # )
+    # DELETE FROM documents
+    # WHERE original_id IS NOT NULL;
+
+    sql = <<-SQL
+      UPDATE documents
+      SET title = pd.proposal_nature
+      FROM
+      proposal_details pd
+      WHERE documents.id = pd.document_id;
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
   end
 
   def run_queries

--- a/lib/tasks/elibrary/citations_cop_importer.rb
+++ b/lib/tasks/elibrary/citations_cop_importer.rb
@@ -100,7 +100,7 @@ class Elibrary::CitationsCopImporter < Elibrary::CitationsImporter
 
     sql = <<-SQL
       UPDATE documents
-      SET title = COALESCE(title, pd.proposal_nature)
+      SET title = COALESCE(pd.proposal_nature, title)
       FROM
       proposal_details pd
       WHERE documents.id = pd.document_id;
@@ -131,7 +131,7 @@ class Elibrary::CitationsCopImporter < Elibrary::CitationsImporter
   # but in the new system it is document-level
   def all_proposal_details_rows_sql
     <<-SQL
-      SELECT DocumentID, ProposalNature, ProposalOutcome, ProposalRepresentation
+      SELECT CAST(DocumentID AS INT), ProposalNature, ProposalOutcome, ProposalRepresentation
       FROM #{table_name}
       GROUP BY DocumentID, ProposalNature, ProposalOutcome, ProposalRepresentation
     SQL

--- a/lib/tasks/elibrary/citations_cop_importer.rb
+++ b/lib/tasks/elibrary/citations_cop_importer.rb
@@ -1,0 +1,80 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+require Rails.root.join('lib/tasks/elibrary/citations_importer.rb')
+
+class Elibrary::CitationsCopImporter < Elibrary::CitationsImporter
+
+  def columns_with_type
+    super() + [
+      ['ProposalNo', 'TEXT'],
+      ['ProposalNature', 'TEXT'],
+      ['ProposalOutcome', 'TEXT'],
+      ['ProposalAdditionalComments', 'TEXT'],
+      ['ProposalHardCopy', 'TEXT'],
+      ['ProposalRepresentation', 'TEXT'],
+      ['ProposalOtherTaxonName', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+    super()
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET ProposalNature = NULL WHERE ProposalNature='NULL'" )
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET ProposalOutcome = NULL WHERE ProposalOutcome='NULL'" )
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET ProposalRepresentation = NULL WHERE ProposalRepresentation='NULL'" )
+  end
+
+  def run_queries
+    super()
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{proposal_details_rows_to_insert_sql}
+      ), rows_to_insert_resolved AS (
+        SELECT *, outcomes.id AS proposal_outcome_id, documents.id AS document_id
+        FROM rows_to_insert
+        JOIN documents ON DocumentID = documents.elib_legacy_id
+        LEFT JOIN document_tags outcomes ON BTRIM(UPPER(outcomes.name)) = BTRIM(UPPER(ProposalOutcome))
+      )
+      INSERT INTO proposal_details(document_id, proposal_outcome_id, proposal_nature, representation, created_at, updated_at)
+      SELECT document_id, proposal_outcome_id, ProposalNature, ProposalRepresentation, NOW(), NOW()
+      FROM rows_to_insert_resolved
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  # this performs grouping, the proposal meta data used to be citation-level
+  # but in the new system it is document-level
+  def all_proposal_details_rows_sql
+    <<-SQL
+      SELECT DocumentID, ProposalNature, ProposalOutcome, ProposalRepresentation
+      FROM #{table_name}
+      GROUP BY DocumentID, ProposalNature, ProposalOutcome, ProposalRepresentation
+    SQL
+  end
+
+  # this might return more than 1 row per DocumentID
+  # it will lead to inserting multiple proposal_details records per document
+  # that is not expected in the new structure; to work around the problem
+  # after the import documents with multiple details will need to be duplicated
+  def proposal_details_rows_to_insert_sql
+    sql = <<-SQL
+      SELECT * FROM (
+        #{all_proposal_details_rows_sql}
+      ) all_rows_in_table_name
+      WHERE ProposalNature IS NOT NULL
+        OR ProposalOutcome IS NOT NULL
+        OR ProposalRepresentation IS NOT NULL
+      EXCEPT
+      SELECT
+        d.elib_legacy_id,
+        dd.proposal_nature,
+        outcomes.name,
+        dd.representation
+      FROM (
+        #{all_rows_sql}
+      ) nc
+      JOIN documents d ON d.elib_legacy_id = nc.DocumentID
+      JOIN proposal_details dd ON d.id = dd.document_id
+      JOIN document_tags outcomes ON dd.proposal_outcome_id = outcomes.id
+    SQL
+  end
+
+end

--- a/lib/tasks/elibrary/citations_importer.rb
+++ b/lib/tasks/elibrary/citations_importer.rb
@@ -1,0 +1,152 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::CitationsImporter
+  include Elibrary::Importable
+
+  def initialize(file_name)
+    @file_name = file_name
+    @file_name =~ /citations_(.+)\.csv$/
+    @document_group = $1
+  end
+
+  def table_name; :"elibrary_citations_#{@document_group}_import"; end
+
+  def columns_with_type
+    [
+      ['EventTypeID', 'TEXT'],
+      ['EventTypeName', 'TEXT'],
+      ['splus_event_type', 'TEXT'],
+      ['EventID', 'INT'],
+      ['EventName', 'TEXT'],
+      ['EventDate', 'TEXT'],
+      ['MeetingType', 'TEXT'],
+      ['EventDocumentReference', 'TEXT'],
+      ['DocumentOrder', 'TEXT'],
+      ['DocumentTypeID', 'TEXT'],
+      ['DocumentTypeName', 'TEXT'],
+      ['splus_document_type', 'TEXT'],
+      ['DocumentID', 'INT'],
+      ['DocumentTitle', 'TEXT'],
+      ['supertitle', 'TEXT'],
+      ['subtitle', 'TEXT'],
+      ['DocumentDate', 'TEXT'],
+      ['DocumentFileName', 'TEXT'],
+      ['DocumentFilePath', 'TEXT'],
+      ['DocumentIsPubliclyAccessible', 'TEXT'],
+      ['DateCreated', 'TEXT'],
+      ['DateModified', 'TEXT'],
+      ['LanguageName', 'TEXT'],
+      ['DocumentIsTranslationIntoEnglish', 'TEXT'],
+      ['CitationID', 'INT'],
+      ['CtyRecID', 'TEXT'],
+      ['CtyShort', 'TEXT'],
+      ['CtyISO2', 'TEXT'],
+      ['SpeciesID', 'TEXT'],
+      ['SpeciesName', 'TEXT'],
+      ['splus_taxon_concept_id', 'INT'],
+      ['CtyShortCombined', 'TEXT'],
+      ['SpeciesNameCombined', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET CtyISO2 = NULL WHERE CtyISO2='NULL'" )
+  end
+
+  def run_queries
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{rows_to_insert_sql}
+      ), rows_to_insert_resolved AS (
+        SELECT
+        d.id AS document_id,
+        CitationID,
+        geo_entities.id AS geo_entity_id,
+        splus_taxon_concept_id
+        FROM rows_to_insert
+        JOIN documents d ON d.elib_legacy_id = rows_to_insert.DocumentID
+        JOIN geo_entities ON UPPER(BTRIM(geo_entities.iso_code2)) = UPPER(BTRIM(rows_to_insert.CtyISO2))
+      ), inserted_citations AS (
+        INSERT INTO document_citations (
+          document_id,
+          elib_legacy_id,
+          created_at,
+          updated_at
+        )
+        SELECT
+          rows_to_insert_resolved.document_id,
+          CitationID,
+          NOW(),
+          NOW()
+        FROM rows_to_insert_resolved
+        RETURNING *
+      ), inserted_citations_geo_entity AS (
+        INSERT INTO document_citation_geo_entities (
+          document_citation_id,
+          geo_entity_id
+        )
+        SELECT
+          inserted_citations.id,
+          geo_entity_id
+        FROM rows_to_insert_resolved
+        JOIN inserted_citations ON inserted_citations.elib_legacy_id = rows_to_insert_resolved.CitationID
+      )
+      INSERT INTO document_citation_taxon_concepts (
+        document_citation_id,
+        taxon_concept_id
+      )
+      SELECT
+        inserted_citations.id,
+        splus_taxon_concept_id
+      FROM rows_to_insert_resolved
+      JOIN inserted_citations ON inserted_citations.elib_legacy_id = rows_to_insert_resolved.CitationID
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def all_rows_sql
+    columns = %w(DocumentID CitationID CtyISO2 splus_taxon_concept_id)
+    "SELECT #{columns.join(', ')} FROM #{table_name} t"
+  end
+
+  def rows_to_insert_sql
+    sql = <<-SQL
+      SELECT * FROM (
+        #{all_rows_sql}
+      ) all_rows_in_table_name
+      WHERE CtyISO2 IS NOT NULL
+        AND splus_taxon_concept_id IS NOT NULL
+      EXCEPT
+      SELECT
+        d.elib_legacy_id,
+        c.elib_legacy_id,
+        geo_entities.iso_code2,
+        c_tc.taxon_concept_id
+      FROM (
+        #{all_rows_sql}
+      ) nc
+      JOIN document_citations c ON c.elib_legacy_id = nc.CitationID
+      JOIN documents d ON c.document_id = d.id
+      JOIN document_citation_geo_entities c_g ON c_g.document_citation_id = d.id
+      JOIN geo_entities ON geo_entities.id = c_g.geo_entity_id
+      JOIN document_citation_taxon_concepts c_tc ON c_tc.document_citation_id = d.id
+    SQL
+  end
+
+  def print_pre_import_stats
+    print_citations_breakdown
+    print_query_counts
+  end
+
+  def print_post_import_stats
+    print_citations_breakdown
+  end
+
+  def print_citations_breakdown
+    puts "#{Time.now} There are #{DocumentCitation.count} citations in total"
+    DocumentCitation.includes(:document).group('documents.type').order('documents.type').count.each do |type, count|
+      puts "\t #{type} #{count}"
+    end
+  end
+
+end

--- a/lib/tasks/elibrary/citations_importer.rb
+++ b/lib/tasks/elibrary/citations_importer.rb
@@ -133,16 +133,7 @@ class Elibrary::CitationsImporter
     SQL
   end
 
-  def print_pre_import_stats
-    print_citations_breakdown
-    print_query_counts
-  end
-
-  def print_post_import_stats
-    print_citations_breakdown
-  end
-
-  def print_citations_breakdown
+  def print_breakdown
     puts "#{Time.now} There are #{DocumentCitation.count} citations in total"
     DocumentCitation.includes(:document).group('documents.type').order('documents.type').count.each do |type, count|
       puts "\t #{type} #{count}"

--- a/lib/tasks/elibrary/citations_ndf_importer.rb
+++ b/lib/tasks/elibrary/citations_ndf_importer.rb
@@ -1,0 +1,11 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::CitationsNdfImporter < Elibrary::CitationsImporter
+
+  def columns_with_type
+    super() + [
+      ['NDFSource', 'TEXT']
+    ]
+  end
+
+end

--- a/lib/tasks/elibrary/citations_no_event_importer.rb
+++ b/lib/tasks/elibrary/citations_no_event_importer.rb
@@ -1,0 +1,45 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::CitationsNoEventImporter < Elibrary::CitationsImporter
+
+  def columns_with_type
+    super() + [
+      ['ProposalNo', 'TEXT'],
+      ['ProposalNature', 'TEXT'],
+      ['ProposalOutcome', 'TEXT'],
+      ['ProposalAdditionalComments', 'TEXT'],
+      ['ProposalHardCopy', 'TEXT'],
+      ['ProposalRepresentation', 'TEXT'],
+      ['ProposalOtherTaxonName', 'TEXT'],
+      ['NDFSource', 'TEXT'],
+      ['SigTradePhase', 'TEXT'],
+      ['SigTradeProcessStage', 'TEXT'],
+      ['SigTradeDocumentNumber', 'TEXT'],
+      ['SigTradeIntroduced', 'TEXT'],
+      ['SigTradeMeeting1', 'TEXT'],
+      ['SigTradeACMeetingDate1', 'TEXT'],
+      ['SigTradeMeeting2', 'TEXT'],
+      ['SigTradeCommitteeFirstDiscussed', 'TEXT'],
+      ['SigTradeSignificantTradeReviewFor', 'TEXT'],
+      ['SigTradeRegion1', 'TEXT'],
+      ['SigTradeRegion2', 'TEXT'],
+      ['SigTradeRegion3', 'TEXT'],
+      ['SigTradeURL', 'TEXT'],
+      ['SigTradeURL2', 'TEXT'],
+      ['SigTradeHardCopyLocation', 'TEXT'],
+      ['SigTradeFileName', 'TEXT'],
+      ['SigTradePages', 'TEXT'],
+      ['SigTradeLanguage', 'TEXT'],
+      ['SigTradeIUCNConservationStatus', 'TEXT'],
+      ['SigTradeIUCNConservationStatusCriteria', 'TEXT'],
+      ['SigTradeAssessorsOfIUCNStatus', 'TEXT'],
+      ['SigTradeDateOfIUCNAssessment', 'TEXT'],
+      ['SigTradeRecommendedCategory', 'TEXT'],
+      ['SigTradeNotes', 'TEXT'],
+      ['SigTradeOtherDocumentInformation', 'TEXT'],
+      ['SigTradeInitials', 'TEXT'],
+      ['SigTradeTaxonID', 'TEXT']
+    ]
+  end
+
+end

--- a/lib/tasks/elibrary/citations_rst_importer.rb
+++ b/lib/tasks/elibrary/citations_rst_importer.rb
@@ -1,0 +1,101 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::CitationsRstImporter < Elibrary::CitationsImporter
+
+  def columns_with_type
+    super() + [
+      ['SigTradePhase', 'TEXT'],
+      ['SigTradeProcessStage', 'TEXT'],
+      ['SigTradeDocumentNumber', 'TEXT'],
+      ['SigTradeIntroduced', 'TEXT'],
+      ['SigTradeMeeting1', 'TEXT'],
+      ['SigTradeACMeetingDate1', 'TEXT'],
+      ['SigTradeMeeting2', 'TEXT'],
+      ['SigTradeCommitteeFirstDiscussed', 'TEXT'],
+      ['SigTradeSignificantTradeReviewFor', 'TEXT'],
+      ['SigTradeRegion1', 'TEXT'],
+      ['SigTradeRegion2', 'TEXT'],
+      ['SigTradeRegion3', 'TEXT'],
+      ['SigTradeURL', 'TEXT'],
+      ['SigTradeURL2', 'TEXT'],
+      ['SigTradeHardCopyLocation', 'TEXT'],
+      ['SigTradeFileName', 'TEXT'],
+      ['SigTradePages', 'TEXT'],
+      ['SigTradeLanguage', 'TEXT'],
+      ['SigTradeIUCNConservationStatus', 'TEXT'],
+      ['SigTradeIUCNConservationStatusCriteria', 'TEXT'],
+      ['SigTradeAssessorsOfIUCNStatus', 'TEXT'],
+      ['SigTradeDateOfIUCNAssessment', 'TEXT'],
+      ['SigTradeRecommendedCategory', 'TEXT'],
+      ['SigTradeNotes', 'TEXT'],
+      ['SigTradeOtherDocumentInformation', 'TEXT'],
+      ['SigTradeInitials', 'TEXT'],
+      ['SigTradeTaxonID', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+    super()
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET SigTradePhase = NULL WHERE SigTradePhase='NULL'" )
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET SigTradeProcessStage = NULL WHERE SigTradeProcessStage='NULL'" )
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET SigTradeRecommendedCategory = NULL WHERE SigTradeRecommendedCategory='NULL'" )
+  end
+
+  def run_queries
+    super()
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{review_details_rows_to_insert_sql}
+      ), rows_to_insert_resolved AS (
+        SELECT *, phases.id AS review_phase_id, stages.id AS process_stage_id, documents.id AS document_id
+        FROM rows_to_insert
+        JOIN documents ON DocumentID = documents.elib_legacy_id
+        LEFT JOIN document_tags phases ON BTRIM(UPPER(phases.name)) = BTRIM(UPPER(SigTradeReviewPhase))
+        LEFT JOIN document_tags stages ON BTRIM(UPPER(stages.name)) = BTRIM(UPPER(SigTradeProcessStage))
+      )
+      INSERT INTO review_details(document_id, review_phase_id, process_stage_id, recommended_category, created_at, updated_at)
+      SELECT document_id, review_phase_id, process_stage_id, SigTradeRecommendedCategory, NOW(), NOW()
+      FROM rows_to_insert_resolved
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  # this performs grouping, the review meta data used to be citation-level
+  # but in the new system it is document-level
+  def all_review_details_rows_sql
+    <<-SQL
+      SELECT DocumentID, SigTradePhase, SigTradeProcessStage, SigTradeRecommendedCategory
+      FROM #{table_name}
+      GROUP BY DocumentID, SigTradePhase, SigTradeProcessStage, SigTradeRecommendedCategory
+    SQL
+  end
+
+  # this might return more than 1 row per DocumentID
+  # it will lead to inserting multiple review_details records per document
+  # that is not expected in the new structure; to work around the problem
+  # after the import documents with multiple details will need to be duplicated
+  def review_details_rows_to_insert_sql
+    sql = <<-SQL
+      SELECT * FROM (
+        #{all_proposal_details_rows_sql}
+      ) all_rows_in_table_name
+      WHERE SigTradePhase IS NOT NULL
+        OR SigTradeProcessStage IS NOT NULL
+        OR SigTradeRecommendedCategory IS NOT NULL
+      EXCEPT
+      SELECT
+        d.elib_legacy_id,
+        phases.name,
+        stages.name,
+        dd.recommended_category
+      FROM (
+        #{all_rows_sql}
+      ) nc
+      JOIN documents d ON d.elib_legacy_id = nc.DocumentID
+      JOIN review_details dd ON d.id = dd.document_id
+      JOIN document_tags phases ON dd.review_phase_id = phases.id AND phases.type = 'DocumentTag::ReviewPhase'
+      JOIN document_tags stages ON dd.process_stage_id = stages.id AND stages.type = 'DocumentTag::ProcessStage'
+    SQL
+  end
+
+end

--- a/lib/tasks/elibrary/citations_rst_importer.rb
+++ b/lib/tasks/elibrary/citations_rst_importer.rb
@@ -50,7 +50,7 @@ class Elibrary::CitationsRstImporter < Elibrary::CitationsImporter
         SELECT *, phases.id AS review_phase_id, stages.id AS process_stage_id, documents.id AS document_id
         FROM rows_to_insert
         JOIN documents ON DocumentID = documents.elib_legacy_id
-        LEFT JOIN document_tags phases ON BTRIM(UPPER(phases.name)) = BTRIM(UPPER(SigTradeReviewPhase))
+        LEFT JOIN document_tags phases ON BTRIM(UPPER(phases.name)) = BTRIM(UPPER(SigTradePhase))
         LEFT JOIN document_tags stages ON BTRIM(UPPER(stages.name)) = BTRIM(UPPER(SigTradeProcessStage))
       )
       INSERT INTO review_details(document_id, review_phase_id, process_stage_id, recommended_category, created_at, updated_at)
@@ -77,7 +77,7 @@ class Elibrary::CitationsRstImporter < Elibrary::CitationsImporter
   def review_details_rows_to_insert_sql
     sql = <<-SQL
       SELECT * FROM (
-        #{all_proposal_details_rows_sql}
+        #{all_review_details_rows_sql}
       ) all_rows_in_table_name
       WHERE SigTradePhase IS NOT NULL
         OR SigTradeProcessStage IS NOT NULL

--- a/lib/tasks/elibrary/document_discussions_importer.rb
+++ b/lib/tasks/elibrary/document_discussions_importer.rb
@@ -1,0 +1,103 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::DocumentDiscussionsImporter
+  include Elibrary::Importable
+
+  def initialize(file_name)
+    @file_name = file_name
+  end
+
+  def table_name; :"elibrary_document_discussions_import"; end
+
+  def columns_with_type
+    [
+      ['EventTypeName', 'TEXT'],
+      ['EventName', 'TEXT'],
+      ['EventDate', 'TEXT'],
+      ['DocumentTypeName', 'TEXT'],
+      ['DocumentID', 'INT'],
+      ['DocumentTitle', 'TEXT'],
+      ['DocumentFilePath', 'TEXT'],
+      ['DocumentFileName', 'TEXT'],
+      ['DocumentDate', 'TEXT'],
+      ['DiscussionID', 'INT'],
+      ['DocumentOrder', 'TEXT'],
+      ['DiscussionTitle', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+    ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentOrder = NULL WHERE DocumentOrder='NULL'" )
+  end
+
+  def run_queries
+    # insert missing discussions
+    sql = <<-SQL
+      WITH missing_discussions AS (
+        SELECT DISTINCT DiscussionTitle FROM #{table_name}
+        EXCEPT
+        SELECT name FROM document_tags WHERE type='DocumentTag::Discussion'
+      )
+      INSERT INTO document_tags (name, type, created_at, updated_at)
+      SELECT DiscussionTitle, 'DocumentTag::Discussion', NOW(), NOW()
+      FROM missing_discussions;
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+
+    # update documents
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{rows_to_insert_sql}
+      )
+      UPDATE documents
+      SET discussion_id = t.discussion_id, discussion_sort_index = t.DocumentOrder
+      FROM rows_to_insert t
+      WHERE documents.id = t.id;
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def all_rows_sql
+    sql = <<-SQL
+      SELECT
+        DocumentID,
+        CAST(DocumentOrder AS INT) AS DocumentOrder,
+        DiscussionTitle
+      FROM #{table_name}
+    SQL
+  end
+
+  def rows_to_insert_sql
+    sql = <<-SQL
+      SELECT
+      d.id AS id,
+      DocumentOrder,
+      dd.id AS discussion_id
+      FROM (
+        SELECT * FROM (
+          #{all_rows_sql}
+        ) all_rows_in_table_name
+        EXCEPT
+        SELECT
+          d.elib_legacy_id,
+          d.discussion_sort_index,
+          dd.name
+        FROM (
+          #{all_rows_sql}
+        ) nd
+        JOIN documents d ON d.elib_legacy_id = nd.DocumentID
+        JOIN document_tags dd ON dd.id = d.discussion_id
+      ) rows_to_insert
+      JOIN documents d ON d.elib_legacy_id = rows_to_insert.DocumentID
+      JOIN document_tags dd ON UPPER(BTRIM(dd.name)) = UPPER(BTRIM(DiscussionTitle))
+    SQL
+  end
+
+  def print_breakdown
+    puts <<-EOT
+      #{Time.now} There are #{Document.where('discussion_id IS NOT NULL').count} documents
+      in #{DocumentTag.where(type: 'DocumentTag::Discussion').count} discussions in total
+    EOT
+  end
+
+end

--- a/lib/tasks/elibrary/document_files_importer.rb
+++ b/lib/tasks/elibrary/document_files_importer.rb
@@ -1,0 +1,40 @@
+require 'fileutils'
+# The purpose of this is to go over all document records and match them
+# with respective files.
+# Where files are present, create the expected directory structure, e.g.
+# /private/elibrary/documents/1/filename
+# Where files are missing, generate a report.
+# source_dir is the path to the directory with flat file structure
+# target dir is the path to the /private/elibrary
+class Elibrary::DocumentFilesImporter
+  def initialize(source_dir, target_dir)
+    @source_dir = source_dir
+    @target_dir = target_dir
+  end
+
+  def copy_with_path(src, dst)
+    FileUtils.mkdir_p(File.dirname(dst))
+    FileUtils.cp(src, dst)
+  end
+
+  def run
+    total = Document.count
+    Document.order(:type, :date).select([:id, :elib_legacy_file_name]).each_with_index do |doc, idx|
+      info_txt = "#{doc.filename} (#{idx} of #{total})"
+      target_location = @target_dir + "/documents/#{doc.id}/#{doc.elib_legacy_file_name}"
+      # check if file exists at target location
+      if File.exists?(target_location)
+        puts "TARGET PRESENT #{target_location}" + info_txt
+        next
+      end
+      source_location = @source_dir + "/#{doc.elib_legacy_file_name}"
+      # check if file exists at source location
+      unless File.exists?(source_location)
+        puts "SOURCE MISSING #{source_location}" + info_txt
+        next
+      end
+      copy_with_path(source_location, target_location)
+      puts "COPIED " + info_txt
+    end
+  end
+end

--- a/lib/tasks/elibrary/documents_import.rake
+++ b/lib/tasks/elibrary/documents_import.rake
@@ -1,0 +1,160 @@
+require Rails.root.join('lib/tasks/elibrary/helpers.rb')
+namespace 'elibrary:documents' do
+
+  def import_table; :elibrary_documents_import; end
+
+  def all_rows_in_import_table_sql
+    sql = <<-SQL
+      SELECT
+        EventID,
+        CASE WHEN DocumentOrder = 'NULL' THEN NULL ELSE DocumentOrder END,
+        BTRIM(splus_document_type) AS splus_document_type,
+        DocumentID,
+        BTRIM(DocumentTitle) AS DocumentTitle,
+        CAST(DocumentDate AS DATE) AS DocumentDate,
+        BTRIM(DocumentFileName) AS DocumentFileName,
+        BTRIM(DocumentFilePath) AS DocumentFilePath,
+        CASE WHEN DocumentIsPubliclyAccessible = 1 THEN TRUE ELSE FALSE END AS DocumentIsPubliclyAccessible,
+        CASE WHEN LanguageName = 'Unspecified' THEN NULL ELSE LanguageName END AS LanguageName,
+        MasterDocumentID
+      FROM #{import_table}
+    SQL
+  end
+
+  def rows_to_insert_sql
+    sql = <<-SQL
+      SELECT * FROM (
+        #{all_rows_in_import_table_sql}
+      ) all_rows_in_import_table
+      EXCEPT
+      SELECT
+        e.elib_legacy_id,
+        d.sort_index,
+        d.type,
+        d.elib_legacy_id,
+        d.title,
+        d.date,
+        d.elib_legacy_file_name,
+        d.elib_legacy_file_path,
+        d.is_public,
+        lng.name_en,
+        d.primary_language_document_id
+      FROM (
+        #{all_rows_in_import_table_sql}
+      ) nd
+      JOIN documents d ON d.elib_legacy_id = nd.DocumentID
+      JOIN events e ON e.id = d.event_id
+      JOIN languages lng ON lng.id = document.language_id
+    SQL
+  end
+
+  def print_documents_breakdown
+    puts "#{Time.now} There are #{Document.count} documents in total"
+    Document.group(:type).order(:type).count.each do |type, count|
+      puts "\t #{type} #{count}"
+    end
+  end
+
+  def print_pre_import_stats
+    queries = {'rows_in_import_file' => "SELECT COUNT(*) FROM #{import_table}"}
+    queries['rows_to_insert'] = "SELECT COUNT(*) FROM (#{rows_to_insert_sql}) t"
+    queries.each do |q_name, q|
+      res = ActiveRecord::Base.connection.execute(q)
+      puts "#{res[0]['count']} #{q_name.humanize}"
+    end
+  end
+
+  desc 'Import documents from csv file'
+  task :import => :environment do |task_name|
+    check_file_provided(task_name)
+    drop_table_if_exists(import_table)
+    columns_with_type = [
+      ['EventTypeID', 'INT'],
+      ['EventTypeName', 'TEXT'],
+      ['splus_event_type', 'TEXT'],
+      ['EventID', 'INT'],
+      ['EventName', 'TEXT'],
+      ['EventDate', 'TEXT'],
+      ['MeetingType', 'TEXT'],
+      ['EventDocumentReference', 'TEXT'],
+      ['DocumentOrder', 'TEXT'],
+      ['DocumentTypeID', 'INT'],
+      ['DocumentTypeName', 'TEXT'],
+      ['splus_document_type', 'TEXT'],
+      ['DocumentID', 'INT'],
+      ['DocumentTitle', 'TEXT'],
+      ['supertitle', 'TEXT'],
+      ['subtitle', 'TEXT'],
+      ['DocumentDate', 'TEXT'],
+      ['DocumentFileName', 'TEXT'],
+      ['DocumentFilePath', 'TEXT'],
+      ['DocumentIsPubliclyAccessible', 'TEXT'],
+      ['DateCreated', 'TEXT'],
+      ['DateModified', 'TEXT'],
+      ['LanguageName', 'TEXT'],
+      ['DocumentIsTranslationIntoEnglish', 'TEXT'],
+      ['MasterDocumentID', 'INT']
+    ]
+    create_table_from_column_array(
+      import_table, columns_with_type.map{ |ct| ct.join(' ') }
+    )
+    copy_from_csv(
+      ENV['FILE'], import_table, columns_with_type.map{ |ct| ct.first }
+    )
+
+    print_documents_breakdown
+    print_pre_import_stats
+
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{rows_to_insert_sql}
+      ), rows_to_insert_resolved AS (
+        SELECT rows_to_insert.*,
+        events.id AS event_id,
+        DocumentOrder,
+        splus_document_type,
+        DocumentID,
+        DocumentTitle,
+        DocumentDate,
+        DocumentFileName,
+        DocumentFilePath,
+        DocumentIsPubliclyAccessible,
+        lng.id AS language_id
+        FROM rows_to_insert
+        JOIN events e ON e.elib_legacy_id = rows_to_insert.EventID
+        JOIN languages lng ON lng.name_en = rows_to_insert.LanguageName
+      ), inserted_rows AS (
+        INSERT INTO "documents" (
+          event_id,
+          sort_index,
+          type,
+          elib_legacy_id,
+          title,
+          date,
+          elib_legacy_file_name,
+          elib_legacy_file_path,
+          is_public,
+          language_id
+        )
+        SELECT
+          rows_to_insert_resolved.*,
+          NOW(),
+          NOW()
+        FROM rows_to_insert_resolved
+      ), rows_to_insert_with_master_document_id AS (
+        SELECT documents.id, master_documents.id AS primary_language_document_id
+        FROM rows_to_insert
+        JOIN documents ON documents.elib_legacy_id = rows_to_insert.DocumentID
+        JOIN documents master_documents ON master_documents.elib_legacy_id = rows_to_insert.MasterDocumentID
+      )
+      -- now resolve the self-reference to master document
+      UPDATE documents
+      SET primary_language_document_id = rows_to_insert_with_master_document_id.primary_language_document_id
+      FROM rows_to_insert_with_master_document_id
+      WHERE rows_to_insert_with_master_document_id.id = documents.id
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+
+    print_documents_breakdown
+  end
+end

--- a/lib/tasks/elibrary/documents_importer.rb
+++ b/lib/tasks/elibrary/documents_importer.rb
@@ -55,7 +55,6 @@ class Elibrary::DocumentsImporter
         DocumentDate,
         DocumentFileName AS filename,
         DocumentFileName,
-        DocumentFilePath,
         DocumentIsPubliclyAccessible,
         lng.id AS language_id
         FROM rows_to_insert
@@ -110,7 +109,6 @@ class Elibrary::DocumentsImporter
           ELSE COALESCE(CAST(DocumentDate AS DATE), CAST(EventDate AS DATE))
         END AS DocumentDate,
         BTRIM(DocumentFileName) AS DocumentFileName,
-        REGEXP_REPLACE(BTRIM(DocumentFilePath), BTRIM(DocumentFileName) || '$','') AS DocumentFilePath,
         CASE WHEN BTRIM(DocumentIsPubliclyAccessible) = '1' THEN TRUE ELSE FALSE END AS DocumentIsPubliclyAccessible,
         CASE WHEN LanguageName = 'Unspecified' THEN NULL ELSE LanguageName END AS LanguageName,
         MasterDocumentID

--- a/lib/tasks/elibrary/documents_importer.rb
+++ b/lib/tasks/elibrary/documents_importer.rb
@@ -154,16 +154,7 @@ class Elibrary::DocumentsImporter
     SQL
   end
 
-  def print_pre_import_stats
-    print_documents_breakdown
-    print_query_counts
-  end
-
-  def print_post_import_stats
-    print_documents_breakdown
-  end
-
-  def print_documents_breakdown
+  def print_breakdown
     puts "#{Time.now} There are #{Document.count} documents in total"
     Document.group(:type).order(:type).count.each do |type, count|
       puts "\t #{type} #{count}"

--- a/lib/tasks/elibrary/events_importer.rb
+++ b/lib/tasks/elibrary/events_importer.rb
@@ -127,16 +127,7 @@ class Elibrary::EventsImporter
     SQL
   end
 
-  def print_pre_import_stats
-    print_events_breakdown
-    print_query_counts
-  end
-
-  def print_post_import_stats
-    print_events_breakdown
-  end
-
-  def print_events_breakdown
+  def print_breakdown
     puts "#{Time.now} There are #{Event.count} events in total"
     Event.group(:type).order(:type).count.each do |type, count|
       puts "\t #{type} #{count}"

--- a/lib/tasks/elibrary/events_importer.rb
+++ b/lib/tasks/elibrary/events_importer.rb
@@ -7,20 +7,6 @@ class Elibrary::EventsImporter
     @file_name = file_name
   end
 
-  def run
-    drop_table_if_exists(table_name)
-    create_table_from_column_array(
-      table_name, columns_with_type.map{ |ct| ct.join(' ') }
-    )
-    copy_from_csv(
-      @file_name, table_name, columns_with_type.map{ |ct| ct.first }
-    )
-    run_preparatory_queries
-    print_pre_import_stats
-    run_queries
-    print_post_import_stats
-  end
-
   def table_name; :elibrary_events_import; end
 
   def columns_with_type

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -24,4 +24,13 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :users do
+    require Rails.root.join('lib/tasks/elibrary/users_importer.rb')
+    desc 'Import users from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::UsersImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
 end

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -15,4 +15,13 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :documents do
+    require Rails.root.join('lib/tasks/elibrary/documents_importer.rb')
+    desc 'Import documents from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::DocumentsImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
 end

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -24,6 +24,15 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :document_discussions do
+    require Rails.root.join('lib/tasks/elibrary/document_discussions_importer.rb')
+    desc 'Import document discussions'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::DocumentDiscussionsImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
   namespace :document_files do
     require Rails.root.join('lib/tasks/elibrary/document_files_importer.rb')
     desc 'Import document files'

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -24,6 +24,17 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :document_files do
+    require Rails.root.join('lib/tasks/elibrary/document_files_importer.rb')
+    desc 'Import document files'
+    task :import => :environment do |task_name|
+      if ENV['SOURCE_DIR'].blank? || ENV['TARGET_DIR'].blank?
+        fail "Usage: SOURCE_DIR=/abs/path/to/dir TARGET_DIR=/abs/path/to/dir rake elibrary:import:#{task_name}"
+      end
+      importer = Elibrary::DocumentFilesImporter.new(ENV['SOURCE_DIR'], ENV['TARGET_DIR'])
+      importer.run
+    end
+  end
   namespace :users do
     require Rails.root.join('lib/tasks/elibrary/users_importer.rb')
     desc 'Import users from csv file'

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -60,6 +60,15 @@ namespace :elibrary do
       importer.run
     end
   end
+    namespace :citations_no_event do
+    require Rails.root.join('lib/tasks/elibrary/citations_no_event_importer.rb')
+    desc 'Import citations from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsNoEventImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
   namespace :citations do
     require Rails.root.join('lib/tasks/elibrary/citations_importer.rb')
     desc 'Import citations from csv file'

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -33,4 +33,40 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :citations_cop do
+    require Rails.root.join('lib/tasks/elibrary/citations_cop_importer.rb')
+    desc 'Import citations & proposal details from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsCopImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
+  namespace :citations_rst do
+    require Rails.root.join('lib/tasks/elibrary/citations_rst_importer.rb')
+    desc 'Import citations & review details from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsRstImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
+  namespace :citations_ndf do
+    require Rails.root.join('lib/tasks/elibrary/citations_ndf_importer.rb')
+    desc 'Import citations from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsNdfImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
+  namespace :citations do
+    require Rails.root.join('lib/tasks/elibrary/citations_importer.rb')
+    desc 'Import citations from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
 end

--- a/lib/tasks/elibrary/importable.rb
+++ b/lib/tasks/elibrary/importable.rb
@@ -1,6 +1,20 @@
 module Elibrary
   module Importable
 
+    def run
+      drop_table_if_exists(table_name)
+      create_table_from_column_array(
+        table_name, columns_with_type.map{ |ct| ct.join(' ') }
+      )
+      copy_from_csv(
+        @file_name, table_name, columns_with_type.map{ |ct| ct.first }
+      )
+      run_preparatory_queries
+      print_pre_import_stats
+      run_queries
+      print_post_import_stats
+    end
+
     def drop_table_if_exists(table_name)
       ActiveRecord::Base.connection.execute "DROP TABLE IF EXISTS #{table_name} CASCADE"
       puts "Table removed"

--- a/lib/tasks/elibrary/importable.rb
+++ b/lib/tasks/elibrary/importable.rb
@@ -49,5 +49,16 @@ module Elibrary
         puts "#{res[0]['count']} #{q_name.humanize}"
       end
     end
+
+    def print_breakdown; end
+
+    def print_pre_import_stats
+      print_breakdown
+      print_query_counts
+    end
+
+    def print_post_import_stats
+      print_breakdown
+    end
   end
 end

--- a/lib/tasks/elibrary/users_importer.rb
+++ b/lib/tasks/elibrary/users_importer.rb
@@ -35,7 +35,7 @@ class Elibrary::UsersImporter
               WHEN RoleName = 'Full Viewer' THEN 3
             END
           )
-        FROM elibrary_users_import
+        FROM #{table_name}
       )
       DELETE FROM #{table_name} t
       USING users_with_roles

--- a/lib/tasks/elibrary/users_importer.rb
+++ b/lib/tasks/elibrary/users_importer.rb
@@ -119,16 +119,7 @@ class Elibrary::UsersImporter
     SQL
   end
 
-  def print_pre_import_stats
-    print_users_breakdown
-    print_query_counts
-  end
-
-  def print_post_import_stats
-    print_users_breakdown
-  end
-
-  def print_users_breakdown
+  def print_breakdown
     puts "#{Time.now} There are #{User.count} users in total"
     User.group(:role).order(:role).count.each do |role, count|
       puts "\t #{role} #{count}"

--- a/lib/tasks/elibrary/users_importer.rb
+++ b/lib/tasks/elibrary/users_importer.rb
@@ -1,0 +1,138 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::UsersImporter
+  include Elibrary::Importable
+
+  def initialize(file_name)
+    @file_name = file_name
+  end
+
+  def table_name; :"elibrary_users_import"; end
+
+  def columns_with_type
+    [
+      ['LoweredUserName', 'TEXT'],
+      ['LoweredEmail', 'TEXT'],
+      ['RoleName', 'TEXT'],
+      ['CreateDate', 'TEXT'],
+      ['LastLoginDate', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+    # delete public viewers
+    ActiveRecord::Base.connection.execute("DELETE FROM #{table_name} WHERE RoleName = 'Public Viewer'")
+
+    # only keep 1 highest priority role per user
+    sql = <<-SQL
+      WITH users_with_roles AS (
+        SELECT *,
+          ROW_NUMBER() OVER (
+            PARTITION BY LoweredUserName
+            ORDER BY CASE
+              WHEN RoleName = 'Administrator' THEN 1
+              WHEN RoleName = 'Data Contributor' THEN 2
+              WHEN RoleName = 'Full Viewer' THEN 3
+            END
+          )
+        FROM elibrary_users_import
+      )
+      DELETE FROM #{table_name} t
+      USING users_with_roles
+      WHERE t.LoweredUserNAme = users_with_roles.LoweredUserName
+      AND t.RoleName = users_with_roles.RoleName
+      AND row_number > 1
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def run_queries
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{rows_to_insert_sql}
+      )
+      INSERT INTO "users" (email, name, role, geo_entity_id, created_at, updated_at)
+        SELECT
+        email,
+        name,
+        splus_role,
+        splus_geo_entity_id,
+        NOW(),
+        NOW()
+      FROM rows_to_insert
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def all_rows_sql
+    sql = <<-SQL
+      SELECT
+        LoweredEmail,
+        COALESCE(
+          INITCAP(name_ary[1]) || ' ' || INITCAP(name_ary[2]),
+          LoweredUserName
+        ) AS name,
+        splus_role,
+        geo_entities.id AS splus_geo_entity_id
+      FROM (
+        SELECT
+          LoweredUserName,
+          LoweredEmail,
+          REGEXP_SPLIT_TO_ARRAY(
+            SUBSTRING(LoweredEmail FROM '(.+)@.+'),
+            '[\._]'
+          ) AS name_ary,
+          UPPER(BTRIM(SUBSTRING(LoweredEmail FROM '.+\.(.+)$'))) AS iso_code2,
+          CASE
+            WHEN RoleName = 'Administrator' THEN 'admin'
+            WHEN RoleName = 'Data Contributor' THEN 'default'
+            ELSE 'elibrary'
+          END AS splus_role
+        FROM #{table_name}
+      ) t
+      LEFT JOIN geo_entities
+      ON CASE
+      WHEN UPPER(t.iso_code2) = 'UK'
+        OR t.LoweredEmail LIKE '%@unep-wcmc.org'
+        OR t.LoweredEmail LIKE '%@kew.org'
+      THEN UPPER(BTRIM(geo_entities.iso_code2)) = 'GB'
+      ELSE UPPER(BTRIM(geo_entities.iso_code2)) = UPPER(BTRIM(t.iso_code2))
+      END
+    SQL
+  end
+
+  def rows_to_insert_sql
+    sql = <<-SQL
+      SELECT
+        email,
+        name,
+        splus_role,
+        splus_geo_entity_id
+      FROM (
+        SELECT UPPER(BTRIM(LoweredEmail)) AS email
+        FROM #{table_name}
+        EXCEPT
+        SELECT UPPER(BTRIM(email)) FROM users
+      ) new_emails
+      JOIN (#{all_rows_sql}) tt
+      ON UPPER(BTRIM(new_emails.email)) = UPPER(BTRIM(tt.LoweredEmail))
+    SQL
+  end
+
+  def print_pre_import_stats
+    print_users_breakdown
+    print_query_counts
+  end
+
+  def print_post_import_stats
+    print_users_breakdown
+  end
+
+  def print_users_breakdown
+    puts "#{Time.now} There are #{User.count} users in total"
+    User.group(:role).order(:role).count.each do |role, count|
+      puts "\t #{role} #{count}"
+    end
+  end
+
+end

--- a/lib/tasks/elibrary/users_importer.rb
+++ b/lib/tasks/elibrary/users_importer.rb
@@ -82,7 +82,7 @@ class Elibrary::UsersImporter
             SUBSTRING(LoweredEmail FROM '(.+)@.+'),
             '[\._]'
           ) AS name_ary,
-          UPPER(BTRIM(SUBSTRING(LoweredEmail FROM '.+\.(.+)$'))) AS iso_code2,
+          UPPER(BTRIM(SUBSTRING(LoweredEmail FROM '.+\\.(.+)$'))) AS iso_code2,
           CASE
             WHEN RoleName = 'Administrator' THEN 'admin'
             WHEN RoleName = 'Data Contributor' THEN 'default'

--- a/spec/models/cites_cop_spec.rb
+++ b/spec/models/cites_cop_spec.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 require 'spec_helper'

--- a/spec/models/cites_suspension_notification_spec.rb
+++ b/spec/models/cites_suspension_notification_spec.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 require 'spec_helper'

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -20,6 +20,8 @@
 #  primary_language_document_id :integer
 #  elib_legacy_file_name        :text
 #  original_id                  :integer
+#  discussion_id                :integer
+#  discussion_sort_index        :integer
 #
 
 require 'spec_helper'

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,20 +2,24 @@
 #
 # Table name: documents
 #
-#  id            :integer          not null, primary key
-#  title         :text             not null
-#  filename      :text             not null
-#  date          :date             not null
-#  type          :string(255)      not null
-#  is_public     :boolean          default(FALSE), not null
-#  event_id      :integer
-#  language_id   :integer
-#  legacy_id     :integer
-#  created_by_id :integer
-#  updated_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  number        :string(255)
+#  id                           :integer          not null, primary key
+#  title                        :text             not null
+#  filename                     :text             not null
+#  date                         :date             not null
+#  type                         :string(255)      not null
+#  is_public                    :boolean          default(FALSE), not null
+#  event_id                     :integer
+#  language_id                  :integer
+#  elib_legacy_id               :integer
+#  created_by_id                :integer
+#  updated_by_id                :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  number                       :string(255)
+#  sort_index                   :integer
+#  primary_language_document_id :integer
+#  elib_legacy_file_name        :text
+#  original_id                  :integer
 #
 
 require 'spec_helper'

--- a/spec/models/eu_regulation_spec.rb
+++ b/spec/models/eu_regulation_spec.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 require 'spec_helper'

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -20,6 +20,7 @@
 #  created_by_id        :integer
 #  extended_description :text
 #  multilingual_url     :text
+#  elib_legacy_id       :integer
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Import scripts for documents, citations, discussions and users.

A couple of changes to the documents upload / download functionality within the admin tool, namely:
- documents to be stored outside of public directory in `private/elibrary`
- downloads handled by the `admin/documents/show` action
- accepted file extensions are now white-listed

A new type of document tag was added to accommodate discussions. Discussions are like threads of documents, order matters, which is why both discussion_id and discussion_sort_index were added. That is not to be confused with sort_index, which is for ordering documents under an event. Both the sort_index and discussion_sort_index could use some drag and drop interface to manage the order of documents, but because we're not sure if there will be time to implement that, a minimum effort solution was added to the document edit form with plain input fields to specify the order as a workaround.

Some schema changes have been introduced for purposes of verification of the import process (storing legacy ids of documents and citations)