### PR TITLE
Search form changes

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -20,11 +20,8 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
     @set('titleQuery', filtersHash.title_query)
     @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', filtersHash.event_type))
     @set('selectedEventId', filtersHash.event_id)
-    documentType = @get('controllers.events.documentTypes').findBy('id', filtersHash.document_type)
-    if documentType
-      @set('selectedDocumentType', documentType)
-    else
-      @set('selectedInterSessionalDocType', @get('controllers.events.interSessionalDocumentTypes').findBy('id', filtersHash.document_type))
+    allDocumentTypes = @get('controllers.events.documentTypes').concat @get('controllers.events.interSessionalDocumentTypes')
+    @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
     @set('selectedProposalOutcomeId', filtersHash.proposal_outcome_id)
     @set('selectedReviewPhaseId', filtersHash.review_phase_id)
 
@@ -33,18 +30,13 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       taxonConceptQuery = @get('taxonConceptQueryForDisplay')
     if @get('titleQuery') && @get('titleQuery').length > 0
       titleQuery = @get('titleQuery')
-    documentType = null
-    if @get('documentTypeDropdownVisible')
-      documentType = @get('selectedDocumentType.id')
-    else if @get('interSessionalDocTypeDropdownVisible')
-      documentType = @get('selectedInterSessionalDocType.id')
     {
       taxon_concept_query: taxonConceptQuery,
       geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),
       title_query: titleQuery,
       event_type: @get('selectedEventType.id'),
       event_id: @get('selectedEvent.id'),
-      document_type: documentType,
+      document_type: @get('selectedDocumentType.id'),
       proposal_outcome_id: @get('selectedProposalOutcome.id'),
       review_phase_id: @get('selectedReviewPhase.id')
     }
@@ -79,12 +71,6 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
 
     handleDocumentTypeDeselection:  ->
       @set('selectedDocumentType', null)
-
-    handleInterSessionalDocTypeSelection: (documentType) ->
-      @set('selectedInterSessionalDocType', documentType)
-
-    handleInterSessionalDocTypeDeselection:  ->
-      @set('selectedInterSessionalDocType', null)
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       @set('autoCompleteTaxonConcept', autoCompleteTaxonConcept)

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -20,7 +20,11 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
     @set('titleQuery', filtersHash.title_query)
     @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', filtersHash.event_type))
     @set('selectedEventId', filtersHash.event_id)
-    @set('selectedDocumentType', @get('controllers.events.documentTypes').findBy('id', filtersHash.document_type))
+    documentType = @get('controllers.events.documentTypes').findBy('id', filtersHash.document_type)
+    if documentType
+      @set('selectedDocumentType', documentType)
+    else
+      @set('selectedInterSessionalDocType', @get('controllers.events.interSessionalDocumentTypes').findBy('id', filtersHash.document_type))
     @set('selectedProposalOutcomeId', filtersHash.proposal_outcome_id)
     @set('selectedReviewPhaseId', filtersHash.review_phase_id)
 
@@ -29,13 +33,18 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       taxonConceptQuery = @get('taxonConceptQueryForDisplay')
     if @get('titleQuery') && @get('titleQuery').length > 0
       titleQuery = @get('titleQuery')
+    documentType = null
+    if @get('documentTypeDropdownVisible')
+      documentType = @get('selectedDocumentType.id')
+    else if @get('interSessionalDocTypeDropdownVisible')
+      documentType = @get('selectedInterSessionalDocType.id')
     {
       taxon_concept_query: taxonConceptQuery,
       geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),
       title_query: titleQuery,
       event_type: @get('selectedEventType.id'),
       event_id: @get('selectedEvent.id'),
-      document_type: @get('selectedDocumentType.id'),
+      document_type: documentType,
       proposal_outcome_id: @get('selectedProposalOutcome.id'),
       review_phase_id: @get('selectedReviewPhase.id')
     }
@@ -49,6 +58,18 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       @get('controllers.events.documentTypes')
   ).property('selectedEventType.id')
 
+  interSessionalDocumentTypes: ( ->
+    @get('controllers.events.interSessionalDocumentTypes')
+  ).property()
+
+  documentTypeDropdownVisible: ( ->
+    @get('selectedEventType.id') == 'EcSrg'
+  ).property('selectedEventType')
+
+  interSessionalDocTypeDropdownVisible: ( ->
+    !@get('selectedEventType.id')?
+  ).property('selectedEventType')
+
   actions:
     openSearchPage:->
       @transitionToRoute('documents', {queryParams: @getFilters()})
@@ -56,8 +77,14 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
     handleDocumentTypeSelection: (documentType) ->
       @set('selectedDocumentType', documentType)
 
-    handleDocumentTypeDeselection: (documentType) ->
+    handleDocumentTypeDeselection:  ->
       @set('selectedDocumentType', null)
+
+    handleInterSessionalDocTypeSelection: (documentType) ->
+      @set('selectedInterSessionalDocType', documentType)
+
+    handleInterSessionalDocTypeDeselection:  ->
+      @set('selectedInterSessionalDocType', null)
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       @set('autoCompleteTaxonConcept', autoCompleteTaxonConcept)
@@ -72,5 +99,6 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       @set('selectedEvent', null)
       @set('selectedEventId', null)
       @set('selectedDocumentType', null)
+      @set('selectedInterSessionalDocType', null)
       @set('selectedProposalOutcome', null)
       @set('selectedReviewPhase', null)

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -68,14 +68,13 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
       id: 'Document::ListOfParticipants',
       name: 'List of Participants',
       eventTypes: ['EcSrg']
-    },
+    }
+  ]
+
+  interSessionalDocumentTypes: [
     {
       id: 'Document::CommissionNotes',
       name: 'Commission Notes'
-    },
-    {
-      id: 'Document::NdfConsultation',
-      name: 'NDF Consultation'
     },
     {
       id: 'Document::NonDetrimentFindings',

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -4,23 +4,19 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
   eventTypes: [
     {
       id: 'CitesCop',
-      name: 'CITES CoP'
+      name: 'CITES CoP Proposals'
     },
     {
-      id: 'CitesAc',
-      name: 'CITES Animals Committee'
+      id: 'CitesAc,CitesTc',
+      name: 'Review of Significant Trade (animals)'
     },
     {
       id: 'CitesPc',
-      name: 'CITES Plants Committee'
+      name: 'Review of Significant Trade (plants)'
     },
     {
       id: 'EcSrg',
       name: 'EU Scientific Review Group'
-    },
-    {
-      id: 'CitesTc',
-      name: 'CITES Technical Committee'
     }
   ]
 

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -21,10 +21,6 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
     {
       id: 'CitesTc',
       name: 'CITES Technical Committee'
-    },
-    {
-      id: 'CitesExtraordinaryMeeting',
-      name: 'CITES Extraordinary Meeting'
     }
   ]
 

--- a/app/assets/javascripts/species/mixins/document_loader.js.coffee
+++ b/app/assets/javascripts/species/mixins/document_loader.js.coffee
@@ -1,12 +1,14 @@
 Species.DocumentLoader = Ember.Mixin.create
   euSrgDocuments: {}
   citesCopProposalsDocuments: {}
-  citesRSTDocuments: {}
+  citesAcDocuments: {}
+  citesPcDocuments: {}
   otherDocuments: {}
 
   euSrgDocsIsLoading: true
   citesCopProposalsDocsIsLoading: true
-  citesRSTDocsIsLoading: true
+  citesAcDocsIsLoading: true
+  citesPcDocsIsLoading: true
   otherDocsIsLoading: true
 
   euSrgDocsLoadMore: ( ->
@@ -17,9 +19,13 @@ Species.DocumentLoader = Ember.Mixin.create
     @get('citesCopProposalsDocuments.docs.length') < @get('citesCopProposalsDocuments.meta.total')
   ).property('citesCopProposalsDocuments.docs.length', 'citesCopProposalsDocuments.meta.total')
 
-  citesRSTDocsLoadMore: ( ->
-    @get('citesRSTDocuments.docs.length') < @get('citesRSTDocuments.meta.total')
-  ).property('citesRSTDocuments.docs.length', 'citesRSTDocuments.meta.total')
+  citesAcDocsLoadMore: ( ->
+    @get('citesAcDocuments.docs.length') < @get('citesAcDocuments.meta.total')
+  ).property('citesAcDocuments.docs.length', 'citesAcDocuments.meta.total')
+
+  citesPcDocsLoadMore: ( ->
+    @get('citesPcDocuments.docs.length') < @get('citesPcDocuments.meta.total')
+  ).property('citesPcDocuments.docs.length', 'citesPcDocuments.meta.total')
 
   otherDocsLoadMore: ( ->
     @get('otherDocuments.docs.length') < @get('otherDocuments.meta.total')
@@ -33,9 +39,13 @@ Species.DocumentLoader = Ember.Mixin.create
     @set('citesCopProposalsDocsIsLoading', false)
   ).observes('citesCopProposalsDocuments.docs.@each.didLoad')
 
-  citesRSTDocsObserver: ( ->
-    @set('citesRSTDocsIsLoading', false)
-  ).observes('citesRSTDocuments.docs.@each.didLoad')
+  citesAcDocsObserver: ( ->
+    @set('citesAcDocsIsLoading', false)
+  ).observes('citesAcDocuments.docs.@each.didLoad')
+
+  citesPcDocsObserver: ( ->
+    @set('citesPcDocsIsLoading', false)
+  ).observes('citesPcDocuments.docs.@each.didLoad')
 
   citesOtherDocsObserver: ( ->
     @set('otherDocsIsLoading', false)
@@ -69,8 +79,9 @@ Species.DocumentLoader = Ember.Mixin.create
 
   getEventTypeKey: (eventType) ->
     key = switch eventType
-      when 'CitesCop', 'CitesCop,CitesExtraordinaryMeeting' then 'CitesCopProposals'
-      when 'CitesAc', 'CitesPc', 'CitesTc', 'CitesAc,CitesPc,CitesTc' then 'CitesRST'
+      when 'CitesCop' then 'CitesCopProposals'
+      when 'CitesAc', 'CitesTc', 'CitesAc,CitesTc' then 'CitesAc'
+      when 'CitesPc' then 'CitesPc'
       when 'EcSrg' then 'EuSrg'
       else 'Other'
 

--- a/app/assets/javascripts/species/mixins/event_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_lookup.js.coffee
@@ -24,13 +24,14 @@ Species.EventLookup = Ember.Mixin.create
       if @get('selectedEventType.id') != @get('selectedEvent.type')
         @set('selectedEvent', null)
         @set('selectedEventId', null)
-      if @get('selectedDocumentType.eventTypes') && @get('selectedDocumentType.eventTypes').indexOf(@get('selectedEvent.type')) < 0
+      if (@get('selectedDocumentType.eventTypes') && @get('selectedDocumentType.eventTypes').indexOf(@get('selectedEvent.type')) < 0) || eventType.id == 'EcSrg'
         @set('selectedDocumentType', null)
 
     handleEventTypeDeselection: (eventType) ->
       @set('selectedEventType', null)
       @set('selectedEvent', null)
       @set('selectedEventId', null)
+      @set('selectedDocumentType', null)
 
     handleEventSelection: (event) ->
       @set('selectedEvent', event)

--- a/app/assets/javascripts/species/mixins/event_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_lookup.js.coffee
@@ -9,7 +9,11 @@ Species.EventLookup = Ember.Mixin.create
 
   filteredEvents: ( ->
     if @get('selectedEventType')
-      @get('controllers.events.content').filterBy('type', @get('selectedEventType.id'))
+      event_ids = @get('selectedEventType.id').split(',')
+      events = []
+      for event_id in event_ids
+        events = events.concat @get('controllers.events.content').filterBy('type', event_id)
+      events
     else
       []
   ).property('selectedEventType.id')

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -18,7 +18,7 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
     if queryParams['event_type']
       @loadDocumentsForEventType(queryParams['event_type'], queryParams)
     else
-      ['EcSrg', 'CitesCop,CitesExtraordinaryMeeting', 'CitesAc,CitesPc,CitesTc', 'Other'].forEach((eventType) =>
+      ['EcSrg', 'CitesCop', 'CitesAc,CitesTc', 'CitesPc', 'Other'].forEach((eventType) =>
         eventTypeQueryParams = {}
         $.extend(eventTypeQueryParams, queryParams, {event_type: eventType})
         @loadDocumentsForEventType(eventType, eventTypeQueryParams)
@@ -56,5 +56,6 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
     controller = @controllerFor('documents')
     controller.set('euSrgDocuments', {})
     controller.set('citesCopProposalsDocuments', {})
-    controller.set('citesRSTDocuments', {})
+    controller.set('citesAcDocuments', {})
+    controller.set('citesPcDocuments', {})
     controller.set('otherDocuments', {})

--- a/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/taxon_concept_documents_route.js.coffee
@@ -8,7 +8,7 @@ Species.TaxonConceptDocumentsRoute = Ember.Route.extend Species.DocumentLoader,
   getDocuments: ->
     model = @modelFor("taxonConcept")
     controller = @controllerFor('taxonConceptDocuments')
-    ['EcSrg', 'CitesCop,CitesExtraordinaryMeeting', 'CitesAc,CitesPc,CitesTc', 'Other'].forEach((eventType) =>
+    ['EcSrg', 'CitesCop', 'CitesAc,CitesTc', 'CitesPc', 'Other'].forEach((eventType) =>
       params = {
         event_type: eventType,
         taxon_concepts_ids: [model.get('id')]

--- a/app/assets/javascripts/species/templates/documents.handlebars
+++ b/app/assets/javascripts/species/templates/documents.handlebars
@@ -40,7 +40,7 @@
           loadMore=controller.euSrgDocsLoadMore
           documents=controller.euSrgDocuments
           isLoading=controller.euSrgDocsIsLoading}}
-        {{documents-row meeting_type="Other"
+        {{documents-row meeting_type="Intersessional documents"
           eventType="other"
           dataController=controller
           loadMore=controller.otherDocsLoadMore

--- a/app/assets/javascripts/species/templates/documents.handlebars
+++ b/app/assets/javascripts/species/templates/documents.handlebars
@@ -14,19 +14,26 @@
       </thead>
       <tbody>
         {{documents-row meeting_type="CITES CoP Proposals"
-          eventType="CitesCop,CitesExtraordinaryMeeting"
+          eventType="CitesCop"
           dataController=controller
           loadMore=controller.citesCopProposalsDocsLoadMore
           documents=controller.citesCopProposalsDocuments
           proposalOutcome=true
           isLoading=controller.citesCopProposalsDocsIsLoading}}
-        {{documents-row meeting_type="CITES Review of Significant Trade"
-          eventType="CitesAc,CitesPc,CitesTc"
+        {{documents-row meeting_type="CITES Review of Significant Trade (animals)"
+          eventType="CitesAc,CitesTc"
           dataController=controller
-          loadMore=controller.citesRSTDocsLoadMore
-          documents=controller.citesRSTDocuments
+          loadMore=controller.citesAcDocsLoadMore
+          documents=controller.citesAcDocuments
           reviewPhase=true
-          isLoading=controller.citesRSTDocsIsLoading}}
+          isLoading=controller.citesAcDocsIsLoading}}
+        {{documents-row meeting_type="CITES Review of Significant Trade (plants)"
+          eventType="CitesPc"
+          dataController=controller
+          loadMore=controller.citesPcDocsLoadMore
+          documents=controller.citesPcDocuments
+          reviewPhase=true
+          isLoading=controller.citesPcDocsIsLoading}}
         {{documents-row meeting_type="EU Scientific Review Group"
           eventType="EcSrg"
           dataController=controller

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -64,12 +64,12 @@
       <div class="documents-control-group">
         {{single-dropdown
           isVisible=controller.interSessionalDocTypeDropdownVisible
-          action="handleInterSessionalDocTypeSelection"
-          clearAction="handleInterSessionalDocTypeDeselection"
+          action="handleDocumentTypeSelection"
+          clearAction="handleDocumentTypeDeSelection"
           title="Inter-sessional documents type"
           placeholder="Document types"
           values=controller.interSessionalDocumentTypes
-          selection=controller.selectedInterSessionalDocType
+          selection=controller.selectedDocumentType
         }}
       </div>
       <div class="documents-control-group">

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -52,12 +52,24 @@
       </div>
       <div class="documents-control-group">
         {{single-dropdown
+          isVisible=controller.documentTypeDropdownVisible
           action="handleDocumentTypeSelection"
           clearAction="handleDocumentTypeDeselection"
           title="Document type"
           placeholder="All document types"
           values=controller.filteredDocumentTypes
           selection=controller.selectedDocumentType
+        }}
+      </div>
+      <div class="documents-control-group">
+        {{single-dropdown
+          isVisible=controller.interSessionalDocTypeDropdownVisible
+          action="handleInterSessionalDocTypeSelection"
+          clearAction="handleInterSessionalDocTypeDeselection"
+          title="Inter-sessional documents type"
+          placeholder="Document types"
+          values=controller.interSessionalDocumentTypes
+          selection=controller.selectedInterSessionalDocType
         }}
       </div>
       <div class="documents-control-group">

--- a/app/assets/javascripts/species/templates/taxon_concept.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept.handlebars
@@ -62,9 +62,10 @@
     <li class="last-child documents-tab">{{#linkTo 'taxonConcept.documents'}}DOCUMENTS{{/linkTo}}
       <ul>
           <li class="first"><a href="#cites_cop" class="scroll-to">CITES CoP Proposals</a></li>
-          <li><a href="#cites_rst" class="scroll-to">CITES Review of Significant Trade</a></li>
-          <li><a href="#eu_srg" class="scroll-to">EU Scientific Review Group</a></li>
-          <li><a href="#other" class="scroll-to">Other</a></li>
+          <li><a href="#cites_rst_animals" class="scroll-to">CITES RST (animals)</a></li>
+          <li><a href="#cites_rst_animals" class="scroll-to">CITES RST (plants)</a></li>
+          <li><a href="#eu_srg" class="scroll-to">EU SRG</a></li>
+          <li><a href="#other" class="scroll-to">Inter-sessional docs</a></li>
       </ul>
     </li>
     {{/unless}}

--- a/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
@@ -15,7 +15,7 @@
       </tbody>
     </table>
 
-    <h2 id="cites_rst">CITES Review of Significant Trade (animals)</h2>
+    <h2 id="cites_rst_animals">CITES Review of Significant Trade (animals)</h2>
 
     <table class="grouped-results-table">
       <tbody>
@@ -29,7 +29,7 @@
       </tbody>
     </table>
 
-    <h2 id="cites_rst">CITES Review of Significant Trade (plants)</h2>
+    <h2 id="cites_rst_plants">CITES Review of Significant Trade (plants)</h2>
 
     <table class="grouped-results-table">
       <tbody>
@@ -56,7 +56,7 @@
       </tbody>
     </table>
 
-    <h2 id="other">Intersessional documents</h2>
+    <h2 id="other">Inter-sessional documents</h2>
 
     <table class="grouped-results-table">
       <tbody>

--- a/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
@@ -56,7 +56,7 @@
       </tbody>
     </table>
 
-    <h2 id="other">Other</h2>
+    <h2 id="other">Intersessional documents</h2>
 
     <table class="grouped-results-table">
       <tbody>

--- a/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
@@ -6,7 +6,7 @@
     <table class="grouped-results-table">
       <tbody>
         {{documents-results
-          eventType="CitesCop,CitesExtraordinaryMeeting"
+          eventType="CitesCop"
           dataController=controller
           loadMore=controller.citesCopProposalsDocsLoadMore
           documents=controller.citesCopProposalsDocuments.docs
@@ -15,17 +15,31 @@
       </tbody>
     </table>
 
-    <h2 id="cites_rst">CITES Review of Significant Trade</h2>
+    <h2 id="cites_rst">CITES Review of Significant Trade (animals)</h2>
 
     <table class="grouped-results-table">
       <tbody>
         {{documents-results
-          eventType="CitesAc,CitesPc,CitesTc"
+          eventType="CitesAc,CitesTc"
           dataController=controller
-          loadMore=controller.citesRSTDocsLoadMore
-          documents=controller.citesRSTDocuments.docs
+          loadMore=controller.citesAcDocsLoadMore
+          documents=controller.citesAcDocuments.docs
           reviewPhase=true
-          isLoading=controller.citesRSTDocsIsLoading}}
+          isLoading=controller.citesAcDocsIsLoading}}
+      </tbody>
+    </table>
+
+    <h2 id="cites_rst">CITES Review of Significant Trade (plants)</h2>
+
+    <table class="grouped-results-table">
+      <tbody>
+        {{documents-results
+          eventType="CitesPc"
+          dataController=controller
+          loadMore=controller.citesPcDocsLoadMore
+          documents=controller.citesPcDocuments.docs
+          reviewPhase=true
+          isLoading=controller.citesPcDocsIsLoading}}
       </tbody>
     </table>
 

--- a/app/assets/stylesheets/species/all.css
+++ b/app/assets/stylesheets/species/all.css
@@ -903,7 +903,7 @@ body.inner #footer .holder{
 }
 
 #main .tabset > li.documents-tab > ul > li {
-  padding: 5px 51px 0 0
+  padding: 5px 45px 0 0
 }
 
 #main .tabset > li.documents-tab > ul > li.first {

--- a/app/assets/stylesheets/species/downloads.scss
+++ b/app/assets/stylesheets/species/downloads.scss
@@ -98,7 +98,7 @@
 		}
 		.list-holder {
 			height: 188px;
-			width: 220px;
+			width: 221px;
 			overflow: auto;
 			margin: 17px 0 15px;
 			padding: 0 0 20px 19px;

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,13 +1,12 @@
 # /admin/event/:event_id/documents
 # /admin/documents
 class Admin::DocumentsController < Admin::StandardAuthorizationController
-  belongs_to :event, optional: true
 
   def index
     load_associations
     @search = DocumentSearch.new(params.merge(show_private: true), 'admin')
     index! do
-      if @event
+      if @event.present?
         render 'admin/event_documents/index'
       else
         render 'index'
@@ -91,6 +90,7 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
       Event.elibrary_current_event_types.map(&:to_s)
     end
     @events = Event.where(type: @event_types).order(:published_at).reverse_order
+    @event = Event.find(params[:event_id]) if params[:event_id].present?
     @languages = Language.select([:id, :name_en, :name_es, :name_fr]).
      order(:name_en)
     @english = Language.find_by_iso_code1('EN')
@@ -102,7 +102,7 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   end
 
   def success_redirect
-    url = if @event
+    url = if @event.present?
       admin_event_documents_url(@event)
     else
       admin_documents_url
@@ -111,7 +111,7 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   end
 
   def failure_redirect
-    url = if @event
+    url = if @event.present?
       admin_event_documents_url(@event)
     else
       admin_documents_url

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -102,25 +102,24 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   end
 
   def success_redirect
-    url = if @event.present?
-      admin_event_documents_url(@event)
-    else
-      admin_documents_url
-    end
-    redirect_to url, :notice => 'Operation succeeded'
+    redirect_to redirect_url, :notice => 'Operation succeeded'
   end
 
   def failure_redirect
-    url = if @event.present?
-      admin_event_documents_url(@event)
-    else
-      admin_documents_url
-    end
     alert = if resource.errors.present?
       "Operation #{resource.errors.messages[:base].join(", ")}"
     else
       "Operation failed"
     end
-    redirect_to url, :alert => alert
+    redirect_to redirect_url, :alert => alert
+  end
+
+  def redirect_url
+    event_id = params[:event_id]
+    url = if event_id.present?
+      admin_event_documents_url(Event.find(event_id))
+    else
+      admin_documents_url
+    end
   end
 end

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -85,11 +85,11 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   def load_associations
     @designations = Designation.where(name: ['CITES', 'EU']).select([:id, :name]).order(:name)
     @event_types = if @document && @document.event
-      @event_types = [@document.event.type]
+      @event_types = [{id: @document.event.type}]
     else
-      Event.elibrary_current_event_types.map(&:to_s)
+      Event.event_types_with_names
     end
-    @events = Event.where(type: @event_types).order(:published_at).reverse_order
+    @events = Event.where(type: @event_types.map{ |t| t[:id] }).order(:published_at).reverse_order
     @event = Event.find(params[:event_id]) if params[:event_id].present?
     @languages = Language.select([:id, :name_en, :name_es, :name_fr]).
      order(:name_en)

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -67,7 +67,7 @@ class DocumentSearch
   end
 
   def add_conditions_for_event
-    if @event_id
+    if @event_id.present?
       @query = @query.where(event_id: @event_id)
       return
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -67,10 +67,6 @@ class Event < ActiveRecord::Base
       {
         id: 'CitesTc',
         name: 'CITES Technical Committee'
-      },
-      {
-        id: 'CitesExtraordinaryMeeting',
-        name: 'CITES Extraordinary Meeting'
       }
     ]
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -46,8 +46,37 @@ class Event < ActiveRecord::Base
     elibrary_current_event_types + [CitesTc, CitesExtraordinaryMeeting]
   end
 
+  def self.event_types_with_names
+    [
+      {
+        id: 'CitesCop',
+        name: 'CITES CoP'
+      },
+      {
+        id: 'CitesAc',
+        name: 'CITES Animals Committee'
+      },
+      {
+        id: 'CitesPc',
+        name: 'CITES Plants Committee'
+      },
+      {
+        id: 'EcSrg',
+        name: 'EU Scientific Review Group'
+      },
+      {
+        id: 'CitesTc',
+        name: 'CITES Technical Committee'
+      },
+      {
+        id: 'CitesExtraordinaryMeeting',
+        name: 'CITES Extraordinary Meeting'
+      }
+    ]
+  end
+
   # Returns document types (class objects) that are relevant to E-Library and
-  # that can be associated with this event type  
+  # that can be associated with this event type
   # Should be overriden in subclasses
   def self.elibrary_document_types
     [Document]
@@ -68,7 +97,7 @@ class Event < ActiveRecord::Base
   def self.search query
     if query.present?
       where("UPPER(events.name) LIKE UPPER(:query)
-            OR UPPER(events.description) LIKE UPPER(:query)", 
+            OR UPPER(events.description) LIKE UPPER(:query)",
             :query => "%#{query}%")
     else
       scoped

--- a/app/views/admin/documents/index.html.erb
+++ b/app/views/admin/documents/index.html.erb
@@ -8,7 +8,7 @@
       <legend>Upload documents</legend>
       <div class="form-group">
       <%= select_tag 'event-type', options_for_select(
-        @event_types.map{ |t| [t, t, {'data-path' => t.pluralize.underscore}] }
+        @event_types.map{ |t| [t[:name], t[:id], {'data-path' => t[:id].pluralize.underscore}] }
         ), {:prompt => "Select an event type"}
       %>
       <%= select_tag 'event-id',
@@ -32,7 +32,7 @@
       <legend>Filter documents</legend>
       <div class="form-group">
         <%= select_tag 'event_type_search',
-          options_for_select(@event_types, @search.event_type), {
+          options_for_select(@event_types.map{ |t| [t[:name], t[:id]] }, @search.event_type), {
             :prompt => 'Select an event type...', class: 'input-large', name: 'event_type'
           }
         %>


### PR DESCRIPTION
This covers [Potential change in search options](https://www.pivotaltracker.com/story/show/114722801).
All the specifications can be found in that PT story. To summarise:

- Split RST documents to CITES RST animals and plants
- Added inter-sessional documents type dropdown
- Fixed admin documents search when no event is selected
- Admin documents search to behave like the public one