### PR TITLE
Add new taxon button

### DIFF
--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -7,12 +7,14 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
   def index
     @taxonomies = Taxonomy.order(:name)
     @ranks = Rank.order(:taxonomic_position)
-    @taxon_concept = TaxonConcept.new(:name_status => 'A')
+    @taxon_concept = TaxonConcept.new(name_status: 'A')
     @taxon_concept.build_taxon_name
-    @synonym = TaxonConcept.new(:name_status => 'S')
+    @synonym = TaxonConcept.new(name_status: 'S')
     @synonym.build_taxon_name
-    @hybrid = TaxonConcept.new(:name_status => 'H')
+    @hybrid = TaxonConcept.new(name_status: 'H')
     @hybrid.build_taxon_name
+    @n_name = TaxonConcept.new(name_status: 'N')
+    @n_name.build_taxon_name
     @taxon_concepts = TaxonConceptMatcher.new(@search_params).taxon_concepts.
       includes([:rank, :taxonomy, :taxon_name, :parent]).
       order("taxon_concepts.taxonomic_position").page(params[:page])

--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -31,6 +31,22 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
     end
   end
 
+  def create
+    create! do |success, failure|
+      @taxonomies = Taxonomy.order(:name)
+      @ranks = Rank.order(:taxonomic_position)
+      success.js { render('create') }
+      failure.js {
+        if @taxon_concept.is_synonym?
+          @synonym = @taxon_concept
+          render('new_synonym')
+        else
+          render('new')
+        end
+      }
+    end
+  end
+
   def update
     @taxon_concept = TaxonConcept.find(params[:id])
     taxa_ids = sanitize_update_params
@@ -85,7 +101,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
 
     def sanitize_search_params
       @search_params = SearchParams.new(
-        params[:search_params] || 
+        params[:search_params] ||
         { :taxonomy => { :id => Taxonomy.
           where(:name => Taxonomy::CITES_EU).limit(1).select(:id).first.id }
         })

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -116,11 +116,11 @@ module TaxonConceptHelper
     ){ nested ? '' : render('admin/distributions/form') }
   end
 
-  def admin_new_hybrid_modal
+  def admin_new_hybrid_modal(nested = false)
     admin_new_modal(
       :resource => 'taxon_concept_hybrid',
       :title => 'Add new Hybrid'
-    ){ '' }
+    ){ nested ? '' : render('hybrid_form') }
   end
 
   def admin_add_new_reference_button

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -8,7 +8,27 @@ module TaxonConceptHelper
         else
           controller_name.titleize
         end
-      )
+      ) + (content_tag(:div, class: 'action-buttons') do
+        admin_add_new_taxon_concept_multi
+      end)
+    end
+  end
+
+  def admin_add_new_taxon_concept_multi
+    content_tag(:div, :class => 'btn-group', :style => 'float:right') do
+      link_to('<i class="icon-plus-sign"></i> Add new Taxon Concept'.html_safe, '#', :class => 'btn') +
+      link_to('<span class="caret"></span>'.html_safe, '#', :class => 'btn dropdown-toggle', :"data-toggle" => 'dropdown') +
+      content_tag(:ul, :class => 'dropdown-menu') do
+        content_tag(:li) do
+          link_to('Accepted name', '#new-taxon_concept', :"data-toggle" => 'modal')
+        end +
+        content_tag(:li) do
+          link_to('Synonym', '#new-taxon_concept_synonym', :"data-toggle" => 'modal')
+        end +
+        content_tag(:li) do
+          link_to('Hybrid', '#new-taxon_concept_hybrid', :"data-toggle" => 'modal')
+        end
+      end
     end
   end
 
@@ -45,11 +65,11 @@ module TaxonConceptHelper
     )
   end
 
-  def admin_new_synonym_modal
+  def admin_new_synonym_modal(nested = false)
     admin_new_modal(
       resource: 'taxon_concept_synonym',
       title: 'Add new Synonym'
-    ){ '' }
+    ){ nested ? '' : render('synonym_form') }
   end
 
   def admin_new_trade_name_modal

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -27,6 +27,9 @@ module TaxonConceptHelper
         end +
         content_tag(:li) do
           link_to('Hybrid', '#new-taxon_concept_hybrid', :"data-toggle" => 'modal')
+        end +
+        content_tag(:li) do
+          link_to('N name', '#new-taxon_concept_n_name', :"data-toggle" => 'modal')
         end
       end
     end
@@ -121,6 +124,13 @@ module TaxonConceptHelper
       :resource => 'taxon_concept_hybrid',
       :title => 'Add new Hybrid'
     ){ nested ? '' : render('hybrid_form') }
+  end
+
+  def admin_new_n_name_modal
+    admin_new_modal(
+      resource: 'taxon_concept_n_name',
+      title: 'Add new N name'
+    ){ render('n_name_form') }
   end
 
   def admin_add_new_reference_button

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -192,6 +192,8 @@ class TaxonConcept < ActiveRecord::Base
     :if => lambda { |tc| tc.full_name }
   before_validation :check_parent_taxon_concept_exists,
     :if => lambda { |tc| tc.parent_scientific_name }
+  before_validation :check_accepted_taxon_concept_exists,
+    :if => lambda { |tc| tc.is_synonym? && tc.accepted_scientific_name }
 
   before_validation :ensure_taxonomic_position
 
@@ -475,6 +477,16 @@ class TaxonConcept < ActiveRecord::Base
     end
 
     true
+  end
+
+  def check_accepted_taxon_concept_exists
+    check_associated_taxon_concept_exists(:accepted_scientific_name) do |tc|
+      inverse_taxon_relationships.build(
+        taxon_concept_id: tc.id,
+        taxon_relationship_type_id: TaxonRelationshipType.
+        find_by_name(TaxonRelationshipType::HAS_SYNONYM).id
+      )
+    end
   end
 
   def check_parent_taxon_concept_exists

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -45,13 +45,14 @@ class TaxonConcept < ActiveRecord::Base
   attr_accessible :parent_id, :taxonomy_id, :rank_id,
     :parent_id, :author_year, :taxon_name_id, :taxonomic_position,
     :legacy_id, :legacy_type, :full_name, :name_status,
-    :parent_scientific_name,
+    :parent_scientific_name, :accepted_scientific_name,
     :tag_list, :legacy_trade_code, :hybrid_parent_ids,
     :accepted_name_ids, :accepted_names_for_trade_name_ids,
     :nomenclature_note_en, :nomenclature_note_es, :nomenclature_note_fr,
     :created_by_id, :updated_by_id, :dependents_updated_at
 
   attr_writer :parent_scientific_name
+  attr_accessor :accepted_scientific_name
   acts_as_taggable
 
   serialize :data, ActiveRecord::Coders::Hstore

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -270,6 +270,10 @@ class TaxonConcept < ActiveRecord::Base
     inverse_synonym_relationships.limit(1).count > 0
   end
 
+  def is_accepted_name?
+    name_status == 'A'
+  end
+
   def is_synonym?
     name_status == 'S'
   end
@@ -471,10 +475,10 @@ class TaxonConcept < ActiveRecord::Base
 
   def check_taxon_name_exists
     self.full_name = TaxonConcept.sanitize_full_name(full_name)
-    scientific_name = if is_synonym? || is_trade_name? || is_hybrid?
-      full_name
-    else
+    scientific_name = if is_accepted_name?
       TaxonName.sanitize_scientific_name(self.full_name)
+    else
+      full_name
     end
 
     tn = taxon_name && TaxonName.where(["UPPER(scientific_name) = UPPER(?)", scientific_name]).first

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -46,13 +46,15 @@ class TaxonConcept < ActiveRecord::Base
     :parent_id, :author_year, :taxon_name_id, :taxonomic_position,
     :legacy_id, :legacy_type, :full_name, :name_status,
     :parent_scientific_name, :accepted_scientific_name,
+    :hybrid_parent_scientific_name, :other_hybrid_parent_scientific_name,
     :tag_list, :legacy_trade_code, :hybrid_parent_ids,
     :accepted_name_ids, :accepted_names_for_trade_name_ids,
     :nomenclature_note_en, :nomenclature_note_es, :nomenclature_note_fr,
     :created_by_id, :updated_by_id, :dependents_updated_at
 
   attr_writer :parent_scientific_name
-  attr_accessor :accepted_scientific_name
+  attr_accessor :accepted_scientific_name, :hybrid_parent_scientific_name,
+    :other_hybrid_parent_scientific_name
   acts_as_taggable
 
   serialize :data, ActiveRecord::Coders::Hstore
@@ -199,6 +201,12 @@ class TaxonConcept < ActiveRecord::Base
 
   after_save :check_accepted_taxon_concept_exists,
     :if => lambda { |tc| tc.is_synonym? && tc.accepted_scientific_name }
+
+  after_save :check_hybrid_parent_taxon_concept_exists,
+    :if => lambda { |tc| tc.is_hybrid? && tc.hybrid_parent_scientific_name }
+
+  after_save :check_other_hybrid_parent_taxon_concept_exists,
+    :if => lambda { |tc| tc.is_hybrid? && tc.other_hybrid_parent_scientific_name }
 
   scope :at_parent_ranks, lambda{ |rank|
     joins_sql = <<-SQL
@@ -478,6 +486,28 @@ class TaxonConcept < ActiveRecord::Base
     end
 
     true
+  end
+
+  def check_hybrid_parent_taxon_concept_exists
+    check_associated_taxon_concept_exists(:hybrid_parent_scientific_name) do |tc|
+      inverse_taxon_relationships.create(
+        :taxon_concept_id => tc.id,
+        :other_taxon_concept_id => self.id,
+        :taxon_relationship_type_id => TaxonRelationshipType.
+          find_by_name(TaxonRelationshipType::HAS_HYBRID).id
+      )
+    end
+  end
+
+  def check_other_hybrid_parent_taxon_concept_exists
+    check_associated_taxon_concept_exists(:other_hybrid_parent_scientific_name) do |tc|
+      inverse_taxon_relationships.create(
+        :taxon_concept_id => tc.id,
+        :other_taxon_concept_id => self.id,
+        :taxon_relationship_type_id => TaxonRelationshipType.
+          find_by_name(TaxonRelationshipType::HAS_HYBRID).id
+      )
+    end
   end
 
   def check_accepted_taxon_concept_exists

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -192,12 +192,13 @@ class TaxonConcept < ActiveRecord::Base
     :if => lambda { |tc| tc.full_name }
   before_validation :check_parent_taxon_concept_exists,
     :if => lambda { |tc| tc.parent_scientific_name }
-  before_validation :check_accepted_taxon_concept_exists,
-    :if => lambda { |tc| tc.is_synonym? && tc.accepted_scientific_name }
 
   before_validation :ensure_taxonomic_position
 
   translates :nomenclature_note
+
+  after_save :check_accepted_taxon_concept_exists,
+    :if => lambda { |tc| tc.is_synonym? && tc.accepted_scientific_name }
 
   scope :at_parent_ranks, lambda{ |rank|
     joins_sql = <<-SQL
@@ -481,8 +482,9 @@ class TaxonConcept < ActiveRecord::Base
 
   def check_accepted_taxon_concept_exists
     check_associated_taxon_concept_exists(:accepted_scientific_name) do |tc|
-      inverse_taxon_relationships.build(
+      inverse_taxon_relationships.create(
         taxon_concept_id: tc.id,
+        other_taxon_concept_id: self.id,
         taxon_relationship_type_id: TaxonRelationshipType.
         find_by_name(TaxonRelationshipType::HAS_SYNONYM).id
       )

--- a/app/models/taxon_relationship.rb
+++ b/app/models/taxon_relationship.rb
@@ -34,7 +34,6 @@ class TaxonRelationship < ActiveRecord::Base
     scope: [:taxon_relationship_type_id, :other_taxon_concept_id],
     message: 'This relationship already exists, choose another taxon.'
   }
-  validates :other_taxon_concept_id, presence: true
   validate :intertaxonomic_relationship_uniqueness, :if => "taxon_relationship_type.is_intertaxonomic?"
 
   def update_higher_taxa_for_hybrid_child

--- a/app/models/taxon_relationship.rb
+++ b/app/models/taxon_relationship.rb
@@ -34,6 +34,7 @@ class TaxonRelationship < ActiveRecord::Base
     scope: [:taxon_relationship_type_id, :other_taxon_concept_id],
     message: 'This relationship already exists, choose another taxon.'
   }
+  validates :other_taxon_concept_id, presence: true
   validate :intertaxonomic_relationship_uniqueness, :if => "taxon_relationship_type.is_intertaxonomic?"
 
   def update_higher_taxa_for_hybrid_child

--- a/app/views/admin/names/index.html.erb
+++ b/app/views/admin/names/index.html.erb
@@ -3,7 +3,7 @@
   <div class="span4">
     <h3>Synonyms</h3>
     <%= admin_add_new_synonym_button %>
-    <%= admin_new_synonym_modal %>
+    <%= admin_new_synonym_modal(true) %>
     <hr>
     <div id="synonyms-list">
       <% if @taxon_concept.has_synonyms? %>

--- a/app/views/admin/names/index.html.erb
+++ b/app/views/admin/names/index.html.erb
@@ -43,7 +43,7 @@
   <div class="span4">
     <h3>Hybrids</h3>
     <%= admin_add_new_hybrid_button %>
-    <%= admin_new_hybrid_modal %>
+    <%= admin_new_hybrid_modal(true) %>
     <hr>
     <div id="hybrids-list">
       <% if @taxon_concept.has_hybrids? %>

--- a/app/views/admin/taxon_concepts/_hybrid_form.html.erb
+++ b/app/views/admin/taxon_concepts/_hybrid_form.html.erb
@@ -1,0 +1,54 @@
+<%= form_for [:admin, @hybrid], :remote => true, :namespace => 'hybrid' do |f| %>
+  <%= error_messages_for(@hybrid) %>
+  <%= f.hidden_field :name_status %>
+
+  <div class="control-group">
+    <label>Taxonomy</label>
+    <%= f.select :taxonomy_id,
+      options_from_collection_for_select(
+        @taxonomies, :id, :name, @hybrid && @hybrid.taxonomy_id
+      )
+    %>
+  </div>
+  <div class="control-group">
+    <label>Rank</label>
+    <%= f.select :rank_id,
+      options_from_collection_for_select(
+        @ranks, :id, :name,
+        @hybrid && @hybrid.rank_id
+      )
+    %>
+  </div>
+  <div class="control-group">
+    <label>Hybrid parent name</label>
+    <%= f.text_field :hybrid_parent_scientific_name, :class => 'typeahead',
+      "data-rank-scope" => 'ancestors'
+    %>
+  </div>
+  <div class="control-group">
+    <label>Other hybrid parent name</label>
+    <%= f.text_field :other_hybrid_parent_scientific_name, :class => 'typeahead',
+      "data-rank-scope" => 'ancestors'
+    %>
+  </div>
+  <div class="control-group">
+    <label>Hybrid</label>
+    <%= f.text_field :full_name %>
+  </div>
+  <div class="control-group">
+    <label>Tags</label>
+    <%= f.select :tag_list,
+      options_from_collection_for_select(
+        @tags,
+        :name,
+        :name,
+        @taxon_concept.tag_list
+      ), {},
+      { :multiple => true, :class => 'tags', :style => "width: 220px"}
+    %>
+  </div>
+  <div class="control-group">
+    <label>Author & year</label>
+    <%= f.text_field :author_year %>
+  </div>
+<% end %>

--- a/app/views/admin/taxon_concepts/_n_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_n_name_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_for [:admin, @n_name], :remote => true do |f| %>
+
+  <%= error_messages_for(@taxon_concept) %>
+  <%= f.hidden_field :name_status %>
+  <div class="control-group">
+    <label>Taxonomy</label>
+    <%= f.select :taxonomy_id,
+      options_from_collection_for_select(@taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id)
+    %>
+  </div>
+  <div class="control-group">
+    <label>Rank</label>
+    <%= f.select :rank_id,
+      options_from_collection_for_select(@ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id)
+    %>
+  </div>
+  <%= name_status_related_fields(f, @taxon_concept.name_status) %>
+  <div class="control-group">
+    <label>Scientific name</label>
+    <%= f.text_field :full_name %>
+  </div>
+  <div class="control-group">
+    <label>Tags</label>
+    <%= f.select :tag_list,
+      options_from_collection_for_select(
+        @tags,
+        :name,
+        :name,
+        @taxon_concept.tag_list
+      ), {},
+      { :multiple => true, :class => 'tags', :style => "width: 220px"}
+    %>
+  </div>
+  <div class="control-group">
+    <label>Author & year</label>
+    <%= f.text_field :author_year %>
+  </div>
+  <%= render :partial => 'admin/shared/nomenclature_notes_form',
+    locals: {
+      f: f,
+      locale_columns: TaxonConcept.locale_columns(:nomenclature_note)
+    }
+  %>
+<% end %>

--- a/app/views/admin/taxon_concepts/_n_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_n_name_form.html.erb
@@ -1,20 +1,20 @@
 <%= form_for [:admin, @n_name], :remote => true do |f| %>
 
-  <%= error_messages_for(@taxon_concept) %>
+  <%= error_messages_for(@n_name) %>
   <%= f.hidden_field :name_status %>
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,
-      options_from_collection_for_select(@taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id)
+      options_from_collection_for_select(@taxonomies, :id, :name, @n_name && @n_name.taxonomy_id)
     %>
   </div>
   <div class="control-group">
     <label>Rank</label>
     <%= f.select :rank_id,
-      options_from_collection_for_select(@ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id)
+      options_from_collection_for_select(@ranks, :id, :name, @n_name && @n_name.rank_id)
     %>
   </div>
-  <%= name_status_related_fields(f, @taxon_concept.name_status) %>
+  <%= name_status_related_fields(f, @n_name.name_status) %>
   <div class="control-group">
     <label>Scientific name</label>
     <%= f.text_field :full_name %>
@@ -26,7 +26,7 @@
         @tags,
         :name,
         :name,
-        @taxon_concept.tag_list
+        @n_name.tag_list
       ), {},
       { :multiple => true, :class => 'tags', :style => "width: 220px"}
     %>

--- a/app/views/admin/taxon_concepts/_synonym_form.html.erb
+++ b/app/views/admin/taxon_concepts/_synonym_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_for [:admin, @synonym], :remote => true, :namespace => 'synonym' do |f| %>
+  <%= error_messages_for(@synonym) %>
+  <%= f.hidden_field :name_status %>
+
+  <div class="control-group">
+    <label>Taxonomy</label>
+    <%= f.select :taxonomy_id,
+      options_from_collection_for_select(
+        @taxonomies, :id, :name, @synonym && @synonym.taxonomy_id
+      )
+    %>
+  </div>
+  <div class="control-group">
+    <label>Rank</label>
+    <%= f.select :rank_id,
+      options_from_collection_for_select(
+        @ranks, :id, :name,
+        @synonym && @synonym.rank_id
+      )
+    %>
+  </div>
+  <div class="control-group">
+    <label>Accepted name</label>
+    <%= f.text_field :accepted_scientific_name, :class => 'typeahead' %>
+  </div>
+  <div class="control-group">
+    <label>Synonym</label>
+    <%= f.text_field :full_name %>
+  </div>
+  <div class="control-group">
+    <label>Author & year</label>
+    <%= f.text_field :author_year %>
+  </div>
+<% end %>

--- a/app/views/admin/taxon_concepts/index.html.erb
+++ b/app/views/admin/taxon_concepts/index.html.erb
@@ -3,6 +3,7 @@
 <%= admin_new_modal %>
 <%= admin_new_synonym_modal %>
 <%= admin_new_hybrid_modal %>
+<%= admin_new_n_name_modal %>
 
 <%= render :partial => 'search' %>
 

--- a/app/views/admin/taxon_concepts/index.html.erb
+++ b/app/views/admin/taxon_concepts/index.html.erb
@@ -1,5 +1,9 @@
 <%= admin_taxon_concept_title %>
 
+<%= admin_new_modal %>
+<%= admin_new_synonym_modal %>
+<%= admin_new_hybrid_modal %>
+
 <%= render :partial => 'search' %>
 
 <%= admin_table %>

--- a/app/views/admin/taxon_concepts/new_hybrid.js.erb
+++ b/app/views/admin/taxon_concepts/new_hybrid.js.erb
@@ -1,0 +1,4 @@
+$('#admin-new-taxon_concept_hybrid-form').html(
+  "<%= escape_javascript(render('hybrid_form')) %>");
+$('#new-taxon_concept_hybrid').modal('show');
+window.adminEditor.initTaxonConceptTypeaheads();

--- a/app/views/admin/taxon_concepts/new_synonym.js.erb
+++ b/app/views/admin/taxon_concepts/new_synonym.js.erb
@@ -1,0 +1,4 @@
+$('#admin-new-taxon_concept_synonym-form').html(
+  "<%= escape_javascript(render('synonym_form')) %>");
+$('#new-taxon_concept_synonym').modal('show');
+window.adminEditor.initTaxonConceptTypeaheads();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ SAPI::Application.routes.draw do
     resources :ahoy_visits, :only => [:index, :show]
     resources :ahoy_events, :only => [:index, :show]
 
-    resources :taxon_concepts, only: [:index, :edit, :update, :show, :destroy] do
+    resources :taxon_concepts do
       get :autocomplete, :on => :collection
       resources :children, :only => [:index]
       resources :taxon_relationships, :only => [:index, :create, :destroy]

--- a/spec/controllers/admin/taxon_concepts_controller_spec.rb
+++ b/spec/controllers/admin/taxon_concepts_controller_spec.rb
@@ -33,6 +33,19 @@ describe Admin::TaxonConceptsController do
     end
   end
 
+  describe "XHR POST create" do
+    let(:taxon_concept_attributes){ build_tc_attributes(:taxon_concept) }
+    it "renders create when successful" do
+      xhr :post, :create,
+        taxon_concept: taxon_concept_attributes
+      response.should render_template("create")
+    end
+    it "renders new when not successful" do
+      xhr :post, :create, taxon_concept: {}
+      response.should render_template("new")
+    end
+  end
+
   describe "XHR PUT update" do
     let(:taxon_concept){ create(:taxon_concept) }
     context "when JSON" do


### PR DESCRIPTION
This brings back the "Add new Taxon Concept" button in the admin home page according to the tasks in [this PT story](https://www.pivotaltracker.com/story/show/115605031).
Moreover, even if the N names form is the same as the accepted names one, N names get the full scientific name as specified in the scientific name input box rather than having it sanitised as it happens for the accepted names.