### PR TITLE
skip parent rank validation unless accepted name

### DIFF
--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -168,7 +168,8 @@ class TaxonConcept < ActiveRecord::Base
   validates :rank_id, :presence => true
   validates :name_status, :presence => true
   validate :parent_in_same_taxonomy, :if => lambda { |tc| tc.parent }
-  validate :parent_at_immediately_higher_rank, :if => lambda { |tc| tc.parent }
+  validate :parent_at_immediately_higher_rank,
+    :if => lambda { |tc| tc.parent && tc.name_status == 'A' }
   validate :parent_name_compatible, :if => lambda { |tc|
     tc.parent && tc.rank && tc.full_name && (
       ['A', 'N'].include?(tc.name_status) || tc.name_status.blank?

--- a/spec/models/nomenclature_change/output_spec.rb
+++ b/spec/models/nomenclature_change/output_spec.rb
@@ -60,10 +60,10 @@ describe NomenclatureChange::Output do
           :new_scientific_name => 'xxx',
           :new_parent_id => create_cites_eu_species.id,
           :new_rank_id => species_rank.id,
-          :new_name_status => nil
+          :new_name_status => 'A'
         )
       }
-      specify { expect(output).to have(2).errors_on(:new_parent_id) }
+      specify { expect(output).to have(1).error_on(:new_parent_id) }
     end
     context "when taxon concept specified" do
       let(:tc){ create_cites_eu_species }


### PR DESCRIPTION
The change is to skip parent rank validation for taxa where name status != A

Background:

We have a validation in place that checks if the parent of the taxon concept is at immediately higher rank. That makes a lot of sense for accepted taxa, but we had to make a lot of exceptions when importing status N taxa (including those newly added for purposes of the E-Library) that come in the way of performing status changes.

For example, if we attempt turning subspecies_ Laterallus jamaicensis jamaicensis_ [N] into a synonym, we get an exception saying "parent must be at immediately higher rank" because the parent of that subspecies is in fact a family. Since we're turning this into a synonym, we're not giving any possibility of changing the parent so the user cannot proceed past this stage. 