### PR TITLE
Documents limit rework

### DIFF
--- a/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
@@ -8,11 +8,11 @@ Species.TaxonConceptDocumentsRoute = Ember.Route.extend
     $.ajax(
       url: "/api/v1/documents?taxon_concepts_ids=" + model.get('id'),
       success: (data) ->
-        model.set('cites_cop_docs', data.cites_cop_docs)
-        model.set('ec_srg_docs', data.ec_srg_docs)
-        model.set('cites_ac_docs', data.cites_ac_docs)
-        model.set('cites_pc_docs', data.cites_pc_docs)
-        model.set('other_docs', data.other_docs)
+        model.set('cites_cop_docs', data.cites_cop.docs)
+        model.set('ec_srg_docs', data.ec_srg.docs)
+        model.set('cites_ac_docs', data.cites_ac.docs)
+        model.set('cites_pc_docs', data.cites_pc.docs)
+        model.set('other_docs', data.other.docs)
       error: (jqXHR, textStatus, errorThrown) ->
         console.log("AJAX Error:" + textStatus)
     )

--- a/app/assets/javascripts/species/templates/components/documents-results.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-results.handlebars
@@ -55,5 +55,5 @@
     </div>
   </td>
 {{else}}
-  <td><div>No data available</div></td>
+  <td colspan="3"><div>No data available</div></td>
 {{/if}}

--- a/app/assets/javascripts/species/templates/components/documents-row.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-row.handlebars
@@ -1,0 +1,11 @@
+<tr class="group">
+  <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
+  <td class="meeting-type">{{meeting_type}}</td>
+  <td>
+    <span class="no-of-documents">{{documents.docs.length}}</span>
+    {{#if documents.excluded_docs}}
+      <span>(excluded: {{documents.excluded_docs}})</span>
+    {{/if}}
+  </td>
+</tr>
+{{documents-results documents=documents.docs}}

--- a/app/assets/javascripts/species/templates/documents.handlebars
+++ b/app/assets/javascripts/species/templates/documents.handlebars
@@ -12,36 +12,11 @@
         </tr>
       </thead>
       <tbody>
-        <tr class="group">
-          <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
-          <td>EC SRG</td>
-          <td>{{content.ec_srg_docs.length}}</td>
-        </tr>
-        {{documents-results documents=content.ec_srg_docs}}
-        <tr class="group">
-          <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
-          <td>CITES CoP</td>
-          <td>{{content.cites_cop_docs.length}}</td>
-        </tr>
-        {{documents-results documents=content.cites_cop_docs proposalOutcome=true}}
-        <tr class="group">
-          <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
-          <td>CITES Animals Committee</td>
-          <td>{{content.cites_ac_docs.length}}</td>
-        </tr>
-        {{documents-results documents=content.cites_ac_docs reviewPhase=true}}
-        <tr class="group">
-          <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
-          <td>CITES Plants Committee</td>
-          <td>{{content.cites_pc_docs.length}}</td>
-        </tr>
-        {{documents-results documents=content.cites_pc_docs reviewPhase=true}}
-        <tr class="group">
-          <td>{{#view Species.ResultToggleButton}}{{/view}}</td>
-          <td>Other</td>
-          <td>{{content.other_docs.length}}</td>
-        </tr>
-        {{documents-results documents=content.other_docs}}
+        {{documents-row meeting_type="EC SRG" documents=content.ec_srg}}
+        {{documents-row meeting_type="CITES CoP" documents=content.cites_cop}}
+        {{documents-row meeting_type="CITES Animals Committee" documents=content.cites_ac}}
+        {{documents-row meeting_type="CITES Plants Committee" documents=content.cites_pc}}
+        {{documents-row meeting_type="Other" documents=content.other}}
       </tbody>
     </table>
   </div>

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -1,7 +1,4 @@
 <strong class="documents-search-results-header">Search Results</strong>
-<span>
-  (Results have been limited to the 100 most recent documents per each meeting type)
-</span>
 <p class="search-options-toggle">
   <i class="fa fa-plus-circle"></i>
   <span {{action toggleSearchOptions target=view}}>

--- a/app/assets/javascripts/species/views/documents/documents_row_component.js.coffee
+++ b/app/assets/javascripts/species/views/documents/documents_row_component.js.coffee
@@ -1,0 +1,2 @@
+Species.DocumentsRowComponent = Ember.Component.extend
+  layoutName: 'species/components/documents-row'

--- a/app/assets/stylesheets/species/documents.scss
+++ b/app/assets/stylesheets/species/documents.scss
@@ -1,123 +1,101 @@
 table.grouped-results-table {
-    width: 100%;
-    thead.grouped-header {
-      th { font-weight: bold; }
-    }
-    tr {background: none;}
-    tbody {
-      &:before {
-        display: block;
-        line-height: 1em;
-        color: transparent;
-      }
-      tr{
-        td{
-          padding: 10px 1px;
-          vertical-align: middle;
-          i {
-            font-size: 48px;
-            color: #648aa2;
-            margin-left: 10px;
-          }
-        }
-      }
-      tr.group {
-        td { border-top: 1px solid #DFE1E2; }
-      }
-      tr.table-row {
-        display: none;
-        & > td {
-          padding-bottom: 0;
-
-        }
-        div.inner-table-container {
-          display: none;
-          i { font-size: 12px; }
-
-          table.table-header {
-            width: 100%;
-            th.event-col, th.event-date-col, th.title-col {
-              ul {
-                display: inline-block;
-                vertical-align: middle;
-                line-height: 0;
-                i.fa-caret-up { line-height: 0; }
-              }
-            }
-          }
-
-          table.table-body {
-            overflow-y: auto;
-            min-height: 100px;
-            max-height: 400px;
-            width: 100%;
-            margin-top: 10px;
-            border-top: 2px solid #DFE1E2;
-            border-bottom: 1px solid #DFE1E2;
-            -webkit-box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
-                                inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
-            -moz-box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
-                             inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
-            box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
-                        inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
-          }
-          table {
-            width: 908px;
-            clear: both;
-            table-layout: fixed; //not always necessary
-            td { cell-spacing: 2px; }
-            td:first-child, th:first-child {
-              padding-left: 20px;
-            }
-            td { word-wrap: break-word } //not always necessary
-            th.event-col { max-width: 100px; }
-            th.event-date-col { max-width: 112px; }
-            th.title-col { max-width: 198px; }
-            th.language-col { max-width: 90px; }
-            th.countries-col { max-width: 169px; }
-            th.taxon-col { max-width: 169px; }
-            th.download-col {
-              width: 70px;
-              i.fa-download { cursor: pointer; }
-            }
-            &.table-body tbody {
-              td{border-bottom: 1px solid #DFE1E2;}
-              td.title-col {
-                i.fa-file-pdf-o { color: #868686; }
-                .tooltip[data-descr] { cursor: pointer; }
-              }
-              input { margin-left: 28px; }
-              .multiple-data-container {
-                  position: relative;
-                  z-index: 10;
-                  i { font-size: 16px; }
-              }
-            }
-          }
-        }
-      }
-    }
+  width: 100%;
+  thead.grouped-header {
+    th { font-weight: bold; }
   }
-
-#documents {
-  .grouped-results-table {
-    tr {
-      background: none;
+  tr {background: none;}
+  tbody {
+    &:before {
+      display: block;
+      line-height: 1em;
+      color: transparent;
+    }
+    tr{
+      td{
+        padding: 10px 1px;
+        vertical-align: middle;
+        i {
+          font-size: 48px;
+          color: #648aa2;
+          margin-left: 10px;
+        }
+      }
+    }
+    tr.group {
+      td { border-top: 1px solid #DFE1E2; }
+      .meeting-type, .no-of-documents { font-weight: bold; }
     }
     tr.table-row {
-      display: block;
+      display: none;
+      & > td {
+        padding-bottom: 0;
+
+      }
       div.inner-table-container {
-        display: block;
+        display: none;
+        i { font-size: 12px; }
+
+        table.table-header {
+          width: 100%;
+          th.event-col, th.event-date-col, th.title-col {
+            ul {
+              display: inline-block;
+              vertical-align: middle;
+              line-height: 0;
+              i.fa-caret-up { line-height: 0; }
+            }
+          }
+        }
+
+        table.table-body {
+          overflow-y: auto;
+          min-height: 100px;
+          max-height: 400px;
+          width: 100%;
+          margin-top: 10px;
+          border-top: 2px solid #DFE1E2;
+          border-bottom: 1px solid #DFE1E2;
+          -webkit-box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
+          inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
+          -moz-box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
+          inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
+          box-shadow: inset 0px 10px 10px -6px rgba(223, 225, 226, 0.75),
+          inset 0px -10px 10px -6px rgba(223, 225, 226, 0.75);
+        }
+        table {
+          width: 908px;
+          clear: both;
+          table-layout: fixed; //not always necessary
+          td { cell-spacing: 2px; }
+          td:first-child, th:first-child {
+            padding-left: 20px;
+          }
+          td { word-wrap: break-word } //not always necessary
+          th.event-col { max-width: 100px; }
+          th.event-date-col { max-width: 112px; }
+          th.title-col { max-width: 198px; }
+          th.language-col { max-width: 90px; }
+          th.countries-col { max-width: 169px; }
+          th.taxon-col { max-width: 169px; }
+          th.download-col {
+            width: 70px;
+            i.fa-download { cursor: pointer; }
+          }
+          &.table-body tbody {
+            td{border-bottom: 1px solid #DFE1E2;}
+            td.title-col {
+              i.fa-file-pdf-o { color: #868686; }
+              .tooltip[data-descr] { cursor: pointer; }
+            }
+            input { margin-left: 28px; }
+            .multiple-data-container {
+              position: relative;
+              z-index: 10;
+              i { font-size: 16px; }
+            }
+          }
+        }
       }
     }
-    th {
-      border-bottom: none;
-      color: none;
-      padding: 0;
-    }
-    td {
-      border-top: none;
-    }
-    table.table-body { margin-top: 10px; }
   }
 }

--- a/app/assets/stylesheets/species/documents.scss
+++ b/app/assets/stylesheets/species/documents.scss
@@ -29,6 +29,7 @@ table.grouped-results-table {
       display: none;
       & > td {
         padding-bottom: 0;
+        width: 820px; //Temporary fix for FF on Windows
 
       }
       div.inner-table-container {
@@ -99,3 +100,28 @@ table.grouped-results-table {
     }
   }
 }
+
+//TaxonConcept documents table
+#documents {
+  .grouped-results-table {
+    tr {
+      background: none;
+    }
+    tr.table-row {
+      display: block;
+      div.inner-table-container {
+        display: block;
+      }
+    }
+    th {
+      border-bottom: none;
+      color: none;
+      padding: 0;
+    }
+    td {
+      border-top: none;
+    }
+    table.table-body { margin-top: 10px; }
+  }
+}
+

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -111,7 +111,9 @@ class Api::V1::DocumentsController < ApplicationController
   end
 
   def no_of_excluded_docs(documents, limit)
-    excluded = documents.length - limit
+    query = "SELECT count(*) AS count_all FROM (#{documents.to_sql}) x"
+    count = ActiveRecord::Base.connection.execute(query).first.try(:[], "count_all").to_i
+    excluded = count - limit
     excluded < 0 ? 0 : excluded
   end
 

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -8,14 +8,19 @@ class Api::V1::DocumentsController < ApplicationController
     end
     @search = DocumentSearch.new(params, 'public')
 
-    documents = @search.results.order('date_raw DESC').limit(100)
+    documents = @search.results.order('date_raw DESC')
 
     documents = documents.where(is_public: "true") if access_denied?
 
+    limit = 200
     cites_cop_docs = documents.where(event_type: "CitesCop")
+    cites_cop_excluded = no_of_excluded_docs(cites_cop_docs, limit)
     ec_srg_docs = documents.where(event_type: "EcSrg")
+    ec_srg_excluded = no_of_excluded_docs(ec_srg_docs, limit)
     cites_ac_docs = documents.where(event_type: "CitesAc")
+    cites_ac_excluded = no_of_excluded_docs(cites_ac_docs, limit)
     cites_pc_docs = documents.where(event_type: "CitesPc")
+    cites_pc_excluded = no_of_excluded_docs(cites_pc_docs, limit)
     # other docs can be docs tied to historic types of events (CITES Technical
     # Committe, CITES Extraordinary Meeting) or ones without event
     other_docs = documents.where(
@@ -24,13 +29,29 @@ class Api::V1::DocumentsController < ApplicationController
         OR event_type NOT IN ('EcSrg', 'CitesCop', 'CitesAc', 'CitesPc')
       SQL
     )
+    other_excluded = no_of_excluded_docs(other_docs, limit)
 
     render :json => {
-      cites_cop_docs: serialize_documents(cites_cop_docs),
-      ec_srg_docs: serialize_documents(ec_srg_docs),
-      cites_ac_docs: serialize_documents(cites_ac_docs),
-      cites_pc_docs: serialize_documents(cites_pc_docs),
-      other_docs: serialize_documents(other_docs)
+      cites_cop: {
+        docs: serialize_documents(cites_cop_docs, limit),
+        excluded_docs: cites_cop_excluded,
+      },
+      ec_srg: {
+        docs: serialize_documents(ec_srg_docs, limit),
+        excluded_docs: ec_srg_excluded
+      },
+      cites_ac: {
+        docs: serialize_documents(cites_ac_docs, limit),
+        excluded_docs: cites_ac_excluded
+      },
+      cites_pc: {
+        docs: serialize_documents(cites_pc_docs, limit),
+        excluded_docs: cites_pc_excluded
+      },
+      other: {
+        docs: serialize_documents(other_docs, limit),
+        excluded_docs: other_excluded
+      }
     }
   end
 
@@ -82,11 +103,16 @@ class Api::V1::DocumentsController < ApplicationController
     !current_user || current_user.role == User::API_USER
   end
 
-  def serialize_documents(documents)
+  def serialize_documents(documents, limit)
     ActiveModel::ArraySerializer.new(
-      documents,
+      documents.limit(limit),
       each_serializer: Species::DocumentsSerializer
     )
+  end
+
+  def no_of_excluded_docs(documents, limit)
+    excluded = documents.length - limit
+    excluded < 0 ? 0 : excluded
   end
 
 end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -17,7 +17,8 @@ describe Api::V1::DocumentsController, :type => :controller do
   context "GET index returns all documents" do
     def get_all_documents
       get :index, taxon_concept_id: @taxon_concept.id
-      response.body.should have_json_size(2).at_path('cites_cop_docs')
+      response.body.should have_json_size(2).at_path('cites_cop/docs')
+      response.body.should have_json_path('cites_cop/excluded_docs')
     end
     context "GET index contributor" do
       login_contributor
@@ -39,7 +40,8 @@ describe Api::V1::DocumentsController, :type => :controller do
   context "GET index returns only public documents" do
     def get_public_documents
       get :index, taxon_concept_id: @taxon_concept.id
-      response.body.should have_json_size(1).at_path('cites_cop_docs')
+      response.body.should have_json_size(1).at_path('cites_cop/docs')
+      response.body.should have_json_path('cites_cop/excluded_docs')
     end
     context "GET index api user " do
       login_api_user


### PR DESCRIPTION
Documents are now limited to 200 per each meeting type and the count of the excluded documents is shown on the right.
Fixed also a bug affecting the display of tables in FF for Windows