### PR TITLE
Shorten documents title

### DIFF
--- a/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
@@ -43,7 +43,7 @@ Ember.Handlebars.registerHelper 'getItem', (id, options) ->
   field = options.hash.field
   model = options.hash.model
   Species[model].find(id).get(field)
-  
+
 Ember.Handlebars.registerHelper 'sizeGt', (str, options) ->
   str = Ember.Handlebars.get(this, str, options)
   if str.length > options.hash.max then options.fn(@) else options.inverse(@)
@@ -52,3 +52,10 @@ Ember.Handlebars.registerHelper 'tolower', (str, options) ->
   str = Ember.Handlebars.get(this, str)
   defaultString = options.hash?.default or ""
   if str then str.toLowerCase() else defaultString
+
+Ember.Handlebars.registerHelper 'truncate', (text, options) ->
+  text = Ember.Handlebars.get(this, text)
+  limit = options.hash.limit || 50
+  if text.length > limit
+    text = text.substr(0, limit - 3) + "..."
+  return text

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -1,7 +1,7 @@
 <td class="event-col">{{unbound doc.event_name}}</td>
 <td class='event-date-col'>{{unbound doc.date}}</td>
 <td class='title-col'>
-  <a class="legal-links" {{bind-attr href=view.documentUrl}}>{{truncate title}}</a>
+  <a class="legal-links" {{bind-attr title=title}} {{bind-attr href=view.documentUrl}}>{{truncate title}}</a>
   [{{unbound doc.extension}}]
 </td>
 <td class='language-col'>

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -1,7 +1,7 @@
 <td class="event-col">{{unbound doc.event_name}}</td>
 <td class='event-date-col'>{{unbound doc.date}}</td>
 <td class='title-col'>
-  <a class="legal-links" {{bind-attr title=title}} {{bind-attr href=view.documentUrl}}>{{truncate title}}</a>
+  <a class="legal-links tooltip" {{bind-attr data-descr=title}} {{bind-attr href=view.documentUrl}}>{{truncate title}}</a>
   [{{unbound doc.extension}}]
 </td>
 <td class='language-col'>

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -1,7 +1,7 @@
 <td class="event-col">{{unbound doc.event_name}}</td>
 <td class='event-date-col'>{{unbound doc.date}}</td>
 <td class='title-col'>
-  <a class="legal-links" {{bind-attr href=view.documentUrl}}>{{title}}</a>
+  <a class="legal-links" {{bind-attr href=view.documentUrl}}>{{truncate title}}</a>
   [{{unbound doc.extension}}]
 </td>
 <td class='language-col'>

--- a/app/assets/javascripts/species/templates/components/documents-tooltip.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-tooltip.handlebars
@@ -2,10 +2,9 @@
   <div class='multiple-data-container'>
     <div class='document-data'>
       {{data.length}}&nbsp{{type}}
-      <i class='fa fa-info-circle'></i>
-    </div>
-    <div class='data-tooltip'>
-      {{data}}
+      <span class='tooltip' {{bind-attr data-descr=formattedData}}>
+        <i class='fa fa-info-circle'></i>
+      </span>
     </div>
   </div>
 {{else}}

--- a/app/assets/javascripts/species/views/documents/documents_tooltip_component.js.coffee
+++ b/app/assets/javascripts/species/views/documents/documents_tooltip_component.js.coffee
@@ -4,3 +4,7 @@ Species.DocumentsTooltipComponent = Ember.Component.extend
   multipleValues: ( ->
     this.get('data').length > 1
   ).property('person')
+
+  formattedData: ( ->
+    this.get('data').join(', ')
+  ).property()

--- a/app/assets/stylesheets/species/documents.scss
+++ b/app/assets/stylesheets/species/documents.scss
@@ -84,6 +84,7 @@ table.grouped-results-table {
               td{border-bottom: 1px solid #DFE1E2;}
               td.title-col {
                 i.fa-file-pdf-o { color: #868686; }
+                .tooltip[data-descr] { cursor: pointer; }
               }
               input { margin-left: 28px; }
               .multiple-data-container {

--- a/app/assets/stylesheets/species/documents.scss
+++ b/app/assets/stylesheets/species/documents.scss
@@ -91,17 +91,6 @@ table.grouped-results-table {
                   z-index: 10;
                   i { font-size: 16px; }
               }
-              .data-tooltip {
-                  position: absolute;
-                  max-width: 200px;
-                  bottom: 20px;
-                  left: 20px;
-                  background-color: #FFF;
-                  border: 1px solid #CCC;
-                  display: none;
-              }
-              .multiple-data-container:hover {z-index: 20;}
-              .multiple-data-container:hover .data-tooltip {display: block;}
             }
           }
         }


### PR DESCRIPTION
- Documents title are now shortened at 50 characters by default
- The full title of a document has been added as a tooltip
- Other documents tooltips have been reworked according to other tooltips' style already in place in Species+