### PR TITLE
Move keyword search at the bottom and style as dropdowns

### DIFF
--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -16,12 +16,6 @@
     </fieldset>
     <fieldset>
       <div class="documents-control-group">
-        <label>Search by title keyword(s)</label>
-        <div class="text-input-wrapper">
-          {{input type="text" value=titleQuery placeholder='e.g. "ranching or quotas"'}}
-        </div>
-      </div>
-      <div class="documents-control-group">
         <div class="location-area popup-area">
           <label>Country <i class="fa fa-info-circle" title="Including territories and historic names"></i></label>
           {{view Species.GeoEntitiesSearchButton
@@ -87,6 +81,12 @@
           values=controllers.documentTags.reviewPhases
           selection=controller.selectedReviewPhase
         }}
+      </div>
+      <div class="documents-control-group">
+        <label>Search by title keyword(s)</label>
+        <div class="text-input-wrapper keyword-search">
+          {{input type="text" value=titleQuery placeholder='e.g. "ranching or quotas"'}}
+        </div>
       </div>
     </fieldset>
     <div class="search-buttons-container">

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -168,6 +168,12 @@
       border-radius: 20px;
       border: 1px solid #8fb7cf;
       width: 100%;
+      &.keyword-search {
+        height: 30px;
+        width: 338px;
+        padding: 0;
+        .input[type="text"] { height: initial; }
+      }
     }
 
     input[type="text"] {


### PR DESCRIPTION
This PR is about [Move the "search by keyword" to the bottom of the search form and resize to match dropdowns above](https://www.pivotaltracker.com/story/show/112874855)