### PR TITLE
Fix transferring distribution references

### DIFF
--- a/app/models/nomenclature_change/processor.rb
+++ b/app/models/nomenclature_change/processor.rb
@@ -11,6 +11,7 @@ class NomenclatureChange::Processor
     Rails.logger.warn("[#{@nc.type}] BEGIN")
     @subprocessors.each{ |processor| processor.run }
     Rails.logger.warn("[#{@nc.type}] END")
+    DownloadsCache.clear
   end
 
   def summary

--- a/app/models/nomenclature_change/reassignment_processor.rb
+++ b/app/models/nomenclature_change/reassignment_processor.rb
@@ -85,7 +85,7 @@ class NomenclatureChange::ReassignmentProcessor
   end
 
   def post_process(reassigned_object, object_before_reassignment)
-    Rails.logger.warn("Resassignment post processing BEGIN")
+    Rails.logger.warn("Reassignment post processing BEGIN")
     if reassigned_object.is_a?(TaxonConcept)
       resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(reassigned_object)
       resolver.process
@@ -93,7 +93,7 @@ class NomenclatureChange::ReassignmentProcessor
       resolver = NomenclatureChange::TradeShipmentsResolver.new(reassigned_object, object_before_reassignment)
       resolver.process
     end
-    Rails.logger.warn("Resassignment post processing END")
+    Rails.logger.warn("Reassignment post processing END")
   end
 
 end

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -59,8 +59,14 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
       transfer_distribution_references(reassigned_object, reassignable)
       transfer_distribution_taggings(reassigned_object, reassignable)
     end
+    if reassigned_object.is_a?(ListingChange)
+      transfer_party_listing_distribution(reassigned_object, reassignable)
+      transfer_listing_distributions(reassigned_object, reassignable)
+      transfer_taxonomic_exclusions(reassigned_object, reassignable)
+      transfer_geographic_exclusions(reassigned_object, reassignable)
+    end
     # destroy the original object
-    reassignable.delete
+    reassignable.destroy
   end
 
   def transfer_distribution_references(reassigned_object, reassignable)

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -6,6 +6,7 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
     if reassigned_object
       reassigned_object.save(validate: false)
       post_process(reassigned_object, object_before_reassignment)
+      transfer_associations(reassigned_object, reassignable)
     end
     reassigned_object
   end
@@ -46,6 +47,47 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
   def summary_line
     "The following associations will be transferred from #{@input.taxon_concept.full_name}
       to #{@output.display_full_name}"
+  end
+
+  protected
+
+  def transfer_associations(reassigned_object, reassignable)
+    return if reassigned_object.id == reassignable.id
+    if reassigned_object.is_a?(Distribution)
+      # that means the distribution is a duplicate and was not transferred
+      # but it might have some distribution references and taggings
+      transfer_distribution_references(reassigned_object, reassignable)
+      transfer_distribution_taggings(reassigned_object, reassignable)
+    end
+    # destroy the original object
+    reassignable.delete
+  end
+
+  def transfer_distribution_references(reassigned_object, reassignable)
+    return if reassignable.distribution_references.count == 0
+    distribution_references_to_transfer = reassignable.distribution_references
+    if reassigned_object.distribution_references.count > 0
+      distribution_references_to_transfer = distribution_references_to_transfer.
+      where(
+        'reference_id NOT IN (?)',
+        reassigned_object.distribution_references.select(:reference_id)
+          .map(&:reference_id)
+      )
+    end
+    distribution_references_to_transfer.update_all(distribution_id: reassigned_object.id)
+  end
+
+  def transfer_distribution_taggings(reassigned_object, reassignable)
+    return if reassignable.taggings.count == 0
+    taggings_to_transfer = reassignable.taggings
+    if reassigned_object.taggings.count > 0
+      taggings_to_transfer = taggings_to_transfer.
+      where(
+        'tag_id NOT IN (?)',
+        reassigned_object.taggings.select(:tag_id).map(&:tag_id)
+      )
+    end
+    taggings_to_transfer.update_all(taggable_id: reassigned_object.id)
   end
 
 end

--- a/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
@@ -19,6 +19,12 @@ shared_context 'distribution_reassignments_processor_examples' do
     )
   }
   before(:each) do
+    original_d = create(
+      :distribution,
+      taxon_concept: output_species1,
+      geo_entity: poland
+    )
+    original_d.distribution_references.create(reference_id: create(:reference).id)
     create(:preset_tag, model: 'Distribution', name: 'extinct')
     d = create(
       :distribution,
@@ -33,5 +39,5 @@ shared_context 'distribution_reassignments_processor_examples' do
   specify{ expect(output_species1.distributions.count).to eq(2) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id)).not_to be_nil }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).tag_list).to eq(['extinct']) }
-  specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).distribution_references.count).to eq(1) }
+  specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).distribution_references.count).to eq(2) }
 end

--- a/spec/models/nomenclature_change/shared/legislation_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/legislation_reassignments_processor_examples.rb
@@ -15,6 +15,23 @@ shared_context 'legislation_reassignments_processor_examples' do
   }
   before(:each) do
     lc1_annotation = create(:annotation)
+    original_lc1 = create_cites_III_addition(
+      taxon_concept: output_species1,
+      annotation: lc1_annotation,
+      effective_at: '2013-01-01'
+    )
+    create(
+      :listing_distribution,
+      geo_entity: poland,
+      listing_change: original_lc1,
+      is_party: true
+    )
+    create(
+      :listing_distribution,
+      geo_entity: portugal,
+      listing_change: original_lc1,
+      is_party: false
+    )
     lc1 = create_cites_III_addition(
       taxon_concept: input_species,
       annotation: lc1_annotation,
@@ -99,8 +116,8 @@ shared_context 'legislation_reassignments_processor_examples' do
     expect(
       output_species1.listing_changes.
       find_by_effective_at_and_change_type_id('2013-01-01', cites_addition.id).
-      listing_distributions
-    ).to_not be_empty
+      listing_distributions.count
+    ).to eq(2)
   }
   specify{
     expect(


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/105376724 - transfer of distribution references. The problem would manifest itself when the same distribution existed on the target taxon. There is now a postprocessing step that handles transfers of disjoint distribution references as well as listing distributions & exclusions. Also adds a step to clear the downloads cache on finished processing.