### PR TITLE
Add tooltip to title just if it has been truncated

### DIFF
--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -2,10 +2,13 @@
 <td class='event-date-col'>{{unbound doc.date}}</td>
 <td class='title-col'>
 
-<a class="legal-links tooltip" {{bind-attr href=view.documentUrl}}>
-    {{truncate title}}
+<a {{bind-attr class=":legal-links isLongTitle:tooltip"}} {{bind-attr href=view.documentUrl}}>
+
+    {{#if isLongTitle}}
+      {{truncate title}}
+    {{/if}}
     <span>
-        {{unbound title}}
+      {{unbound title}}
     </span>
 </a>
 </td>

--- a/app/assets/javascripts/species/views/document_result_component.js.coffee
+++ b/app/assets/javascripts/species/views/document_result_component.js.coffee
@@ -33,3 +33,7 @@ Species.DocumentResultComponent = Ember.Component.extend
   title: ( ->
     @get('documentVersion.title')
   ).property('documentVersion.title')
+
+  isLongTitle: ( ->
+    @get('documentVersion.title').length > 60
+  ).property('documentVersion.title')


### PR DESCRIPTION
This is for the PT story: [Remove tooltip over title where title is not truncated](https://www.pivotaltracker.com/story/show/112874739)