### PR TITLE
Documents params refactoring

### DIFF
--- a/app/assets/javascripts/admin/documents.js.coffee
+++ b/app/assets/javascripts/admin/documents.js.coffee
@@ -1,14 +1,14 @@
 $(document).ready ->
 
   $('#event-id').chained('#event-type')
-  $('#event-id-search').chained('#event-type-search')
-  $('#document-type').chained('#event-type-search')
+  $('#event_id_search').chained('#event_type_search')
+  $('#document_type').chained('#event_type_search')
 
   # Save the children from chained destruction!
-  documentTypeChildren =  $('#document-type').children()
+  documentTypeChildren =  $('#document_type').children()
 
-  $('#event-type-search').change( (e) ->
-    documentType = $('#document-type')
+  $('#event_type_search').change( (e) ->
+    documentType = $('#document_type')
     # if no event type selected
     unless e.target.value
       # enable all document types

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -6,6 +6,7 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLo
     if queryParams.geo_entities_ids && queryParams.geo_entities_ids.substring
       queryParams.geo_entities_ids = queryParams.geo_entities_ids.split(',')
     @controllerFor('elibrarySearch').setFilters(queryParams)
+    $(@spinnerSelector).css("visibility", "visible")
 
   model: (params, queryParams, transition) ->
     controller = @controllerFor('documents')
@@ -17,6 +18,9 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner, Species.GeoEntityLo
       error: (jqXHR, textStatus, errorThrown) ->
         console.log("AJAX Error:" + textStatus)
     )
+
+  afterModel: (queryParams, transition) ->
+    $(@spinnerSelector).css("visibility", "hidden")
 
   renderTemplate: ->
     # Render the `documents` template into

--- a/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
@@ -6,7 +6,7 @@ Species.TaxonConceptDocumentsRoute = Ember.Route.extend
   getDocuments: ->
     model = this.modelFor("taxonConcept")
     $.ajax(
-      url: "/api/v1/documents?taxon-concepts-ids=" + model.get('id'),
+      url: "/api/v1/documents?taxon_concepts_ids=" + model.get('id'),
       success: (data) ->
         model.set('cites_cop_docs', data.cites_cop_docs)
         model.set('ec_srg_docs', data.ec_srg_docs)

--- a/app/assets/javascripts/species/templates/downloads_for_cites.handlebars
+++ b/app/assets/javascripts/species/templates/downloads_for_cites.handlebars
@@ -10,7 +10,7 @@
     {{/view}}
   </li>
 </ul>
-{{#view Species.DownloadsForLegislation 
+{{#view Species.DownloadsForLegislation
   isVisibleBinding="controller.legislationIsCitesListings"
   controllerBinding="controllers.downloadsForCitesListings"
 }}
@@ -25,7 +25,7 @@
         <div class="popup-holder-appendix">
           <div class="popup">
             <div class="list-holder">
-              {{collection Species.AppendixDropdownCollectionView 
+              {{collection Species.AppendixDropdownCollectionView
                 controllerBinding="controller"
                 contentBinding="controller.appendices"
               }}
@@ -49,8 +49,8 @@
         {{view Species.GeoEntitiesSearchDropdown controllerBinding="controller"}}
       </div>
     </div>
-  </div> 
-  <div class="btn-holder">     
+  </div>
+  <div class="btn-holder">
     {{view Species.StartDownloadButton controllerBinding="controller"}}
     <div class="message-area">
       {{#if controller.downloadInProgress}}
@@ -60,7 +60,7 @@
     </div>
   </div>
 {{/view}}
-{{#view Species.DownloadsForLegislation 
+{{#view Species.DownloadsForLegislation
   isVisibleBinding="controller.legislationIsCitesRestrictions"
   controllerBinding="controllers.downloadsForCitesRestrictions"
 }}
@@ -69,13 +69,13 @@
     <div class="typy-columns add">
       <div class="col more-add">
         <label>
-          {{view Ember.RadioButton name="document-type" selectionBinding="documentType" value="Quotas"}}
+          {{view Ember.RadioButton name="document_type" selectionBinding="documentType" value="Quotas"}}
           CITES Quotas
         </label>
       </div>
       <div class="col more-add">
         <label>
-          {{view Ember.RadioButton name="document-type" selectionBinding="documentType" value="CitesSuspensions"}}
+          {{view Ember.RadioButton name="document_type" selectionBinding="documentType" value="CitesSuspensions"}}
           CITES Suspensions
         </label>
       </div>
@@ -126,7 +126,7 @@
       </div>
     </div>
   </div>
-  <div class="btn-holder">     
+  <div class="btn-holder">
     {{view Species.StartDownloadButton controllerBinding="controller"}}
     <div class="message-area">
       {{#if controller.downloadInProgress}}

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -2,6 +2,10 @@ class Api::V1::DocumentsController < ApplicationController
 
   def index
 
+    if params[:taxon_concept_query].present?
+      @species_search = Species::Search.new(params)
+      params[:taxon_concepts_ids] = @species_search.results.map(&:id)
+    end
     @search = DocumentSearch.new(params, 'public')
 
     documents = @search.results

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::DocumentsController < ApplicationController
 
     if params[:taxon_concept_query].present?
       @species_search = Species::Search.new(params)
-      params[:taxon_concepts_ids] = @species_search.results.map(&:id)
+      params[:taxon_concepts_ids] = @species_search.results.map(&:id).join(',')
     end
     @search = DocumentSearch.new(params, 'public')
 

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -10,7 +10,6 @@ class Api::V1::DocumentsController < ApplicationController
 
     documents = @search.results
 
-    #this could be done in the sql query
     documents = documents.where(is_public: "true") if access_denied?
 
     cites_cop_docs = documents.where(event_type: "CitesCop")

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -48,6 +48,8 @@ class DocumentSearch
     @query = Document.from("#{view} AS documents")
     add_conditions_for_event
     add_conditions_for_document
+    add_proposal_outcome_condition if @proposal_outcome_ids.present?
+    add_review_phase_condition if @review_phase_ids.present?
     add_extra_conditions
     add_ordering if interface == 'admin'
   end
@@ -97,6 +99,15 @@ class DocumentSearch
     @query = @query.where("document_tags_ids && ARRAY[#{@document_tags_ids.join(',')}]")
   end
 
+  def add_proposal_outcome_condition
+    @query = @query.where("proposal_outcome_ids && ARRAY[#{@proposal_outcome_ids.join(',')}]")
+
+  end
+
+  def add_review_phase_condition
+    @query = @query.where("review_phase_ids && ARRAY[#{@review_phase_ids.join(',')}]")
+  end
+
   def add_ordering
     return if @document_title.present?
 
@@ -109,8 +120,8 @@ class DocumentSearch
 
   def select_and_group_query
     columns = "event_name, event_date, event_type, is_public, document_type,
-      number, sort_index, proposal_outcome, primary_document_id,
-      geo_entity_names, taxon_names"
+      number, sort_index, primary_document_id, proposal_outcome_ids,
+      review_phase_ids, geo_entity_names, taxon_names"
     aggregators = <<-SQL
       ARRAY_TO_JSON(
         ARRAY_AGG_NOTNULL(

--- a/app/models/document_search_params.rb
+++ b/app/models/document_search_params.rb
@@ -13,6 +13,8 @@ class DocumentSearchParams < Hash
       document_date_end: (Date.parse(params['document_date_end']) rescue nil),
       taxon_concepts_ids: (params['taxon_concepts_ids'].split(',').map(&:to_i) rescue []),
       geo_entities_ids: (params['geo_entities_ids'].map(&:to_i) rescue []),
+      proposal_outcome_ids: (params['proposal_outcome_ids'].split(',').map(&:to_i) rescue []),
+      review_phase_ids: (params['review_phase_ids'].split(',').map(&:to_i) rescue []),
       document_tags_ids: (params['document_tags_ids'].map(&:to_i) rescue []),
       page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,
       per_page: params[:per_page] && params[:per_page].to_i > 0 ? params[:per_page].to_i : 25

--- a/app/models/document_search_params.rb
+++ b/app/models/document_search_params.rb
@@ -5,15 +5,15 @@
 class DocumentSearchParams < Hash
   def initialize(params)
     sanitized_params = {
-      event_id: params['event-id-search'] || params['event_id'],
-      event_type: params['event-type-search'],
-      document_type: params['document-type'],
-      document_title: params['document-title'] ? params['document-title'].strip : nil,
-      document_date_start: (Date.parse(params['document-date-start']) rescue nil),
-      document_date_end: (Date.parse(params['document-date-end']) rescue nil),
-      taxon_concepts_ids: (params['taxon-concepts-ids'].split(',').map(&:to_i) rescue []),
-      geo_entities_ids: (params['geo-entities-ids'].map(&:to_i) rescue []),
-      document_tags_ids: (params['document-tags-ids'].map(&:to_i) rescue []),
+      event_id: params['event_id_search'] || params['event_id'],
+      event_type: params['event_type_search'],
+      document_type: params['document_type'],
+      document_title: params['document_title'] ? params['document_title'].strip : nil,
+      document_date_start: (Date.parse(params['document_date_start']) rescue nil),
+      document_date_end: (Date.parse(params['document_date_end']) rescue nil),
+      taxon_concepts_ids: (params['taxon_concepts_ids'].split(',').map(&:to_i) rescue []),
+      geo_entities_ids: (params['geo_entities_ids'].map(&:to_i) rescue []),
+      document_tags_ids: (params['document_tags_ids'].map(&:to_i) rescue []),
       page: params[:page] && params[:page].to_i > 0 ? params[:page].to_i : 1,
       per_page: params[:per_page] && params[:per_page].to_i > 0 ? params[:per_page].to_i : 25
     }

--- a/app/serializers/species/documents_serializer.rb
+++ b/app/serializers/species/documents_serializer.rb
@@ -1,8 +1,9 @@
 class Species::DocumentsSerializer < ActiveModel::Serializer
   attributes :id, :event_type, :event_name, :event_date, :title, :is_public,
-    :document_type, :number, :sort_index, :language, :proposal_outcome,
+    :document_type, :number, :sort_index, :language,
     :primary_document_id, :taxon_names, :geo_entity_names,
-    :taxon_names, :geo_entity_names, :languages
+    :taxon_names, :geo_entity_names, :languages, :proposal_outcome_ids,
+    :review_phase_ids
 
   def document_type
     object.document_type.split(":").last

--- a/app/views/admin/documents/index.html.erb
+++ b/app/views/admin/documents/index.html.erb
@@ -31,13 +31,13 @@
     <fieldset>
       <legend>Filter documents</legend>
       <div class="form-group">
-        <%= select_tag 'event-type-search',
+        <%= select_tag 'event_type_search',
           options_for_select(@event_types, @search.event_type), {
             :prompt => 'Select an event type...', class: 'input-large'
           }
         %>
 
-        <%= select_tag 'event-id-search',
+        <%= select_tag 'event_id_search',
           options_for_select(
             @events.map { |e| [e.name, e.id, {:class => e.type}] },
             @search.event_id
@@ -45,7 +45,7 @@
             :prompt => 'Select an event...', class: 'input-large'
           }
         %>
-        <%= select_tag 'document-type', options_for_select(
+        <%= select_tag 'document_type', options_for_select(
             Document.elibrary_document_types.map { |document_klass|
               [
                 document_klass.display_name,
@@ -60,7 +60,7 @@
       </div>
 
       <div class="form-group" style="padding-bottom: 8px">
-        <%= hidden_field_tag 'taxon-concepts-ids', params['taxon-concepts-ids'], {
+        <%= hidden_field_tag 'taxon_concepts_ids', params['taxon_concepts_ids'], {
           :class => 'citation-taxon-concept',
           :'data-taxonomy-id' => @taxonomy.id,
           :'data-name-status-filter' => ['A', 'N'].to_json,
@@ -68,7 +68,7 @@
           :multiple => true
         } %>
 
-        <%= select_tag 'geo-entities-ids',
+        <%= select_tag 'geo_entities_ids',
           options_from_collection_for_select(
             @geo_entities,
             :id,
@@ -78,14 +78,14 @@
           {
             :multiple => true, :class => 'citation-geo-entity'
           }
-        %>  
+        %>
 
-        <%= select_tag 'document-tags-ids',
+        <%= select_tag 'document_tags_ids',
           option_groups_from_collection_for_select(
             Document.elibrary_document_tag_types,
             :scoped,
             :display_name,
-            :id, 
+            :id,
             :name,
             @search.document_tags
           ), {
@@ -97,15 +97,15 @@
       <div class="form-group">
         <div class="input-prepend">
           <span class="add-on"><i class="icon-search"></i></span>
-          <%= text_field_tag 'document-title', @search.document_title|| nil,
+          <%= text_field_tag 'document_title', @search.document_title|| nil,
             :class => "align-on-select input-xxlarge", :placeholder => 'Enter a document title...', autocomplete: 'off' %>
         </div>
-        <%= text_field_tag 'document-date-start',
-          params["document-date-start"] || nil, class: 'align-on-select datepicker input-medium',
+        <%= text_field_tag 'document_date_start',
+          params["document_date_start"] || nil, class: 'align-on-select datepicker input-medium',
           placeholder: 'Date after...' %>
 
-        <%= text_field_tag 'document-date-end',
-          params["document-date-end"] || nil, class: 'align-on-select datepicker input-medium',
+        <%= text_field_tag 'document_date_end',
+          params["document_date_end"] || nil, class: 'align-on-select datepicker input-medium',
           placeholder: 'Date before...' %>
       </div>
 
@@ -122,4 +122,3 @@
 <%= admin_table %>
 
 <%= paginate collection %>
-

--- a/db/migrate/20150812180311_add_outcome_and_phase_to_api_documents_view.rb
+++ b/db/migrate/20150812180311_add_outcome_and_phase_to_api_documents_view.rb
@@ -1,0 +1,11 @@
+class AddOutcomeAndPhaseToApiDocumentsView < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_documents_view"
+    execute "CREATE VIEW api_documents_view AS #{view_sql('20150812180311', 'api_documents_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_documents_view"
+    execute "CREATE VIEW api_documents_view AS #{view_sql('20150806092509', 'api_documents_view')}"
+  end
+end

--- a/db/views/api_documents_view/20150812180311.sql
+++ b/db/views/api_documents_view/20150812180311.sql
@@ -1,0 +1,37 @@
+SELECT
+  d.id, e.name AS event_name, to_char(e.published_at, 'DD/MM/YYYY') AS event_date,
+  e.type AS event_type, d.title, d.is_public, d.type AS document_type,
+  d.number, d.sort_index, l.name_en AS language,
+  CASE
+    WHEN d.primary_language_document_id IS NULL
+    THEN d.id
+    ELSE d.primary_language_document_id
+  END AS primary_document_id,
+  ARRAY_AGG_NOTNULL(po.id) AS proposal_outcome_ids,
+  ARRAY_AGG_NOTNULL(rp.id) AS review_phase_ids,
+  ARRAY_AGG_NOTNULL(dctc.taxon_concept_id) AS taxon_concept_ids,
+  ARRAY_TO_STRING(ARRAY_AGG_NOTNULL(tc.full_name), ',') AS taxon_names,
+  ARRAY_AGG_NOTNULL(dcge.geo_entity_id) AS geo_entity_ids,
+  ARRAY_TO_STRING(ARRAY_AGG_NOTNULL(ge.name_en), ',') AS geo_entity_names
+FROM documents d
+LEFT JOIN events e ON e.id = d.event_id
+LEFT JOIN document_citations dc ON dc.document_id = d.id
+LEFT JOIN document_citation_taxon_concepts dctc
+  ON dctc.document_citation_id = dc.id
+LEFT JOIN taxon_concepts tc
+  ON dctc.taxon_concept_id = tc.id
+LEFT JOIN document_citation_geo_entities dcge
+  ON dcge.document_citation_id = dc.id
+LEFT JOIN geo_entities ge
+  ON dcge.geo_entity_id = ge.id
+LEFT JOIN languages l
+  ON d.language_id = l.id
+LEFT JOIN proposal_details pd
+  ON d.id = pd.id
+LEFT JOIN document_tags po
+  ON pd.proposal_outcome_id = po.id
+LEFT JOIN review_details rd
+  ON rd.document_id = d.id
+LEFT JOIN document_tags rp
+  ON rd.review_phase_id = rp.id
+GROUP BY d.id, e.name, e.published_at, e.type, d.title, l.name_en

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -26,35 +26,35 @@ describe Admin::DocumentsController do
 
       context "search" do
         it "runs a full text search on title" do
-          get :index, 'document-title' => 'good'
+          get :index, 'document_title' => 'good'
           assigns(:documents).should eq([@document2])
         end
         it "retrieves documents inclusive of the given start date" do
-          get :index, "document-date-start" => '25/12/2014'
+          get :index, "document_date_start" => '25/12/2014'
           assigns(:documents).should eq([@document1])
         end
         it "retrieves documents inclusive of the given end date" do
-          get :index, "document-date-end" => '01/01/2014'
+          get :index, "document_date_end" => '01/01/2014'
           assigns(:documents).should eq([@document2])
         end
         it "retrieves documents after the given date" do
-          get :index, "document-date-start" => '10/01/2014'
+          get :index, "document_date_start" => '10/01/2014'
           assigns(:documents).should eq([@document1])
         end
         it "retrieves documents before the given date" do
-          get :index, "document-date-end" => '10/01/2014'
+          get :index, "document_date_end" => '10/01/2014'
           assigns(:documents).should eq([@document2])
         end
         it "ignores invalid dates" do
-          get :index, "document-date-start" => '34/24/12', "document-date-end" => '34/24/12'
+          get :index, "document_date_start" => '34/24/12', "document_date_end" => '34/24/12'
           assigns(:documents).should eq([@document2, @document1])
         end
         it "retrieves documents for taxon concept" do
-          get :index, "taxon-concepts-ids" => taxon_concept.id
+          get :index, "taxon_concepts_ids" => taxon_concept.id
           assigns(:documents).should eq([@document1])
         end
         it "retrieves documents for geo entity" do
-          get :index, "geo-entities-ids" => [geo_entity.id]
+          get :index, "geo_entities_ids" => [geo_entity.id]
           assigns(:documents).should eq([@document2])
         end
         context 'by proposal outcome' do
@@ -63,7 +63,7 @@ describe Admin::DocumentsController do
             create(:proposal_details, document_id: @document3.id, proposal_outcome_id: proposal_outcome.id)
           end
           it "retrieves documents for tag" do
-            get :index, "document-tags-ids" => [proposal_outcome.id]
+            get :index, "document_tags_ids" => [proposal_outcome.id]
             assigns(:documents).should eq([@document3])
           end
         end
@@ -73,11 +73,11 @@ describe Admin::DocumentsController do
             create(:review_details, document_id: @document3.id, review_phase_id: review_phase.id, process_stage_id: process_stage.id)
           end
           it "retrieves documents for review_phase tag" do
-            get :index, "document-tags-ids" => [review_phase.id]
+            get :index, "document_tags_ids" => [review_phase.id]
             assigns(:documents).should eq([@document3])
           end
           it "retrieves documents for process_stage tag" do
-            get :index, "document-tags-ids" => [process_stage.id]
+            get :index, "document_tags_ids" => [process_stage.id]
             assigns(:documents).should eq([@document3])
           end
         end


### PR DESCRIPTION
This branch is about renaming the hyphenated params regarding the documents search.
In the end I also decided to put here new params and changes like searching by text for taxon concepts reusing the already existing Species::Search logic, proposal outcome and review phase.
A spinner is added as well to be displayed when the results page is loading.

Requires rake db:migrate