### PR TITLE
fixes full reassignment of common names, CITES quotas & suspensions

### DIFF
--- a/app/models/nomenclature_change/full_reassignment.rb
+++ b/app/models/nomenclature_change/full_reassignment.rb
@@ -6,43 +6,52 @@ class NomenclatureChange::FullReassignment
   end
 
   def process
+    Rails.logger.debug "FULL REASSIGNMENT #{@old_taxon_concept.full_name} to #{@new_taxon_concept.full_name}"
     update_attrs = {
       taxon_concept_id: @new_taxon_concept.id
     }
     # distributions
+    Rails.logger.debug "FULL REASSIGNMENT Distributions (#{@old_taxon_concept.distributions.count})"
     @old_taxon_concept.distributions.each do |d|
       d.update_attributes(update_attrs)
     end
     # references
+    Rails.logger.debug "FULL REASSIGNMENT References (#{@old_taxon_concept.taxon_concept_references.count})"
     @old_taxon_concept.taxon_concept_references.each do |tcr|
       tcr.update_attributes(update_attrs)
     end
     # listing changes
+    Rails.logger.debug "FULL REASSIGNMENT Listing Changes (#{@old_taxon_concept.listing_changes.count})"
     @old_taxon_concept.listing_changes.each do |lc|
       lc.update_attributes(update_attrs)
     end
     # EU opinions
+    Rails.logger.debug "FULL REASSIGNMENT EU Opinions (#{@old_taxon_concept.eu_opinions.count})"
     @old_taxon_concept.eu_opinions.each do |ed|
       ed.update_attributes(update_attrs)
     end
     # EU suspensions
+    Rails.logger.debug "FULL REASSIGNMENT EU Suspensions (#{@old_taxon_concept.eu_suspensions.count})"
     @old_taxon_concept.eu_suspensions.each do |ed|
       ed.update_attributes(update_attrs)
     end
     # CITES quotas
-    @old_taxon_concept.quotas do |tr|
+    Rails.logger.debug "FULL REASSIGNMENT CITES Quotas (#{@old_taxon_concept.quotas.count})"
+    @old_taxon_concept.quotas.each do |tr|
       tr.update_attributes(update_attrs)
     end
     # CITES suspensions
-    @old_taxon_concept.cites_suspensions do |tr|
+    Rails.logger.debug "FULL REASSIGNMENT CITES Suspensions (#{@old_taxon_concept.cites_suspensions.count})"
+    @old_taxon_concept.cites_suspensions.each do |tr|
       tr.update_attributes(update_attrs)
     end
     # common names
-    @old_taxon_concept.taxon_commons do |tc|
+    Rails.logger.debug "FULL REASSIGNMENT Common names (#{@old_taxon_concept.taxon_commons.count})"
+    @old_taxon_concept.taxon_commons.each do |tc|
       tc.update_attributes(update_attrs)
     end
     # shipments
-    Rails.logger.debug "Updating shipments where taxon concept = #{@old_taxon_concept.full_name} to have taxon concept = #{@new_taxon_concept.full_name}"
+    Rails.logger.debug "FULL REASSIGNMENT Shipments"
     Trade::Shipment.update_all(
       update_attrs,
       {taxon_concept_id: @old_taxon_concept.id}

--- a/app/models/nomenclature_change/reassignment_processor.rb
+++ b/app/models/nomenclature_change/reassignment_processor.rb
@@ -85,6 +85,7 @@ class NomenclatureChange::ReassignmentProcessor
   end
 
   def post_process(reassigned_object, object_before_reassignment)
+    Rails.logger.warn("Resassignment post processing BEGIN")
     if reassigned_object.is_a?(TaxonConcept)
       resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(reassigned_object)
       resolver.process
@@ -92,6 +93,7 @@ class NomenclatureChange::ReassignmentProcessor
       resolver = NomenclatureChange::TradeShipmentsResolver.new(reassigned_object, object_before_reassignment)
       resolver.process
     end
+    Rails.logger.warn("Resassignment post processing END")
   end
 
 end

--- a/app/models/trade_restriction.rb
+++ b/app/models/trade_restriction.rb
@@ -38,7 +38,8 @@ class TradeRestriction < ActiveRecord::Base
     :notes, :publication_date, :purpose_ids, :quota, :type,
     :source_ids, :start_date, :term_ids, :unit_id, :internal_notes,
     :nomenclature_note_en, :nomenclature_note_es, :nomenclature_note_fr,
-    :created_by_id, :updated_by_id, :url
+    :created_by_id, :updated_by_id, :url,
+    :taxon_concept_id
 
   belongs_to :taxon_concept
   belongs_to :m_taxon_concept, :foreign_key => :taxon_concept_id

--- a/spec/models/nomenclature_change/full_reassignment_spec.rb
+++ b/spec/models/nomenclature_change/full_reassignment_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe NomenclatureChange::FullReassignment do
+
+  describe 'process' do
+    let(:old_tc){ create_cites_eu_species }
+    let(:new_tc){ create_cites_eu_species }
+    subject { NomenclatureChange::FullReassignment.new(old_tc, new_tc) }
+
+    context 'when distributions present' do
+      before(:each) do
+        create(:distribution, taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.distributions.count).to eq(1) }
+    end
+
+    context 'when references present' do
+      before(:each) do
+        create(:taxon_concept_reference, taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.taxon_concept_references.count).to eq(1) }
+    end
+
+    context 'when listing changes present' do
+      before(:each) do
+        create_cites_I_addition(taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.listing_changes.count).to eq(1) }
+    end
+
+    context 'when EU Opinions present' do
+      before(:each) do
+        create(:eu_opinion, taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.eu_opinions.count).to eq(1) }
+    end
+
+    context 'when EU Suspensions present' do
+      before(:each) do
+        create(:eu_suspension, taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.eu_suspensions.count).to eq(1) }
+    end
+
+    context 'when CITES Quotas present' do
+      before(:each) do
+        create(:quota, taxon_concept: old_tc, geo_entity: create(:geo_entity))
+        subject.process
+      end
+      specify{ expect(new_tc.quotas.count).to eq(1) }
+    end
+
+    context 'when CITES Suspensions present' do
+      before(:each) do
+        create(:cites_suspension, taxon_concept: old_tc,
+          start_notification: create(:cites_suspension_notification, :designation => cites)
+        )
+        subject.process
+      end
+      specify{ expect(new_tc.cites_suspensions.count).to eq(1) }
+    end
+
+    context 'when common names present' do
+      before(:each) do
+        create(:taxon_common, taxon_concept: old_tc)
+        subject.process
+      end
+      specify{ expect(new_tc.taxon_commons.count).to eq(1) }
+    end
+
+  end
+
+end


### PR DESCRIPTION
Fixes [Common names disappeared after ancestor split](http://github.comhttps://www.pivotaltracker.com/story/show/85782196) - the problem affected common names, CITES Quotas and CITES Suspensions. Added tests & additional debugging information for the log.