### PR TITLE
Replace joins with includes to fix readonly exception

### DIFF
--- a/app/models/listing_change.rb
+++ b/app/models/listing_change.rb
@@ -137,14 +137,14 @@ class ListingChange < ActiveRecord::Base
       )
     )
     if party_listing_distribution
-      relation = relation.joins(:party_listing_distribution).where(
+      relation = relation.includes(:party_listing_distribution).where(
         party_listing_distribution.comparison_conditions(
           party_listing_distribution.comparison_attributes.except(:listing_change_id)
         )
       )
     end
     if annotation
-      relation = relation.joins(:annotation).where(
+      relation = relation.includes(:annotation).where(
         annotation.comparison_conditions
       )
     end


### PR DESCRIPTION
This pull request fixes [change A to S](https://www.pivotaltracker.com/n/projects/632333/stories/105120258).
The issue seemed to be caused by the use of joins instead of includes when fetching relations data. Data retrieved using joins is automatically marked as readonly in order to prevent the update of attributes coming from the other table instead of the one who is calling it. Includes instead uses an eager loading approach, so data is not marked as readonly and it is possible to update it.