### PR TITLE
Documents download and restrictions

### DIFF
--- a/app/assets/javascripts/species/templates/components/documents-table.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-table.handlebars
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
       {{#each document in documents}}
-        <tr class="document-row">
+        <tr class="document-row current">
           <td class="event-name">{{document.event_name}}</td>
           <td class="event-date">{{document.event_date}}</td>
           <td class="event-type">{{document.event_type}}</td>

--- a/app/assets/javascripts/species/templates/components/documents-table.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-table.handlebars
@@ -14,7 +14,7 @@
           <td class="event-name">{{document.event_name}}</td>
           <td class="event-date">{{document.event_date}}</td>
           <td class="event-type">{{document.event_type}}</td>
-          <td class="document-title">{{document.title}}</td>
+          <td class="document-title"><a href="/api/v1/documents/{{unbound document.id}}">{{document.title}}</a></td>
         </tr>
       {{/each}}
     </tbody>

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -1,9 +1,14 @@
 class Api::V1::DocumentsController < ApplicationController
 
   def index
+
     documents = Document.from("api_documents_view adv").
       where("adv.taxon_concept_ids @> ARRAY[?]", params[:taxon_concept_id].to_i).
       select("adv.id, adv.event_name, adv.event_date, adv.event_type, adv.title, adv.is_public").order("adv.event_date DESC")
+
+    public_only = !current_user || current_user.role == "api"
+
+    documents = documents.where("adv.is_public = true") if public_only
 
     ec_srg_docs = documents.where("adv.event_type = 'EcSrg'")
     cites_cop_docs = documents.where("adv.event_type = 'CitesCop'")

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -33,8 +33,10 @@ class Api::V1::DocumentsController < ApplicationController
   def show
     @document = Document.find(params[:id])
     path_to_file = @document.filename.path;
-    if access_denied? || !File.exists?(path_to_file)
-      redirect_to "/"
+    if access_denied?
+      render :file => "#{Rails.root}/public/403.html",  :status => 403
+    elsif !File.exists?(path_to_file)
+      render :file => "#{Rails.root}/public/404.html",  :status => 404
     else
       send_file(
         path_to_file,

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -31,4 +31,16 @@ class Api::V1::DocumentsController < ApplicationController
       other_docs: ActiveModel::ArraySerializer.new(other_docs, each_serializer: Species::DocumentsSerializer)
     }
   end
+
+  def show
+    @document = Document.find(params[:id])
+    send_file(
+      @document.filename.path,
+        :filename => File.basename(@document.filename.path),
+        :type => @document.filename.content_type,
+        :disposition => 'attachment',
+        :url_based_filename => true
+    )
+  end
+
 end

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::DocumentsController < ApplicationController
   def index
     documents = Document.from("api_documents_view adv").
       where("adv.taxon_concept_ids @> ARRAY[?]", params[:taxon_concept_id].to_i).
-      select("adv.id, adv.event_name, adv.event_date, adv.event_type, adv.title").order("adv.event_date DESC")
+      select("adv.id, adv.event_name, adv.event_date, adv.event_type, adv.title, adv.is_public").order("adv.event_date DESC")
 
     ec_srg_docs = documents.where("adv.event_type = 'EcSrg'")
     cites_cop_docs = documents.where("adv.event_type = 'CitesCop'")

--- a/app/serializers/species/documents_serializer.rb
+++ b/app/serializers/species/documents_serializer.rb
@@ -1,5 +1,5 @@
 class Species::DocumentsSerializer < ActiveModel::Serializer
-  attributes :id, :event_type, :event_name, :event_date, :title
+  attributes :id, :event_type, :event_name, :event_date, :title, :is_public
 
   def event_date
     DateTime.parse(object.event_date).strftime("%d-%m-%Y")

--- a/app/views/layouts/species.html.erb
+++ b/app/views/layouts/species.html.erb
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
-  
+
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -19,12 +19,12 @@
     </script>
     <%= javascript_include_tag "species" %>
     <%= csrf_meta_tags %>
-  
+
     <script type="text/javascript">
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-21313092-1']);
       _gaq.push(['_trackPageview']);
-  
+
       (function() {
          var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async =   true;
          ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -46,9 +46,11 @@
     <!--[if lt IE 9]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
-  
+
+    <%= render 'shared/alerts' %>
+
     <div class="spinner"><img src="/assets/species/loader.gif"></div>
-    
+
     <noscript>
       Javascript must be enabled for the correct page display
     </noscript>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ SAPI::Application.routes.draw do
       resources :units, :only => [:index]
       resources :sources, :only => [:index]
       resources :purposes, :only => [:index]
-      resources :documents, :only => [:index]
+      resources :documents, :only => [:index, :show]
       match '/dashboard_stats/:iso_code' => 'dashboard_stats#index'
     end
     resources :languages, :only => [:index]

--- a/db/migrate/20150730153305_get_is_public_from_api_documents_view.rb
+++ b/db/migrate/20150730153305_get_is_public_from_api_documents_view.rb
@@ -1,0 +1,11 @@
+class GetIsPublicFromApiDocumentsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_documents_view"
+    execute "CREATE VIEW api_documents_view AS #{view_sql('20150730153305', 'api_documents_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_documents_view"
+    execute "CREATE VIEW api_documents_view AS #{view_sql('20150722113923', 'api_documents_view')}"
+  end
+end

--- a/db/views/api_documents_view/20150730153305.sql
+++ b/db/views/api_documents_view/20150730153305.sql
@@ -1,0 +1,12 @@
+SELECT
+  d.id, e.name AS event_name, e.published_at AS event_date,
+  e.type AS event_type, d.title, d.is_public,
+  ARRAY_AGG_NOTNULL(dctc.taxon_concept_id) AS taxon_concept_ids
+FROM documents d
+LEFT JOIN events e ON e.id = d.event_id
+LEFT JOIN document_citations dc ON dc.document_id = d.id
+LEFT JOIN document_citation_taxon_concepts dctc
+  ON dctc.document_citation_id = dc.id
+LEFT JOIN document_citation_geo_entities dcge
+  ON dcge.document_citation_id = dc.id
+GROUP BY d.id, e.name, e.published_at, e.type, d.title

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Access forbidden</title>
+  <style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/403.html -->
+  <div class="dialog">
+    <h1>Access forbidden</h1>
+    <p>You may not have the permissions to access this page.</p>
+  </div>
+</body>
+</html>

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -1,17 +1,57 @@
 require 'spec_helper'
 
 describe Api::V1::DocumentsController, :type => :controller do
-  context "GET index" do
-    before(:each) do
-      @taxon_concept = create(:taxon_concept)
-      document = create(:proposal, event: create(:cites_cop, designation: cites))
-      citation = create(:document_citation, document_id: document.id)
-      citation_taxon_concept = create(:document_citation_taxon_concept,
-        document_citation_id: citation.id, taxon_concept_id: @taxon_concept.id)
+
+  before(:each) do
+    @taxon_concept = create(:taxon_concept)
+    document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
+    citation = create(:document_citation, document_id: document.id)
+    create(:document_citation_taxon_concept, document_citation_id: citation.id,
+      taxon_concept_id: @taxon_concept.id)
+    document2 = create(:proposal, event: create(:cites_cop, designation: cites))
+    citation2 = create(:document_citation, document_id: document2.id)
+    create(:document_citation_taxon_concept, document_citation_id: citation2.id,
+      taxon_concept_id: @taxon_concept.id)
+  end
+
+  context "GET index returns all documents" do
+    def get_all_documents
+      get :index, taxon_concept_id: @taxon_concept.id
+      response.body.should have_json_size(2).at_path('cites_cop_docs')
     end
-    it "returns documents" do
+    context "GET index contributor" do
+      login_contributor
+
+      it "returns all documents" do
+        get_all_documents
+      end
+    end
+
+    context "GET index manager" do
+      login_admin
+
+      it "returns all documents" do
+        get_all_documents
+      end
+    end
+  end
+
+  context "GET index returns only public documents" do
+    def get_public_documents
       get :index, taxon_concept_id: @taxon_concept.id
       response.body.should have_json_size(1).at_path('cites_cop_docs')
+    end
+    context "GET index api user " do
+      login_api_user
+
+      it "returns only public documents" do
+        get_public_documents
+      end
+    end
+    context "GET index no user" do |variable|
+      it "returns only public documents" do
+        get_public_documents
+      end
     end
   end
 end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -4,8 +4,8 @@ describe Api::V1::DocumentsController, :type => :controller do
 
   before(:each) do
     @taxon_concept = create(:taxon_concept)
-    document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
-    citation = create(:document_citation, document_id: document.id)
+    @document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
+    citation = create(:document_citation, document_id: @document.id)
     create(:document_citation_taxon_concept, document_citation_id: citation.id,
       taxon_concept_id: @taxon_concept.id)
     document2 = create(:proposal, event: create(:cites_cop, designation: cites))
@@ -52,6 +52,14 @@ describe Api::V1::DocumentsController, :type => :controller do
       it "returns only public documents" do
         get_public_documents
       end
+    end
+  end
+
+  context "show action fails" do
+    login_api_user
+    it "should return 403 status when permission denied" do
+      get :show, id: @document.id
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -19,4 +19,11 @@ module ControllerMacros
       sign_in FactoryGirl.create(:user, role: User::ELIBRARY_USER)
     end
   end
+
+  def login_api_user
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sign_in FactoryGirl.create(:user, role: User::API_USER)
+    end
+  end
 end


### PR DESCRIPTION
This branch completes the documents tab on the public interface.
- Added restriction to private documents to not logged-in and api users
- Added download action (show) to documents
- Check permissions before downloading a document
- Added some tests