### PR TITLE
Lumping across taxonomic levels

### DIFF
--- a/app/controllers/admin/nomenclature_changes/lump_controller.rb
+++ b/app/controllers/admin/nomenclature_changes/lump_controller.rb
@@ -11,6 +11,7 @@ class Admin::NomenclatureChanges::LumpController < Admin::NomenclatureChanges::B
       builder.build_inputs
     when :outputs
       set_taxonomy
+      set_ranks
       builder.build_output
     when :notes
       builder.build_input_and_output_notes
@@ -39,10 +40,12 @@ class Admin::NomenclatureChanges::LumpController < Admin::NomenclatureChanges::B
       unless success
         set_events
         set_taxonomy
+        set_ranks
       end
     when :outputs
       unless success
         set_taxonomy
+        set_ranks
       end
     end
     render_wizard @nomenclature_change
@@ -51,6 +54,10 @@ class Admin::NomenclatureChanges::LumpController < Admin::NomenclatureChanges::B
   private
   def klass
     NomenclatureChange::Lump
+  end
+
+  def set_ranks
+    @ranks = Rank.order(:taxonomic_position)
   end
 
 end

--- a/app/models/nomenclature_change/lump.rb
+++ b/app/models/nomenclature_change/lump.rb
@@ -81,11 +81,13 @@ class NomenclatureChange::Lump < NomenclatureChange
   end
 
   def set_output_rank_id
-    if output.new_rank_id.blank? && (
-      output.new_scientific_name.present? ||
-      output.taxon_concept
-      )
-      output.new_rank_id = output.taxon_concept.rank_id
+    if output.new_rank_id.blank?
+      if output.new_scientific_name.present? && output.new_parent_id.present?
+        child_rank = output.new_parent.rank.child_rank_name
+        output.new_rank_id = Rank.find_by_name(child_rank).id
+      elsif output.taxon_concept
+        output.new_rank_id = output.taxon_concept.rank_id
+      end
     end
   end
 

--- a/app/models/nomenclature_change/lump.rb
+++ b/app/models/nomenclature_change/lump.rb
@@ -85,6 +85,10 @@ class NomenclatureChange::Lump < NomenclatureChange
     inputs.select{ |o| o.taxon_concept == output.try(:taxon_concept) }
   end
 
+  def new_output_rank
+    inputs.first.taxon_concept.rank
+  end
+
   def new_output_parent
     inputs.first.taxon_concept.parent
   end

--- a/app/models/nomenclature_change/lump.rb
+++ b/app/models/nomenclature_change/lump.rb
@@ -35,9 +35,6 @@ class NomenclatureChange::Lump < NomenclatureChange
   before_validation :set_output_name_status, if: Proc.new{ |nc|
     !nc.inputs.empty? && nc.output && nc.outputs_or_submitting?
   }
-  before_validation :set_output_rank_id, if: Proc.new{ |nc|
-    !nc.inputs.empty? && nc.output && nc.outputs_or_submitting?
-  }
   before_save :build_auto_reassignments, if: :notes?
 
   def build_auto_reassignments
@@ -80,27 +77,12 @@ class NomenclatureChange::Lump < NomenclatureChange
     end
   end
 
-  def set_output_rank_id
-    if output.new_rank_id.blank?
-      if output.new_scientific_name.present? && output.new_parent_id.present?
-        child_rank = output.new_parent.rank.child_rank_name
-        output.new_rank_id = Rank.find_by_name(child_rank).id
-      elsif output.taxon_concept
-        output.new_rank_id = output.taxon_concept.rank_id
-      end
-    end
-  end
-
   def inputs_except_outputs
     inputs.reject{ |i| i.taxon_concept == output.try(:taxon_concept) }
   end
 
   def inputs_intersect_outputs
     inputs.select{ |o| o.taxon_concept == output.try(:taxon_concept) }
-  end
-
-  def new_output_rank
-    inputs.first.taxon_concept.rank
   end
 
   def new_output_parent

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -59,6 +59,15 @@ class Rank < ActiveRecord::Base
     end
   end
 
+  def child_rank_name
+    if name != Rank::VARIETY
+      rank_index = self.class.dict.index(name)
+      self.class.dict[rank_index+1]
+    else
+      nil
+    end
+  end
+
   private
 
   def dependent_objects_map

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -59,15 +59,6 @@ class Rank < ActiveRecord::Base
     end
   end
 
-  def child_rank_name
-    if name != Rank::VARIETY
-      rank_index = self.class.dict.index(name)
-      self.class.dict[rank_index+1]
-    else
-      nil
-    end
-  end
-
   private
 
   def dependent_objects_map

--- a/app/views/admin/nomenclature_changes/lump/outputs.html.erb
+++ b/app/views/admin/nomenclature_changes/lump/outputs.html.erb
@@ -15,15 +15,6 @@
     <%= outputs_selection ff %>
 
     <div class="control-group">
-      <label class="control-label">Rank</label>
-      <div class="controls">
-        <%= ff.select :new_rank_id,
-          options_from_collection_for_select(@ranks, :id, :name),
-          { class: 'new-rank' }
-        %>
-      </div>
-    </div>
-    <div class="control-group">
       <label class="control-label">Taxon concept:</label>
       <div class="controls">
         <%= ff.text_field :taxon_concept_id, {
@@ -53,6 +44,15 @@
             :class => 'new-author-year'
           } %>
         </div>
+      </div>
+    </div>
+    <div class="control-group">
+      <label class="control-label">Rank</label>
+      <div class="controls">
+        <%= ff.select :new_rank_id,
+          options_from_collection_for_select(@ranks, :id, :name, ff.object.new_rank_id || f.object.new_output_rank.id),
+          { class: 'new-rank' }
+        %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/nomenclature_changes/lump/outputs.html.erb
+++ b/app/views/admin/nomenclature_changes/lump/outputs.html.erb
@@ -15,6 +15,15 @@
     <%= outputs_selection ff %>
 
     <div class="control-group">
+      <label class="control-label">Rank</label>
+      <div class="controls">
+        <%= ff.select :new_rank_id,
+          options_from_collection_for_select(@ranks, :id, :name),
+          { class: 'new-rank' }
+        %>
+      </div>
+    </div>
+    <div class="control-group">
       <label class="control-label">Taxon concept:</label>
       <div class="controls">
         <%= ff.text_field :taxon_concept_id, {

--- a/spec/models/nomenclature_change/lump_spec.rb
+++ b/spec/models/nomenclature_change/lump_spec.rb
@@ -62,4 +62,17 @@ describe NomenclatureChange::Lump do
       end
     end
   end
+  describe :new_output_rank do
+    let(:lump){
+      build(
+        :nomenclature_change_lump,
+        inputs_attributes: {
+          0 => { taxon_concept_id: create_cites_eu_species.id },
+          1 => { taxon_concept_id: create_cites_eu_subspecies.id }
+        },
+        status: NomenclatureChange::Lump::INPUTS
+      )
+    }
+    specify{ expect(lump.new_output_rank.name).to eq(Rank::SPECIES) }
+  end
 end

--- a/spec/models/nomenclature_change/lump_spec.rb
+++ b/spec/models/nomenclature_change/lump_spec.rb
@@ -61,21 +61,5 @@ describe NomenclatureChange::Lump do
         specify { expect(lump).to have(1).errors_on(:inputs) }
       end
     end
-    context "when output has different rank than inputs" do
-      let(:lump){
-        build(:nomenclature_change_lump,
-          :status => NomenclatureChange::Lump::OUTPUTS,
-          :inputs_attributes => {
-            0 => {:taxon_concept_id => create_cites_eu_subspecies.id},
-            1 => {:taxon_concept_id => create_cites_eu_subspecies.id}
-          },
-          :output_attributes => {
-            :taxon_concept_id => create_cites_eu_species.id,
-            :new_rank_id => create(:rank, name: Rank::SPECIES).id
-          }
-        )
-      }
-      specify { expect(lump).to have(1).errors_on(:output) }
-    end
   end
 end

--- a/spec/models/nomenclature_change/shared/lump_definitions.rb
+++ b/spec/models/nomenclature_change/shared/lump_definitions.rb
@@ -33,7 +33,10 @@ shared_context 'lump_definitions' do
         0 => { taxon_concept_id: input_species1.id },
         1 => { taxon_concept_id: input_species2.id }
       },
-      output_attributes: { taxon_concept_id: input_species1.id },
+      output_attributes: {
+        new_rank_id: input_species1.rank_id,
+        taxon_concept_id: input_species1.id
+      },
       status: NomenclatureChange::Lump::OUTPUTS
     )
   }
@@ -43,7 +46,10 @@ shared_context 'lump_definitions' do
         0 => { taxon_concept_id: input_species1.id },
         1 => { taxon_concept_id: input_species2.id }
       },
-      output_attributes: { taxon_concept_id: output_species.id },
+      output_attributes: {
+        new_rank_id: output_species.rank_id,
+        taxon_concept_id: output_species.id
+      },
       status: NomenclatureChange::Lump::OUTPUTS
     )
   }
@@ -54,6 +60,7 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
+        new_rank_id: output_species.rank_id,
         new_scientific_name: 'fatalus',
         new_parent_id: errorus_genus.id
       },
@@ -67,6 +74,7 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
+        new_rank_id: output_species.rank_id,
         taxon_concept_id: output_species.id
       },
       status: NomenclatureChange::Lump::OUTPUTS
@@ -79,6 +87,7 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
+        new_rank_id: output_species.rank_id,
         taxon_concept_id: output_subspecies.id,
         new_scientific_name: 'lolcatus',
         new_parent_id: errorus_genus.id

--- a/spec/models/nomenclature_change/shared/lump_definitions.rb
+++ b/spec/models/nomenclature_change/shared/lump_definitions.rb
@@ -34,7 +34,6 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
-        new_rank_id: input_species1.rank_id,
         taxon_concept_id: input_species1.id
       },
       status: NomenclatureChange::Lump::OUTPUTS
@@ -47,7 +46,6 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
-        new_rank_id: output_species.rank_id,
         taxon_concept_id: output_species.id
       },
       status: NomenclatureChange::Lump::OUTPUTS
@@ -74,7 +72,6 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
-        new_rank_id: output_species.rank_id,
         taxon_concept_id: output_species.id
       },
       status: NomenclatureChange::Lump::OUTPUTS
@@ -87,8 +84,8 @@ shared_context 'lump_definitions' do
         1 => { taxon_concept_id: input_species2.id }
       },
       output_attributes: {
-        new_rank_id: output_species.rank_id,
         taxon_concept_id: output_subspecies.id,
+        new_rank_id: output_species.rank_id,
         new_scientific_name: 'lolcatus',
         new_parent_id: errorus_genus.id
       },


### PR DESCRIPTION
This PR is about [lumping across taxonomic levels](https://www.pivotaltracker.com/story/show/115607659).
There are no more validations about the rank of the inputs and the outputs, while if we are going to create a new taxon with a different taxonomic level of the inputs, after selecting the parent we get the rank immediately next to the parent's one to successfully create the new taxon