### PR TITLE
Fix change document title when changing language

### DIFF
--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -8,7 +8,7 @@
       {{truncate fullTitle}}
     {{/if}}
     <span>
-      {{unbound fullTitle}}
+      {{fullTitle}}
     </span>
 </a>
 </td>


### PR DESCRIPTION
This PR is for [this PT story](https://www.pivotaltracker.com/story/show/114970431).
The unbound wasn't allowing to fire the fullTitle computed property.
In fact, the issue was just about the titles that were not being truncated.