### PR TITLE
Other documents not retrieved

### DIFF
--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -45,6 +45,8 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
 
   loadDocumentsForEventType: (eventType, eventTypeQueryParams) ->
     controller = @controllerFor('documents')
+    if eventType in ['CitesTc', 'CitesExtraordinaryMeeting']
+      eventType = 'Other'
     eventTypeKey = eventType.camelize() + 'Documents'
     @loadDocuments(eventTypeQueryParams, (documents) ->
       controller.set(eventTypeKey, documents)

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -75,7 +75,7 @@ class DocumentSearch
       return
     end
     return unless @event_type.present?
-    if @event_type == 'other'
+    if @event_type == 'Other'
       # public interface event type "other"
       @query = @query.where(
         <<-SQL

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -12,13 +12,17 @@ describe Api::V1::DocumentsController, :type => :controller do
     citation2 = create(:document_citation, document_id: @document2.id)
     create(:document_citation_taxon_concept, document_citation_id: citation2.id,
       taxon_concept_id: @taxon_concept.id)
+    @document3 = create(:proposal, is_public: true, event: nil)
+    citation3 = create(:document_citation, document_id: @document3.id)
+    create(:document_citation_taxon_concept, document_citation_id: citation3.id,
+      taxon_concept_id: @taxon_concept.id)
     DocumentSearch.refresh
   end
 
   context "GET index returns all documents" do
     def get_all_documents
       get :index, taxon_concept_id: @taxon_concept.id
-      response.body.should have_json_size(2).at_path('documents')
+      response.body.should have_json_size(3).at_path('documents')
     end
     context "GET index contributor" do
       login_contributor
@@ -40,7 +44,7 @@ describe Api::V1::DocumentsController, :type => :controller do
   context "GET index returns only public documents" do
     def get_public_documents
       get :index, taxon_concept_id: @taxon_concept.id
-      response.body.should have_json_size(1).at_path('documents')
+      response.body.should have_json_size(2).at_path('documents')
     end
     context "GET index api user " do
       login_api_user
@@ -61,6 +65,13 @@ describe Api::V1::DocumentsController, :type => :controller do
     it "should return 403 status when permission denied" do
       get :show, id: @document2.id
       expect(response.status).to eq(403)
+    end
+  end
+
+  context "GET should retrieve documents with no event_type" do
+    it "returns documents with no event_type" do
+      get :index, event_type: "Other"
+      response.body.should have_json_size(1).at_path('documents')
     end
   end
 


### PR DESCRIPTION
This PR fixes [NDF documents and UNEP-WCMC reports are not retrieved](https://www.pivotaltracker.com/story/show/112526357) and [Searches for CITES TC and CITES Extraordinary Meeting freeze the browser](https://www.pivotaltracker.com/story/show/112338713).

In particular, for the CITES TC and Extraordinary Meeting documents, if one of these is selected, then push the documents into the otherDocuments hash since they are currently listed as other documents
