### PR TITLE
NDF documents to be private

### DIFF
--- a/db/migrate/20160304141931_update_ndf_documents_to_be_private.rb
+++ b/db/migrate/20160304141931_update_ndf_documents_to_be_private.rb
@@ -1,0 +1,11 @@
+class UpdateNdfDocumentsToBePrivate < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        UPDATE documents
+        SET is_public = false
+        WHERE type = 'Document::NonDetrimentFindings' OR type = 'Document::NdfConsultation'
+      SQL
+    )
+  end
+end


### PR DESCRIPTION
A migration to set all NDF documents to be private according to [this PT story](https://www.pivotaltracker.com/story/show/114943961)