### PR TITLE
Nomenclature notes not appending in checklist download

### DIFF
--- a/app/models/m_taxon_concept.rb
+++ b/app/models/m_taxon_concept.rb
@@ -244,7 +244,7 @@ class MTaxonConcept < ActiveRecord::Base
     ["hash_full_note_#{lng.downcase}", "full_note_#{lng.downcase}", "short_note_#{lng.downcase}"].each do |method_name|
       define_method(method_name) do
         current_cites_additions.map do |lc|
-          note = lc.send(method_name)
+          note = lc.send(method_name) || ''
           note && "Appendix #{lc.species_listing_name}:" + (note || '') + (" #{lc.nomenclature_note}" || '')
         end.join("\n")
       end


### PR DESCRIPTION
This fixes [Public display of nomenclature notes in CITES Checklist](https://www.pivotaltracker.com/n/projects/632333/stories/84580092).
The issue reported was about nomenclature notes not displaying for taxa with rank higher than Species; it turned out that this seems to happen just when the full_note_en attribute is originally blank.
So now, if full_note_en is nil then just use empty string as default so that the other notes can be appended correctly