### PR TITLE
Display cop document number

### DIFF
--- a/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
@@ -53,12 +53,8 @@ Ember.Handlebars.registerHelper 'tolower', (str, options) ->
   defaultString = options.hash?.default or ""
   if str then str.toLowerCase() else defaultString
 
-Ember.Handlebars.registerHelper 'truncate', (title, doc, options) ->
-  title = Ember.Handlebars.get(this, title)
-  proposal_number = Ember.Handlebars.get(this, doc).proposal_number
-  number = if proposal_number then proposal_number.toString() else ''
-  text = number + title
+Ember.Handlebars.helper 'truncate', (text, options) ->
   limit = options.hash.limit || 60
-  if (number.length + title.length) > limit
-    text = (number + title).substr(0, limit - 3) + "..."
+  if text.length > limit
+    text = text.substr(0, limit - 3) + "..."
   return text

--- a/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
@@ -53,9 +53,12 @@ Ember.Handlebars.registerHelper 'tolower', (str, options) ->
   defaultString = options.hash?.default or ""
   if str then str.toLowerCase() else defaultString
 
-Ember.Handlebars.registerHelper 'truncate', (text, options) ->
-  text = Ember.Handlebars.get(this, text)
+Ember.Handlebars.registerHelper 'truncate', (title, doc, options) ->
+  title = Ember.Handlebars.get(this, title)
+  proposal_number = Ember.Handlebars.get(this, doc).proposal_number
+  number = if proposal_number then proposal_number.toString() else ''
+  text = number + title
   limit = options.hash.limit || 60
-  if text.length > limit
-    text = text.substr(0, limit - 3) + "..."
+  if (number.length + title.length) > limit
+    text = (number + title).substr(0, limit - 3) + "..."
   return text

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -5,10 +5,10 @@
 <a {{bind-attr class=":legal-links isLongTitle:tooltip"}} {{bind-attr href=view.documentUrl}}>
 
     {{#if isLongTitle}}
-      {{truncate title}}
+      {{truncate title doc}}
     {{/if}}
     <span>
-      {{unbound title}}
+      {{doc.proposal_number}} {{unbound title}}
     </span>
 </a>
 </td>

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -5,10 +5,10 @@
 <a {{bind-attr class=":legal-links isLongTitle:tooltip"}} {{bind-attr href=view.documentUrl}}>
 
     {{#if isLongTitle}}
-      {{truncate title doc}}
+      {{truncate fullTitle}}
     {{/if}}
     <span>
-      {{doc.proposal_number}} {{unbound title}}
+      {{unbound fullTitle}}
     </span>
 </a>
 </td>

--- a/app/assets/javascripts/species/views/document_result_component.js.coffee
+++ b/app/assets/javascripts/species/views/document_result_component.js.coffee
@@ -41,7 +41,7 @@ Species.DocumentResultComponent = Ember.Component.extend
 
   fullTitle: ( ->
     if @get('doc.event_type') == 'CitesCop'
-      (@get('doc.proposal_number') || '') + @get('title')
+      'Prop ' + (@get('doc.proposal_number') || '') + ': ' + @get('title')
     else
       @get('title')
   ).property('doc.event_type', 'doc.proposal_number', 'title')

--- a/app/assets/javascripts/species/views/document_result_component.js.coffee
+++ b/app/assets/javascripts/species/views/document_result_component.js.coffee
@@ -11,6 +11,7 @@ Species.DocumentResultComponent = Ember.Component.extend
       primaryDocumentVersion = @get('doc.document_language_versions.firstObject')
     primaryLanguage = primaryDocumentVersion['language']
     allLanguages = @get('doc.document_language_versions').mapBy('language').sort()
+
     @setProperties(
       language: primaryLanguage,
       languages: allLanguages,
@@ -35,5 +36,12 @@ Species.DocumentResultComponent = Ember.Component.extend
   ).property('documentVersion.title')
 
   isLongTitle: ( ->
-    @get('documentVersion.title').length > 60
-  ).property('documentVersion.title')
+    @get('fullTitle').length > 60
+  ).property('fullTitle')
+
+  fullTitle: ( ->
+    if @get('doc.event_type') == 'CitesCop'
+      (@get('doc.proposal_number') || '') + @get('title')
+    else
+      @get('title')
+  ).property('doc.event_type', 'doc.proposal_number', 'title')


### PR DESCRIPTION
This PR is about [Display CoP document number](https://www.pivotaltracker.com/story/show/109165150).
The truncate helper has been modified such that the document number is considered in the total length of the title itself.