### PR TITLE
Missing documents batch download

### DIFF
--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -4,8 +4,8 @@ describe Api::V1::DocumentsController, :type => :controller do
 
   before(:each) do
     @taxon_concept = create(:taxon_concept)
-    document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
-    citation = create(:document_citation, document_id: document.id)
+    @document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
+    citation = create(:document_citation, document_id: @document.id)
     create(:document_citation_taxon_concept, document_citation_id: citation.id,
       taxon_concept_id: @taxon_concept.id)
     @document2 = create(:proposal, event: create(:cites_cop, designation: cites))
@@ -62,6 +62,36 @@ describe Api::V1::DocumentsController, :type => :controller do
     it "should return 403 status when permission denied" do
       get :show, id: @document2.id
       expect(response.status).to eq(403)
+    end
+  end
+
+  context "download documents" do
+    context "single document selected" do
+      it "should return 404 if file is missing" do
+        File.stub!(:exists?).and_return(false)
+        get :download_zip, ids: @document2.id
+        expect(response.status).to eq(404)
+      end
+      it "should return zip file if file is found" do
+        controller.stub!(:render)
+        File.stub!(:exists?).and_return(true)
+        get :download_zip, ids: @document2.id
+        response.headers['Content-Type'].should eq 'application/zip'
+      end
+    end
+
+    context "multiple documents selected" do
+      it "should return 404 if all files are missing" do
+        File.stub!(:exists?).and_return(false)
+        get :download_zip, ids: "#{@document.id},#{@document2.id}"
+        expect(response.status).to eq(404)
+      end
+
+      it "should return zip file if at least a file is found" do
+        File.stub!(:exists?).and_return(false, true)
+        get :download_zip, ids: "#{@document.id},#{@document2.id}"
+        response.headers['Content-Type'].should eq 'application/zip'
+      end
     end
   end
 end


### PR DESCRIPTION
Batch download will now return 404 just if all selected documents are missing, otherwise a zip file is generated, containing also a missing_files.txt listing all the missing documents.