### PR TITLE
Fix parent selector in taxon editor

### DIFF
--- a/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
+++ b/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
@@ -47,6 +47,46 @@ class AdminEditor
 
     $(alert).insertBefore($('h1'))
 
+  initTaxonConceptTypeaheads: () ->
+
+    $('input.typeahead').each (idx) ->
+      formId = $(@).closest('form').attr('id')
+
+      if formId?
+        matches = formId.match('^(.+_)?(new|edit)_(.+)$')
+        prefix = matches[3]
+        prefix = matches[1] + prefix unless matches[1] == undefined
+
+        taxonomyEl = $('#' + prefix + '_taxonomy_id')
+        rankEl = $('#' + prefix + '_rank_id')
+
+        #initialize this typeahead
+        $(@).typeahead
+          source: (query, process) =>
+            $.get('/admin/taxon_concepts/autocomplete',
+            {
+              search_params: {
+                scientific_name: query,
+                taxonomy: {
+                  id: taxonomyEl && taxonomyEl.val() || $(@).attr('data-taxonomy-id')
+                },
+                rank: {
+                  id: rankEl && rankEl.val() || $(@).attr('data-rank-id'),
+                  scope: $(@).attr('data-rank-scope')
+                }
+              }
+              limit: 25
+            }, (data) =>
+              labels = []
+              $.each(data, (i, item) =>
+                label = item.full_name + ' ' + item.rank_name
+                labels.push(label)
+              )
+              return process(labels)
+            )
+          $().add(taxonomyEl).add(rankEl).change () =>
+            $(@).val(null)
+
   initSearchTypeahead: () ->
     $('.search-typeahead').typeahead
       source: (query, process) ->
@@ -167,46 +207,6 @@ class TaxonConceptsEditor extends AdminEditor
     @saveAndReopen = false
     @initTaxonConceptTypeaheads()
     $('.distributions-list > a').popover({});
-
-  initTaxonConceptTypeaheads: () ->
-
-    $('input.typeahead').each (idx) ->
-      formId = $(@).closest('form').attr('id')
-
-      if formId?
-        matches = formId.match('^(.+_)?(new|edit)_(.+)$')
-        prefix = matches[3]
-        prefix = matches[1] + prefix unless matches[1] == undefined
-
-        taxonomyEl = $('#' + prefix + '_taxonomy_id')
-        rankEl = $('#' + prefix + '_rank_id')
-
-        #initialize this typeahead
-        $(@).typeahead
-          source: (query, process) =>
-            $.get('/admin/taxon_concepts/autocomplete',
-            {
-              search_params: {
-                scientific_name: query,
-                taxonomy: {
-                  id: taxonomyEl && taxonomyEl.val() || $(@).attr('data-taxonomy-id')
-                },
-                rank: {
-                  id: rankEl && rankEl.val() || $(@).attr('data-rank-id'),
-                  scope: $(@).attr('data-rank-scope')
-                }
-              }
-              limit: 25
-            }, (data) =>
-              labels = []
-              $.each(data, (i, item) =>
-                label = item.full_name + ' ' + item.rank_name
-                labels.push(label)
-              )
-              return process(labels)
-            )
-          $().add(taxonomyEl).add(rankEl).change () =>
-            $(@).val(null)
 
   alertSuccess: (txt) ->
     $('.alert').remove()


### PR DESCRIPTION
Moved initTaxonConceptsTypeaheads function into superclass so that all its subclasses can use it, including the one which runs in the taxon concept modal window