### PR TITLE
possibly fixes listing changes reassignments again

### DIFF
--- a/app/models/nomenclature_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/constructor_helpers.rb
@@ -121,8 +121,8 @@ module NomenclatureChange::ConstructorHelpers
     input.legislation_reassignments.each do |reassignment|
       if input.is_a?(NomenclatureChange::Input)
         _build_multiple_targets(reassignment, outputs)
-        #input.reassignments << reassignment
       end
+      input.reassignments << reassignment
     end
   end
 


### PR DESCRIPTION
Fixes [New taxon created when splitting genus level or above doesn't appear in Checklist](https://www.pivotaltracker.com/story/show/85795594)

The issue reported was that the new taxon resulting form a split does not show up in the Checklist; that was caused by the current CITES listing not being calculated correctly, which in turn was caused by CITES listings not copying properly.