### PR TITLE
Group query before total_cnt if not admin interface

### DIFF
--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -11,11 +11,7 @@ class DocumentSearch
   end
 
   def results
-    if !admin_interface?
-      select_and_group_query.limit(@per_page).offset(@offset)
-    else
-      @query.limit(@per_page).offset(@offset)
-    end
+    @query.limit(@per_page).offset(@offset)
   end
 
   def total_cnt
@@ -66,6 +62,7 @@ class DocumentSearch
       add_ordering_for_admin
     else
       add_ordering_for_public
+      select_and_group_query
     end
   end
 
@@ -161,15 +158,14 @@ class DocumentSearch
       ) AS document_language_versions
     SQL
     # sort_col and sort_dir are sanitized
-    tmp = Document.from(
+    @query = Document.from(
       '(' + @query.to_sql + ') documents'
     ).select(columns + "," + aggregators).group(columns)
     if @sort_col != 'title'
-      tmp = tmp.order("#{@sort_col} #{@sort_dir}")
+      @query = @query.order("#{@sort_col} #{@sort_dir}")
     else
-      tmp = tmp.order("MAX(title) #{@sort_dir}")
+      @query = @query.order("MAX(title) #{@sort_dir}")
     end
-    tmp
   end
 
   def self.refresh


### PR DESCRIPTION
This fixes one of the issue reported by email about the mismatching number of documents showed when searching for "Loxodonta africana" for example, which was 48/63.
The issue was about the grouping applied for documents with multiple languages, so the documents were really 63, but grouped by language those are 48; so now the count happens after the grouping, fixing the issue.

This is one way to go though. The other way would be to display 63/63 even if the number of rows are 48 assuming that the actual number of rows is different from the stated one because of the grouping. But I don't think this is preferable. 