### PR TITLE
Fix new tag position on elibrary tab when searching

### DIFF
--- a/app/assets/javascripts/species/templates/_tabs.handlebars
+++ b/app/assets/javascripts/species/templates/_tabs.handlebars
@@ -2,10 +2,10 @@
   <li {{bind-attr class="isSearchContextSpecies:active"}}>
     {{#linkTo 'index'}}Search for Species{{/linkTo}}
   </li>
-  <li {{bind-attr class="isSearchContextDocuments:active"}}>
+  <li {{bind-attr class="isSearchContextDocuments:active :elibrary-tab"}}>
     {{#linkTo 'elibrary'}}
       Search for CITES Documents
+      <img class="new-tag" src="/assets/species/new-tag.png">
     {{/linkTo}}
-    <img class="new-tag" src="/assets/species/new-tag.png">
   </li>
 </ul>

--- a/app/assets/stylesheets/species/tabset-top-level.scss
+++ b/app/assets/stylesheets/species/tabset-top-level.scss
@@ -52,9 +52,13 @@
     display: block;
 }
 
-.new-tag {
-  position: absolute;
-  top: 0;
-  right: 400px;
-  height: 30px;
+.elibrary-tab {
+
+  a { height: 10px; }
+  .new-tag {
+    position: relative;
+    top: -26px;
+    right: -100px;
+    height: 30px;
+  }
 }


### PR DESCRIPTION
Fix new tag position so that it doesn't float around after searching for documents