### PR TITLE
After typing, if length of word is less than 3 then hide dropdown

### DIFF
--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
@@ -17,5 +17,7 @@ Species.TaxonConceptSearchFieldComponent = Em.TextField.extend
     @currentTimeout = Ember.run.later(@, ->
       if @.$()?.val().length > 2
         @get('targetObject').showDropdown()
+      else
+        @get('targetObject').hideDropdown()
       @set('query', event.target.value)
     , 500)

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -1,5 +1,5 @@
 @mixin search-button($color:#fff, $border: none,
-  $background: #376382) {
+  $background: #376382, $line-height: 30px) {
 
   button {
     cursor: pointer;
@@ -7,7 +7,7 @@
     float: right;
     border: $border;
     height: 30px;
-    line-height: 30px;
+    line-height: $line-height;
     color: $color;
     font-size: 13px;
     font-weight: bold;
@@ -139,7 +139,8 @@
         @include search-button(
           $color: #376382,
           $border: (1px solid #376382),
-          $background: #fff
+          $background: #fff,
+          $line-height: 29px
         );
         button:hover { color: #fff; }
       }


### PR DESCRIPTION
This is to fix the taxon search dropdown not hiding when clearing the search itself