### PR TITLE
move the auto-reassignments construction step to an earlier stage of …

### DIFF
--- a/app/models/nomenclature_change/status_change/processor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/processor_helpers.rb
@@ -5,7 +5,7 @@ module NomenclatureChange::StatusChange::ProcessorHelpers
 
     # if input is not one of outputs, that means it only acts as a template
     # for associations and reassignment processor should copy rather than
-    # transfer associations
+    # transfer associations; if it is one of the outputs it is probably a swap
     transfer = [@primary_output, @secondary_output].compact.map(&:taxon_concept).include?(
       @input.taxon_concept
     )

--- a/app/models/nomenclature_change/status_change_helpers.rb
+++ b/app/models/nomenclature_change/status_change_helpers.rb
@@ -24,8 +24,6 @@ module NomenclatureChange::StatusChangeHelpers
       accepts_nested_attributes_for :secondary_output, :allow_destroy => true
 
       validate :required_primary_output, if: :primary_output_or_submitting?
-
-      before_save :build_auto_reassignments, if: :summary?
     end
   end
 

--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -29,13 +29,17 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
     message: "%{value} is not a valid status"
   }
   before_save :build_input_for_swap, if: :swap?
+  before_save :build_auto_reassignments, if: :legislation?
 
   def build_input_for_swap
     # In case the primary output is an S name turning A
     # as part of status swap with another A name
-    # this other name becomes an input of the nomenclature change, so that
-    # reassignments can be put in place between this input and
-    # the primary output
+    # the secondary output becomes a pseudo-input for reassignments
+    # to the primary output.
+    # In case the primary output is an A name turning S
+    # as part of status swap with anoter S name
+    # the primary output becomes a pseudo-input for reassignments
+    # to the secondary output.
     if needs_to_receive_associations? && (
       input.nil? || input.taxon_concept_id.blank?)
       build_input(taxon_concept_id: secondary_output.taxon_concept_id)

--- a/app/models/nomenclature_change/status_to_accepted.rb
+++ b/app/models/nomenclature_change/status_to_accepted.rb
@@ -25,6 +25,7 @@ class NomenclatureChange::StatusToAccepted < NomenclatureChange
   before_validation :set_output_name_status, if: :primary_output_or_submitting?
   before_validation :set_output_rank_id, if: :primary_output_or_submitting?
   before_validation :set_output_parent_id, if: :primary_output_or_submitting?
+  before_save :build_auto_reassignments, if: :parent?
 
   def set_output_name_status
     primary_output && primary_output.new_name_status = 'A'

--- a/app/models/nomenclature_change/status_to_synonym.rb
+++ b/app/models/nomenclature_change/status_to_synonym.rb
@@ -30,6 +30,7 @@ class NomenclatureChange::StatusToSynonym < NomenclatureChange
   }
   validate :required_secondary_output, if: :relay_or_submitting?
   before_save :build_input_for_relay, if: :relay?
+  before_save :build_auto_reassignments, if: :legislation?
   before_validation :ensure_new_name_status, if: :primary_output?
 
   def ensure_new_name_status


### PR DESCRIPTION
Fixes [class-level CITES suspension not transferred](https://www.pivotaltracker.com/story/show/85780468) by fixing the order in which reassignments are constructed and processed.