### PR TITLE
Fix table formatting in taxon documents tab

### DIFF
--- a/app/assets/javascripts/species/templates/components/documents-results.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-results.handlebars
@@ -1,6 +1,6 @@
 {{#if documents.length}}
   <td colspan="3">
-    <div {{bindAttr class=":inner-table-container isNotDocumentsTab:block loadMore:show_more"}}>
+    <div {{bindAttr class=":inner-table-container block:block loadMore:show_more"}}>
 
       <table class="table-header">
         <thead>

--- a/app/assets/javascripts/species/templates/components/documents-row.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-row.handlebars
@@ -17,4 +17,6 @@
   dataController=dataController
   proposalOutcome=proposalOutcome
   reviewPhase=reviewPhase
-  loadMore=loadMore}}
+  loadMore=loadMore
+  block=true
+  }}

--- a/app/assets/javascripts/species/views/documents_results_component.js.coffee
+++ b/app/assets/javascripts/species/views/documents_results_component.js.coffee
@@ -2,7 +2,3 @@ Species.DocumentsResultsComponent = Ember.Component.extend
   layoutName: 'species/components/documents-results'
   tagName: 'tr'
   classNames: ['table-row']
-
-  isNotDocumentsTab: ( ->
-    !$('#documents').length
-  ).property()


### PR DESCRIPTION
This PR is about the [bad formatting of the documents table in the taxon concept documents tab](https://www.pivotaltracker.com/story/show/114233597).
The issue was related to the fact that the isNotDocumentsTab function wasn't fetching the documents div correctly because not yet loaded, and so the `block` class had been added to the inner table container