### PR TITLE
Fix for regions gone missing in S+ locations dropdown

### DIFF
--- a/app/assets/javascripts/species/controllers/geo_entities_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/geo_entities_controller.js.coffee
@@ -5,7 +5,7 @@ Species.GeoEntitiesController = Ember.ArrayController.extend Species.ArrayLoadOb
 
   load: ->
     unless @get('loaded')
-      @set('content', Species.GeoEntity.find({geo_entity_types_set: "5"}))
+      @set('content', Species.GeoEntity.find({geo_entity_types_set: 3}))
 
   handleLoadFinished: () ->
     @set('regions', @get('content').filterProperty('geoEntityType', 'CITES_REGION'))


### PR DESCRIPTION
use correct geo entity type set to fetch regions, countries and territories