### PR TITLE
Link to primary language version

### DIFF
--- a/app/assets/javascripts/admin/documents.js.coffee
+++ b/app/assets/javascripts/admin/documents.js.coffee
@@ -48,9 +48,8 @@ $(document).ready ->
       dataType: 'json'
       data: (query, page) ->
         {
-          search_params:
-            title: query
-            event_id: $('#document_event_id').val()
+          title: query
+          event_id: $('#document_event_id').val()
         }
       results: (data, page) ->
         formatted_documents = data.map (doc) =>

--- a/app/assets/javascripts/admin/documents.js.coffee
+++ b/app/assets/javascripts/admin/documents.js.coffee
@@ -35,6 +35,29 @@ $(document).ready ->
       newEventLink.show()
   )
 
+  primaryDocumentSelect2Options = {
+    placeholder: 'Start typing title'
+    width: '500px'
+    minimumInputLength: 3
+    quietMillis: 500
+    allowClear: true
+    initSelection: (element, callback) ->
+      callback($(element).data('init-selection'))
+    ajax:
+      url: '/admin/documents/autocomplete'
+      dataType: 'json'
+      data: (query, page) ->
+        {
+          search_params:
+            title: query
+        }
+      results: (data, page) ->
+        formatted_documents = data.map (doc) =>
+          id: doc.id
+          text: doc.title
+        results: formatted_documents
+  }
+
   citationTaxonSelect2Options = {
     placeholder: 'Start typing scientific name'
     multiple: true
@@ -76,6 +99,7 @@ $(document).ready ->
     allowClear: true
   }
 
+  $('.primary-language-document').select2(primaryDocumentSelect2Options)
   $('.citation-taxon-concept').select2(citationTaxonSelect2Options)
   $('.citation-geo-entity').select2(citationGeoEntitySelect2Options)
   $('.document-tag').select2(documentTagSelect2Options)

--- a/app/assets/javascripts/admin/documents.js.coffee
+++ b/app/assets/javascripts/admin/documents.js.coffee
@@ -50,6 +50,7 @@ $(document).ready ->
         {
           search_params:
             title: query
+            event_id: $('#document_event_id').val()
         }
       results: (data, page) ->
         formatted_documents = data.map (doc) =>

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -62,6 +62,15 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
     end
   end
 
+  def autocomplete
+    title = params[:search_params][:title]
+    @matched_documents = Document.where("title LIKE ?", "%#{title}%")
+
+    render :json => @matched_documents.to_json(
+      :only => [:id, :title]
+    )
+  end
+
   protected
 
   def collection

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -64,7 +64,17 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
 
   def autocomplete
     title = params[:search_params][:title]
-    @matched_documents = Document.where("title LIKE ?", "%#{title}%")
+    event_id = params[:search_params][:event_id]
+    sql_query = "LOWER(title) LIKE :title"
+    sql_query = "#{sql_query} AND event_id = :event_id"
+    @matched_documents = Document.where(
+      ActiveRecord::Base.send(:sanitize_sql_array, [
+        sql_query,
+        :title => "#{title}%",
+        :event_id => event_id
+
+      ])
+    )
 
     render :json => @matched_documents.to_json(
       :only => [:id, :title]

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -63,19 +63,10 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   end
 
   def autocomplete
-    title = params[:search_params][:title]
-    event_id = params[:search_params][:event_id]
-    sql_query = "LOWER(title) LIKE :title"
-    sql_query = "#{sql_query} AND event_id = :event_id"
-    @matched_documents = Document.where(
-      ActiveRecord::Base.send(:sanitize_sql_array, [
-        sql_query,
-        :title => "#{title}%",
-        :event_id => event_id
-
-      ])
-    )
-
+    title = params[:title]
+    event_id = params[:event_id]
+    @matched_documents = event_id.present? ? Document.where(event_id: event_id) : Document
+    @matched_documents = @matched_documents.search_by_title(title)
     render :json => @matched_documents.to_json(
       :only => [:id, :title]
     )

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -32,7 +32,8 @@ class Document < ActiveRecord::Base
   track_who_does_it
   attr_accessible :event_id, :filename, :date, :type, :title, :is_public,
     :language_id, :citations_attributes, :number,
-    :sort_index, :discussion_id, :discussion_sort_index
+    :sort_index, :discussion_id, :discussion_sort_index,
+    :primary_language_document_id
   belongs_to :event
   belongs_to :language
   belongs_to :primary_language_document, class_name: 'Document', foreign_key: 'primary_language_document_id'

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,6 +35,7 @@ class Document < ActiveRecord::Base
     :sort_index, :discussion_id, :discussion_sort_index
   belongs_to :event
   belongs_to :language
+  belongs_to :primary_language_document, class_name: 'Document', foreign_key: 'primary_language_document_id'
   has_many :citations, class_name: 'DocumentCitation', dependent: :destroy
   has_and_belongs_to_many :tags, class_name: 'DocumentTag', join_table: 'document_tags_documents'
   validates :title, presence: true

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -119,7 +119,11 @@ class DocumentSearch
 
   def select_and_group_query
     columns = "event_name, event_type, date, date_raw, is_public, document_type,
-      number, primary_document_id,
+      SQUISH_NULL(number) AS number, primary_document_id,
+      geo_entity_names, taxon_names, extension,
+      proposal_outcome, review_phase"
+    columns_for_grouping = "event_name, event_type, date, date_raw, is_public, document_type,
+      SQUISH_NULL(number), primary_document_id,
       geo_entity_names, taxon_names, extension,
       proposal_outcome, review_phase"
     aggregators = <<-SQL
@@ -136,7 +140,7 @@ class DocumentSearch
 
     @query = Document.from(
       '(' + @query.to_sql + ') documents'
-    ).select(columns + "," + aggregators).group(columns)
+    ).select(columns + "," + aggregators).group(columns_for_grouping)
   end
 
 end

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -43,6 +43,13 @@
         )
       %>
     </div>
+    <%= f.label :primary_language_document_id, class: 'control-label' %>
+    <div class="controls">
+      <%= f.hidden_field :primary_language_document_id, {
+        :class => 'primary-language-document',
+        :'data-init-selection' => {id: f.object.primary_language_document.id, text: f.object.primary_language_document.title}.to_json,
+      } %>
+    </div>
   </div>
 
   <div class="control-group">

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -43,11 +43,14 @@
         )
       %>
     </div>
+  </div>
+
+  <div class="control-group">
     <%= f.label :primary_language_document_id, class: 'control-label' %>
     <div class="controls">
       <%= f.hidden_field :primary_language_document_id, {
         :class => 'primary-language-document',
-        :'data-init-selection' => {id: f.object.primary_language_document.id, text: f.object.primary_language_document.title}.to_json,
+        :'data-init-selection' => {id: f.object.primary_language_document.try(:id), text: f.object.primary_language_document.try(:title)}.to_json,
       } %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,9 @@ SAPI::Application.routes.draw do
     resources :cites_extraordinary_meetings
 
     resource :document_batch, :only => [:new, :create]
-    resources :documents
+    resources :documents do
+      get :autocomplete, :on => :collection
+    end
 
     resources :cites_suspension_notifications
     resources :references, :only => [:index, :create, :update, :destroy] do

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -208,4 +208,33 @@ describe Admin::DocumentsController do
     end
   end
 
+  describe "XHR GET JSON autocomplete" do
+    let!(:document){
+      create(:document,
+        :title => 'Title',
+        :event_id => event.id
+      )
+    }
+    let!(:document2){ create(:document, :title => 'Title2') }
+
+    context "When no event specified" do
+      it "returns properly formatted json" do
+        xhr :get, :autocomplete, :format => 'json',
+          :title => 'tit'
+        response.body.should have_json_size(2)
+        parse_json(response.body, "0/title").should == 'Title'
+        parse_json(response.body, "1/title").should == 'Title2'
+      end
+    end
+
+    context "When an event is specified" do
+      it "returns properly formatted json" do
+        xhr :get, :autocomplete, :format => 'json',
+          :title => 'tit', :event_id => event.id
+        response.body.should have_json_size(1)
+        parse_json(response.body, "0/title").should == 'Title'
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR is about [this story](https://www.pivotaltracker.com/n/projects/1129270/stories/99139154)
In the admin interface, while editing a document, the admin can add a link to another document as a primary language document. The search is filtered by title and by event if this has been selected