### PR TITLE
match all taxa citations

### DIFF
--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -96,7 +96,10 @@ class DocumentSearch
   end
 
   def add_taxon_concepts_condition
-    @query = @query.where("taxon_concept_ids && ARRAY[#{@taxon_concepts_ids.join(',')}]")
+    @query = @query.where(
+      "taxon_concept_ids && ARRAY[#{@taxon_concepts_ids.join(',')}]
+      OR taxon_concept_ids = ARRAY[]::INT[]"
+    )
   end
 
   def add_geo_entities_condition

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -51,7 +51,7 @@ describe Admin::DocumentsController do
         end
         it "retrieves documents for taxon concept" do
           get :index, "taxon_concepts_ids" => taxon_concept.id
-          assigns(:documents).should eq([@document1])
+          assigns(:documents).should eq([@document2, @document1])
         end
         it "retrieves documents for geo entity" do
           get :index, "geo_entities_ids" => [geo_entity.id]

--- a/spec/models/document_search_spec.rb
+++ b/spec/models/document_search_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+describe DocumentSearch do
+  describe :results do
+    context "when searching by taxon concept" do
+      let(:tc){ create_cites_eu_species }
+      let(:document_with_tc_citation){
+        create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
+      }
+      let(:citation){ create(:document_citation, document_id: document_with_tc_citation.id) }
+      let!(:tc_citation){
+        create(
+          :document_citation_taxon_concept,
+          document_citation_id: citation.id,
+          taxon_concept_id: tc.id
+        )
+      }
+      subject { DocumentSearch.new({taxon_concepts_ids: [tc.id]}, 'admin').results }
+      specify { subject.should include(document_with_tc_citation) }
+      
+      context "when documents without tc citations present" do
+        let!(:document_without_tc_citation){
+          create(:proposal, is_public: true, event: document_with_tc_citation.event)
+        }
+        specify { subject.should include(document_without_tc_citation) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
When searching by a taxon, also match all those documents that have citations for 'all taxa'. Fixes https://www.pivotaltracker.com/story/show/108217088