### PR TITLE
Trigger search button click when pressing enter in the elibrary form

### DIFF
--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -94,7 +94,7 @@
         <button {{action "clearSearch"}}>Clear</button>
       </div>
       <div class="search-button-container">
-        <button {{action "openSearchPage"}}>Search</button>
+        <button class='elibrary-search-button' {{action "openSearchPage"}}>Search</button>
       </div>
     </div>
   </form>

--- a/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
@@ -2,6 +2,10 @@ Species.ElibrarySearchFormView = Ember.View.extend
   templateName: 'species/elibrary_search_form'
   classNames: ['search-block']
 
+  keyDown: (event) ->
+    if event.keyCode == 13
+      $('.elibrary-search-button').click()
+
   actions:
     toggleSearchOptions: () ->
       @.$('.search-form').toggle()

--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
@@ -13,6 +13,7 @@ Species.TaxonConceptSearchFieldComponent = Em.TextField.extend
     Ember.run.cancel(@currentTimeout)
     if event.keyCode == 13
       @get('targetObject').hideDropdown()
+      $('.elibrary-search-button').click()
       return
     @currentTimeout = Ember.run.later(@, ->
       if @.$()?.val().length > 2

--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
@@ -13,7 +13,6 @@ Species.TaxonConceptSearchFieldComponent = Em.TextField.extend
     Ember.run.cancel(@currentTimeout)
     if event.keyCode == 13
       @get('targetObject').hideDropdown()
-      $('.elibrary-search-button').click()
       return
     @currentTimeout = Ember.run.later(@, ->
       if @.$()?.val().length > 2


### PR DESCRIPTION
A quick fix for [Search by keyword needs to function by using enter key](https://www.pivotaltracker.com/story/show/114865983).
It just replicates the search functionality when clicking the search button