### PR TITLE
Elibrary geo entity selector

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -9,6 +9,9 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
     @set('taxonConceptQueryForDisplay', filtersHash.taxon_concept_query)
     @set('taxonConceptQuery', filtersHash.taxon_concept_query)
     @set('selectedGeoEntitiesIds', filtersHash.geo_entities_ids || [])
+    if filtersHash.title_query == ''
+      filtersHash.title_query = null
+    @set('titleQuery', filtersHash.title_query)
 
   actions:
     openSearchPage:->
@@ -18,7 +21,8 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
         query = @get('taxonConceptQueryForDisplay')
       @transitionToRoute('documents', {queryParams: {
         taxon_concept_query: query,
-        geo_entities_ids: @get('selectedGeoEntities').mapProperty('id')
+        geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),
+        title_query: @get('titleQuery')
       }})
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -1,5 +1,6 @@
-Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
+Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Species.SearchContext, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
   needs: ['geoEntities', 'taxonConcepts']
+  searchContext: 'documents'
   autoCompleteTaxonConcept: null
 
   setFilters: (filtersHash) ->

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -1,4 +1,4 @@
-Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup,
+Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
   needs: ['geoEntities', 'taxonConcepts']
   autoCompleteTaxonConcept: null
 

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -8,6 +8,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       filtersHash.taxon_concept_query = null
     @set('taxonConceptQueryForDisplay', filtersHash.taxon_concept_query)
     @set('taxonConceptQuery', filtersHash.taxon_concept_query)
+    @set('selectedGeoEntitiesIds', filtersHash.geo_entities_ids || [])
 
   actions:
     openSearchPage:->
@@ -16,7 +17,8 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       else
         query = @get('taxonConceptQueryForDisplay')
       @transitionToRoute('documents', {queryParams: {
-        taxon_concept_query: query
+        taxon_concept_query: query,
+        geo_entities_ids: @get('selectedGeoEntities').mapProperty('id')
       }})
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->

--- a/app/assets/javascripts/species/controllers/search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/search_controller.js.coffee
@@ -1,11 +1,6 @@
-Species.SearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup,
+Species.SearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
   needs: ['geoEntities', 'taxonConcepts']
   taxonomy: 'cites_eu'
-  geoEntityQuery: null
-  autoCompleteRegions: null
-  autoCompleteCountries: null
-  selectedGeoEntities: []
-  selectedGeoEntitiesIds: []
   redirected: false
 
   setFilters: (filtersHash) ->
@@ -14,31 +9,6 @@ Species.SearchController = Ember.Controller.extend Species.Spinner, Species.Taxo
       filtersHash.taxon_concept_query = null
     @set('taxonConceptQueryForDisplay', filtersHash.taxon_concept_query)
     @set('selectedGeoEntitiesIds', filtersHash.geo_entities_ids || [])
-
-  geoEntityQueryObserver: ( ->
-    re = new RegExp("(^|\\(| )"+@get('geoEntityQuery'),"i")
-
-    @set 'autoCompleteCountries', @get('controllers.geoEntities.countries')
-    .filter (item, index, enumerable) =>
-      re.test item.get('name')
-
-    re = new RegExp("^[0-9]- "+@get('geoEntityQuery'),"i")
-
-    @set 'autoCompleteRegions', @get('controllers.geoEntities.regions')
-    .filter (item, index, enumerable) =>
-      re.test item.get('name')
-  ).observes('geoEntityQuery')
-
-  geoEntitiesObserver: ( ->
-    Ember.run.once(@, 'initForm')
-  ).observes('controllers.geoEntities.@each.didLoad')
-
-  initForm: ->
-    @set('selectedGeoEntities', @get('controllers.geoEntities.content').filter((geoEntity) =>
-      return geoEntity.get('id') in @get('selectedGeoEntitiesIds')
-    ))
-    @set('autoCompleteRegions', @get('controllers.geoEntities.regions'))
-    @set('autoCompleteCountries', @get('controllers.geoEntities.countries'))
 
   openSearchPage: (taxonFullName, page, perPage) ->
     $(".search fieldset").removeClass('parent-focus parent-active')

--- a/app/assets/javascripts/species/controllers/search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/search_controller.js.coffee
@@ -1,5 +1,6 @@
-Species.SearchController = Ember.Controller.extend Species.Spinner, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
+Species.SearchController = Ember.Controller.extend Species.Spinner, Species.SearchContext, Species.TaxonConceptAutoCompleteLookup, Species.GeoEntityAutoCompleteLookup,
   needs: ['geoEntities', 'taxonConcepts']
+  searchContext: 'species'
   taxonomy: 'cites_eu'
   redirected: false
 

--- a/app/assets/javascripts/species/controllers/search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/search_controller.js.coffee
@@ -46,9 +46,6 @@ Species.SearchController = Ember.Controller.extend Species.Spinner, Species.Sear
         @set(property, val)
       @openSearchPage()
 
-    deleteGeoEntitySelection: (context) ->
-      @get('selectedGeoEntities').removeObject(context)
-
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       rankName = autoCompleteTaxonConcept.get('rankName')
       if rankName == 'SPECIES' || rankName == 'SUBSPECIES'

--- a/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
@@ -1,0 +1,31 @@
+Species.GeoEntityAutoCompleteLookup = Ember.Mixin.create
+  geoEntityQuery: null
+  autoCompleteRegions: null
+  autoCompleteCountries: null
+  selectedGeoEntities: []
+  selectedGeoEntitiesIds: []
+
+  geoEntityQueryObserver: ( ->
+    re = new RegExp("(^|\\(| )"+@get('geoEntityQuery'),"i")
+
+    @set 'autoCompleteCountries', @get('controllers.geoEntities.countries')
+    .filter (item, index, enumerable) =>
+      re.test item.get('name')
+
+    re = new RegExp("^[0-9]- "+@get('geoEntityQuery'),"i")
+
+    @set 'autoCompleteRegions', @get('controllers.geoEntities.regions')
+    .filter (item, index, enumerable) =>
+      re.test item.get('name')
+  ).observes('geoEntityQuery')
+
+  geoEntitiesObserver: ( ->
+    Ember.run.once(@, 'initForm')
+  ).observes('controllers.geoEntities.@each.didLoad')
+
+  initForm: ->
+    @set('selectedGeoEntities', @get('controllers.geoEntities.content').filter((geoEntity) =>
+      return geoEntity.get('id') in @get('selectedGeoEntitiesIds')
+    ))
+    @set('autoCompleteRegions', @get('controllers.geoEntities.regions'))
+    @set('autoCompleteCountries', @get('controllers.geoEntities.countries'))

--- a/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
@@ -29,3 +29,7 @@ Species.GeoEntityAutoCompleteLookup = Ember.Mixin.create
     ))
     @set('autoCompleteRegions', @get('controllers.geoEntities.regions'))
     @set('autoCompleteCountries', @get('controllers.geoEntities.countries'))
+
+  actions:
+    deleteGeoEntitySelection: (context) ->
+      @get('selectedGeoEntities').removeObject(context)

--- a/app/assets/javascripts/species/mixins/geo_entity_loader.js.coffee
+++ b/app/assets/javascripts/species/mixins/geo_entity_loader.js.coffee
@@ -1,0 +1,7 @@
+Species.GeoEntityLoader = Ember.Mixin.create
+  ensureGeoEntitiesLoaded: (searchController) ->
+    geoEntitiesLoaded = @controllerFor('geoEntities').get('loaded')
+    if geoEntitiesLoaded
+      searchController.initForm()
+    else
+      @controllerFor('geoEntities').load()

--- a/app/assets/javascripts/species/router.js.coffee
+++ b/app/assets/javascripts/species/router.js.coffee
@@ -11,7 +11,7 @@ Species.Router.map (match) ->
     @route 'documents'
   @route 'elibrary'
   @resource 'documents', {
-    queryParams: ['taxon_concept_query', 'geo_entities_ids']
+    queryParams: ['taxon_concept_query', 'geo_entities_ids', 'title_query']
   }
   @route 'about'
 

--- a/app/assets/javascripts/species/router.js.coffee
+++ b/app/assets/javascripts/species/router.js.coffee
@@ -11,7 +11,7 @@ Species.Router.map (match) ->
     @route 'documents'
   @route 'elibrary'
   @resource 'documents', {
-    queryParams: ['taxon_concept_query']
+    queryParams: ['taxon_concept_query', 'geo_entities_ids']
   }
   @route 'about'
 

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -1,6 +1,10 @@
-Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
+Species.DocumentsRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLoader,
 
   beforeModel: (queryParams, transition) ->
+    @ensureGeoEntitiesLoaded(@controllerFor('search'))
+    #dirty hack to check if we have an array or comma separated string here
+    if queryParams.geo_entities_ids && queryParams.geo_entities_ids.substring
+      queryParams.geo_entities_ids = queryParams.geo_entities_ids.split(',')
     @controllerFor('elibrarySearch').setFilters(queryParams)
 
   setupController: (controller, model) ->
@@ -30,7 +34,3 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
       outlet: 'search',
       controller: @controllerFor('elibrarySearch')
     })
-
-  actions:
-    ensureGeoEntitiesLoaded: ->
-      @controllerFor('geoEntities').load()

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -7,15 +7,16 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLo
       queryParams.geo_entities_ids = queryParams.geo_entities_ids.split(',')
     @controllerFor('elibrarySearch').setFilters(queryParams)
 
-  setupController: (controller, model) ->
+  model: (params, queryParams, transition) ->
+    controller = @controllerFor('documents')
     $.ajax(
-      url: "/api/v1/documents?taxon-concepts-ids=4521",
+      url: "/api/v1/documents",
+      data: queryParams,
       success: (data) ->
         controller.set('content', data)
       error: (jqXHR, textStatus, errorThrown) ->
         console.log("AJAX Error:" + textStatus)
     )
-
 
   renderTemplate: ->
     # Render the `documents` template into

--- a/app/assets/javascripts/species/routes/elibrary_route.js.coffee
+++ b/app/assets/javascripts/species/routes/elibrary_route.js.coffee
@@ -1,4 +1,7 @@
-Species.ElibraryRoute = Ember.Route.extend
+Species.ElibraryRoute = Ember.Route.extend Species.GeoEntityLoader,
+
+  beforeModel: () ->
+    @ensureGeoEntitiesLoaded(@controllerFor('elibrarySearch'))
 
   renderTemplate: ->
     # Render the `index` template into
@@ -17,7 +20,3 @@ Species.ElibraryRoute = Ember.Route.extend
       outlet: 'search',
       controller: @controllerFor('elibrarySearch')
     })
-
-  actions:
-    ensureGeoEntitiesLoaded: ->
-      @controllerFor('geoEntities').load()

--- a/app/assets/javascripts/species/routes/index_route.js.coffee
+++ b/app/assets/javascripts/species/routes/index_route.js.coffee
@@ -1,4 +1,7 @@
-Species.IndexRoute = Ember.Route.extend
+Species.IndexRoute = Ember.Route.extend Species.GeoEntityLoader,
+
+  beforeModel: () ->
+    @ensureGeoEntitiesLoaded(@controllerFor('search'))
 
   renderTemplate: ->
     # Render the `index` template into
@@ -28,10 +31,6 @@ Species.IndexRoute = Ember.Route.extend
       outlet: 'downloadsButton',
       controller: @controllerFor('downloads')
     })
-
-  actions:
-    ensureGeoEntitiesLoaded: ->
-      @controllerFor('geoEntities').load()
 
     ensureHigherTaxaLoaded: ->
       @controllerFor('higherTaxaCitesEu').load()

--- a/app/assets/javascripts/species/routes/index_route.js.coffee
+++ b/app/assets/javascripts/species/routes/index_route.js.coffee
@@ -32,6 +32,7 @@ Species.IndexRoute = Ember.Route.extend Species.GeoEntityLoader,
       controller: @controllerFor('downloads')
     })
 
+  actions:
     ensureHigherTaxaLoaded: ->
       @controllerFor('higherTaxaCitesEu').load()
       @controllerFor('higherTaxaCms').load()

--- a/app/assets/javascripts/species/routes/taxon_concept_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concept_route.js.coffee
@@ -1,6 +1,7 @@
-Species.TaxonConceptRoute = Ember.Route.extend Species.Spinner,
+Species.TaxonConceptRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLoader,
 
   beforeModel: ->
+    @ensureGeoEntitiesLoaded(@controllerFor('search'))
     # Setting a spinner until content is loaded.
     $(@spinnerSelector).css("visibility", "visible")
 
@@ -46,9 +47,6 @@ Species.TaxonConceptRoute = Ember.Route.extend Species.Spinner,
     })
 
   actions:
-    ensureGeoEntitiesLoaded: ->
-      @controllerFor('geoEntities').load()
-
     ensureHigherTaxaLoaded: ->
       @controllerFor('higherTaxaCitesEu').load()
       @controllerFor('higherTaxaCms').load()

--- a/app/assets/javascripts/species/routes/taxon_concepts_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concepts_route.js.coffee
@@ -1,6 +1,7 @@
-Species.TaxonConceptsRoute = Ember.Route.extend Species.Spinner,
+Species.TaxonConceptsRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLoader,
 
   beforeModel: (queryParams, transition) ->
+    @ensureGeoEntitiesLoaded(@controllerFor('search'))
     #dirty hack to check if we have an array or comma separated string here
     if queryParams.geo_entities_ids && queryParams.geo_entities_ids.substring
       queryParams.geo_entities_ids = queryParams.geo_entities_ids.split(',')
@@ -56,9 +57,6 @@ Species.TaxonConceptsRoute = Ember.Route.extend Species.Spinner,
     })
 
   actions:
-    ensureGeoEntitiesLoaded: ->
-      @controllerFor('geoEntities').load()
-
     ensureHigherTaxaLoaded: ->
       @controllerFor('higherTaxaCitesEu').load()
       @controllerFor('higherTaxaCms').load()

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -1,16 +1,31 @@
 <div class="search-form-container">
+
   <p class="search-info">
     <i class="fa fa-info-circle"></i> Select one or more options
   </p>
-  <label>Search by species or higher taxon</label>
-  {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=false}}
-
+  <div class="search-form documents">
+    <form class="search">
+      <fieldset>
+        {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=false}}
+      </fieldset>
+    </form>
+  </div>
   <div class="location-area popup-area">
     {{view Species.GeoEntitiesSearchButton
       selectedGeoEntitiesBinding="controller.selectedGeoEntities"
       loadedBinding="controllers.geoEntities.loaded"
     }}
-    {{view Species.GeoEntitiesSearchDropdown  controllerBinding="controller"}}
+    {{view Species.GeoEntitiesSearchDropdown controllerBinding="controller"}}
+  </div>
+
+  <div style="clear:both"></div>
+  <label>Search by title keywords</label>
+  <div class="search-form documents">
+    <form class="search">
+      <fieldset>
+        {{input type="text" value=titleQuery placeholder="E.g. significant trade in animal species"}}
+      </fieldset>
+    </form>
   </div>
 
   <div class="search-button-container">

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -5,6 +5,14 @@
   <label>Search by species or higher taxon</label>
   {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=false}}
 
+  <div class="location-area popup-area">
+    {{view Species.GeoEntitiesSearchButton
+      selectedGeoEntitiesBinding="controller.selectedGeoEntities"
+      loadedBinding="controllers.geoEntities.loaded"
+    }}
+    {{view Species.GeoEntitiesSearchDropdown  controllerBinding="controller"}}
+  </div>
+
   <div class="search-button-container">
     <button {{action "openSearchPage"}}>Search</button>
   </div>

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -1,7 +1,7 @@
 <div class="search-form-container">
-  <div class="search-info">
+  <p class="search-info">
     <i class="fa fa-info-circle"></i> Select one or more options
-  </div>
+  </p>
   <label>Search by species or higher taxon</label>
   {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=false}}
 

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -19,7 +19,6 @@
   </div>
 
   <div style="clear:both"></div>
-  <label>Search by title keywords</label>
   <div class="search-form documents">
     <form class="search">
       <fieldset>

--- a/app/assets/javascripts/species/templates/geo_entities_search_dropdown.handlebars
+++ b/app/assets/javascripts/species/templates/geo_entities_search_dropdown.handlebars
@@ -3,7 +3,7 @@
     <div class="row01">
       {{view Species.GeoEntitiesSearchTextField
         valueBinding="controller.geoEntityQuery"
-        placeholder="Type to filter countries or regions"
+        placeholderBinding="view.placeholder"
         autocomplete="off"
       }}
       <input type="submit" value="submit" />
@@ -13,6 +13,15 @@
       contentBinding="controller.selectedGeoEntities"}}
   </div>
   <div class="list-holder">
+
+  {{#if controller.isSearchContextDocuments}}
+    <ul>
+      <li>
+        {{collection Species.GeoEntitiesCollectionView
+          contentBinding="controller.autoCompleteCountries"}}
+      </li>
+    </ul>
+  {{else}}
     <ul>
       <li>
         <h2>REGIONS</h2>
@@ -25,5 +34,7 @@
           contentBinding="controller.autoCompleteCountries"}}
       </li>
     </ul>
+  {{/if}}
+
   </div>
 </div>

--- a/app/assets/javascripts/species/templates/search_form.handlebars
+++ b/app/assets/javascripts/species/templates/search_form.handlebars
@@ -6,9 +6,13 @@
       CMS
     {{/view}}
   </div>
-
-  {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=true}}
-
+  <div class="search-form species">
+    <form action="#" class="search">
+      <fieldset>
+      {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=true}}
+      </fieldset>
+    </form>
+  </div>
   <div class="location-area popup-area">
     {{view Species.GeoEntitiesSearchButton
       selectedGeoEntitiesBinding="controller.selectedGeoEntities"

--- a/app/assets/javascripts/species/templates/taxon_concept_search.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept_search.handlebars
@@ -1,5 +1,3 @@
-<form action="#" class="search">
-  <fieldset>
     {{taxon-concept-search-field
       valueBinding="controller.taxonConceptQueryForDisplay"
       queryBinding="controller.taxonConceptQuery"
@@ -26,5 +24,3 @@
       {{/each}}
       </ul>
     </div>
-  </fieldset>
-</form>

--- a/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
@@ -1,5 +1,3 @@
 Species.ElibrarySearchFormView = Ember.View.extend
   templateName: 'species/elibrary_search_form'
   classNames: ['search-block']
-  didInsertElement: ->
-    @get('controller').send('ensureGeoEntitiesLoaded')

--- a/app/assets/javascripts/species/views/search_form/geo_entities_search_dropdown.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/geo_entities_search_dropdown.js.coffee
@@ -1,3 +1,9 @@
 Species.GeoEntitiesSearchDropdown = Ember.View.extend
   templateName: 'species/geo_entities_search_dropdown'
   classNames: ['popup-holder01']
+  placeholder: ( ->
+    if @get('controller.isSearchContextDocuments')
+      'Type to filetr countries or territories'
+    else
+      'Type to filter countries or regions'
+  ).property('controller.isSearchContextDocuments')

--- a/app/assets/javascripts/species/views/search_form/search_form_view.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/search_form_view.js.coffee
@@ -1,5 +1,3 @@
 Species.SearchFormView = Ember.View.extend
   templateName: 'species/search_form'
   classNames: ['search-block']
-  didInsertElement: ->
-    @get('controller').send('ensureGeoEntitiesLoaded')

--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_view.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_view.js.coffee
@@ -1,7 +1,5 @@
 Species.TaxonConceptSearchView = Em.View.extend
   templateName: 'species/taxon_concept_search'
-  classNames: ['search-form']
-  classNameBindings: ['showSearchButton:species:documents'],
   
   mousedOver: false
 

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -83,11 +83,14 @@
   }
 
   .search-form-container {
-    color: #2d3237;
     font-size: 15px;
     text-align: left;
     margin: auto;
     width: 523px;
+
+    p, label {
+      color: #2d3237;
+    }
 
     .search-button-container {
       border-top: 1px solid #8fb7cf;

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -74,9 +74,6 @@
   .search-form {
     width: 493px;
     padding: 10px 15px 13px 15px;
-  }
-
-  .search-form.species {
     float: left;
     text-transform: uppercase;
     border-right: 1px solid #8fb7cf;
@@ -86,7 +83,7 @@
     font-size: 15px;
     text-align: left;
     margin: auto;
-    width: 523px;
+    width: 683px;
 
     p, label {
       color: #2d3237;
@@ -96,6 +93,7 @@
       border-top: 1px solid #8fb7cf;
       padding: 20px 0;
       margin: 15px;
+      clear: both;
       @include blue-search-button;
     }
 


### PR DESCRIPTION
Adds the geo entity selector, like the on in the main search interface. It is not completed visually, but in the interest of early integration this already is set up with passing the available query parameters (`taxon_concept_query`, `geo_entities_ids`, `document_query`) to the back-end.