### PR TITLE
display loading spinners on documents tab while loading documents

### DIFF
--- a/app/assets/javascripts/species/controllers/taxon_concept_documents_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/taxon_concept_documents_controller.js.coffee
@@ -1,2 +1,28 @@
 Species.TaxonConceptDocumentsController = Ember.ArrayController.extend
   needs: 'taxonConcept'
+  ecSrgDocsIsLoading: true
+  citesCopDocsIsLoading: true
+  citesAcDocsIsLoading: true
+  citesPcDocsIsLoading: true
+  otherDocsIsLoading: true
+
+  ecSrgDocsObserver: ( ->
+    console.log("hello ec srg")
+    @set('ecSrgDocsIsLoading', false)
+  ).observes('controllers.taxonConcept.ec_srg_docs.@each.didLoad')
+
+  citesCopDocsObserver: ( ->
+    @set('citesCopDocsIsLoading', false)
+  ).observes('controllers.taxonConcept.cites_cop_docs.@each.didLoad')
+
+  citesAcDocsObserver: ( ->
+    @set('citesAcDocsIsLoading', false)
+  ).observes('controllers.taxonConcept.cites_ac_docs.@each.didLoad')
+
+  citesPcDocsObserver: ( ->
+    @set('citesPcDocsIsLoading', false)
+  ).observes('controllers.taxonConcept.cites_pc_docs.@each.didLoad')
+
+  citesOtherDocsObserver: ( ->
+    @set('citesOtherDocsIsLoading', false)
+  ).observes('controllers.taxonConcept.cites_other_docs.@each.didLoad')

--- a/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
@@ -1,7 +1,9 @@
 Species.TaxonConceptDocumentsRoute = Ember.Route.extend
   renderTemplate: ->
-    @getDocuments()
     @render('taxon_concept/documents')
+    Ember.run.scheduleOnce('afterRender', @, () ->
+      @getDocuments()
+    )
 
   getDocuments: ->
     model = this.modelFor("taxonConcept")

--- a/app/assets/javascripts/species/templates/components/documents-results.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-results.handlebars
@@ -55,5 +55,11 @@
     </div>
   </td>
 {{else}}
-  <td colspan="3"><div>No data available</div></td>
+  <td colspan="3">
+  {{#if isLoading}}
+    <img src="/assets/loading.gif">
+  {{else}}
+    <div>No data available</div>
+  {{/if}}
+  </td>
 {{/if}}

--- a/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
@@ -5,7 +5,8 @@
 
     <table class="grouped-results-table">
       <tbody>
-        {{documents-results documents=controllers.taxonConcept.ec_srg_docs}}
+        {{documents-results documents=controllers.taxonConcept.ec_srg_docs
+          isLoading=controller.ecSrgDocsIsLoading}}
       </tbody>
     </table>
 
@@ -13,7 +14,9 @@
 
     <table class="grouped-results-table">
       <tbody>
-        {{documents-results documents=controllers.taxonConcept.cites_cop_docs proposalOutcome=true}}
+        {{documents-results documents=controllers.taxonConcept.cites_cop_docs
+          proposalOutcome=true
+          isLoading=controller.citesCopDocsIsLoading}}
       </tbody>
     </table>
 
@@ -21,7 +24,9 @@
 
     <table class="grouped-results-table">
       <tbody>
-        {{documents-results documents=controllers.taxonConcept.cites_ac_docs reviewPhase=true}}
+        {{documents-results documents=controllers.taxonConcept.cites_ac_docs
+        reviewPhase=true
+        isLoading=controller.citesAcDocsIsLoading}}
       </tbody>
     </table>
 
@@ -29,7 +34,9 @@
 
     <table class="grouped-results-table">
       <tbody>
-        {{documents-results documents=controllers.taxonConcept.cites_pc_docs reviewPhase=true}}
+        {{documents-results documents=controllers.taxonConcept.cites_pc_docs
+          reviewPhase=true
+          isLoading=controller.citesPcDocsIsLoading}}
       </tbody>
     </table>
 
@@ -37,7 +44,8 @@
 
     <table class="grouped-results-table">
       <tbody>
-        {{documents-results documents=controllers.taxonConcept.other_docs}}
+        {{documents-results documents=controllers.taxonConcept.other_docs
+          isLoading=controller.otherDocsIsLoading}}
       </tbody>
     </table>
 


### PR DESCRIPTION
observers are set up on each of the document arrays, as I haven't been successful in finding a better way of controlling when to hide the spinners (the `complete` callback of the ajax call happens too early)