### PR TITLE
Fix undefined method downcase for Nil

### DIFF
--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -173,9 +173,11 @@ class NomenclatureChange::Output < ActiveRecord::Base
           :tag_list => tag_list
         })
       ).tap do |tc|
-        add_taxon_synonym(tc, accepted_taxon_ids)
-        add_taxon_hybrid(tc, hybrid_parent_id)
-        add_taxon_hybrid(tc, other_hybrid_parent_id)
+        unless nomenclature_change.is_a?(NomenclatureChange::NewName)
+          add_taxon_synonym(tc, accepted_taxon_ids)
+          add_taxon_hybrid(tc, hybrid_parent_id)
+          add_taxon_hybrid(tc, other_hybrid_parent_id)
+        end
       end
     elsif will_update_taxon?
       taxon_concept.assign_attributes(taxon_concept_attrs)


### PR DESCRIPTION
This is about [ActionView::Template::Error happened in Admin::NomenclatureChangesController#show](https://www.pivotaltracker.com/story/show/115323893)

Fix undefined method downcase for nil because of a bug in relationships in new name wizard.
Since we are creating a new record we will not have the Taxon Concept id in advance and we can't create the inverse relationship with the accepted names when creating a synonym.
