### PR TITLE
Add documents cascading search logic to taxon documents tab

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -7,6 +7,15 @@ class Api::V1::DocumentsController < ApplicationController
         taxon_concept_query: params[:taxon_concept_query]
       })
       params[:taxon_concepts_ids] = @species_search.ids.join(',')
+    else
+      if params[:taxon_concepts_ids].present?
+        taxa = TaxonConcept.find(params[:taxon_concepts_ids])
+        children_ids = taxa.map(&:children).map do
+          |children| children.pluck(:id) if children.present?
+        end.flatten.uniq.compact
+        taxa_ids = taxa.map(&:id) + children_ids
+        params[:taxon_concepts_ids] = taxa_ids
+      end
     end
     @search = DocumentSearch.new(
       params.merge(show_private: !access_denied?, per_page: 100), 'public'

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 describe Api::V1::DocumentsController, :type => :controller do
 
   before(:each) do
-    @taxon_concept = create(:taxon_concept, rank: species_rank, taxonomy: cites_eu)
+    @taxon_concept = create_cites_eu_species
     @subspecies = create_cites_eu_subspecies(parent: @taxon_concept)
-    @document = create(:proposal, is_public: true, event: create(:cites_cop, designation: cites))
+    @document = create(:proposal, is_public: true, event: create_cites_cop)
     citation = create(:document_citation, document_id: @document.id)
     create(:document_citation_taxon_concept, document_citation_id: citation.id,
       taxon_concept_id: @taxon_concept.id)
     @subspecies_document = create(:proposal, is_public: true,
-      event: create(:cites_cop, designation: cites))
+      event: create_cites_cop)
     subspecies_citation = create(:document_citation, document_id: @subspecies_document.id)
     create(:document_citation_taxon_concept, document_citation_id: subspecies_citation.id,
       taxon_concept_id: @subspecies.id)
-    @document2 = create(:proposal, event: create(:cites_cop, designation: cites))
+    @document2 = create(:proposal, event: create_cites_cop)
     citation2 = create(:document_citation, document_id: @document2.id)
     create(:document_citation_taxon_concept, document_citation_id: citation2.id,
       taxon_concept_id: @taxon_concept.id)


### PR DESCRIPTION
This PR is about [Document results  via 2 routes not consistent](https://www.pivotaltracker.com/story/show/114232695)

If ids are specified instead of a scientific name (like it happens in the documents tab for a taxon), then fetch the children ids and include those in the documents search