### PR TITLE
Cascading taxon concept notes

### DIFF
--- a/app/models/nomenclature_change/cascading_notes_processor.rb
+++ b/app/models/nomenclature_change/cascading_notes_processor.rb
@@ -1,0 +1,69 @@
+class NomenclatureChange::CascadingNotesProcessor
+
+  def initialize(input_or_output)
+    @input_or_output = input_or_output
+  end
+
+  def run
+    return false unless @input_or_output.taxon_concept
+    @taxon_concept = @input_or_output.taxon_concept
+    descendents_for_note_cascading(@taxon_concept).each do |d|
+      Rails.logger.debug("Processing note for descendant #{d.full_name} of input #{@taxon_concept.full_name}")
+      append_nomenclature_notes(d, @input_or_output)
+    end
+  end
+
+  def summary; end
+
+  private
+
+  def descendents_for_note_cascading(taxon_concept)
+    unless [Rank::GENUS, Rank::SPECIES].include? taxon_concept.rank.try(:name)
+      return []
+    end
+    # if it is a genus or a species, we want taxon-level nomenclature notes,
+    # both public and private, to cascade to descendents
+    subquery =<<-SQL
+      WITH RECURSIVE descendents AS (
+        SELECT id,
+          full_name,
+          name_status,
+          nomenclature_note_en,
+          nomenclature_note_es,
+          nomenclature_note_fr
+        FROM taxon_concepts
+        WHERE parent_id = :taxon_concept_id
+        UNION ALL
+        SELECT taxon_concepts.id,
+          taxon_concepts.full_name,
+          taxon_concepts.name_status,
+          taxon_concepts.nomenclature_note_en,
+          taxon_concepts.nomenclature_note_es,
+          taxon_concepts.nomenclature_note_fr
+        FROM taxon_concepts
+        JOIN descendents h ON h.id = taxon_concepts.parent_id
+      )
+      SELECT * FROM descendents
+    SQL
+    sanitized_subquery = ActiveRecord::Base.send(
+      :sanitize_sql_array, [subquery, taxon_concept_id: taxon_concept.id]
+    )
+    TaxonConcept.from(
+      "(#{sanitized_subquery}) taxon_concepts"
+    )
+  end
+
+  def append_nomenclature_notes(tc, input_or_output)
+    tc.nomenclature_note_en = "#{tc.nomenclature_note_en} #{input_or_output.note_en}"
+    tc.nomenclature_note_es = "#{tc.nomenclature_note_es} #{input_or_output.note_es}"
+    tc.nomenclature_note_fr = "#{tc.nomenclature_note_es} #{input_or_output.note_fr}"
+    tc.save(validate: false)
+    nomenclature_comment = tc.nomenclature_comment ||
+      tc.create_nomenclature_comment
+    nomenclature_comment.update_attribute(
+      :note,
+      "#{nomenclature_comment.note} #{input_or_output.internal_note}"
+    )
+  end
+
+end

--- a/app/models/nomenclature_change/cascading_notes_processor.rb
+++ b/app/models/nomenclature_change/cascading_notes_processor.rb
@@ -17,7 +17,7 @@ class NomenclatureChange::CascadingNotesProcessor
     end
   end
 
-  def summary; end
+  def summary; []; end
 
   private
 

--- a/app/models/nomenclature_change/cascading_notes_processor.rb
+++ b/app/models/nomenclature_change/cascading_notes_processor.rb
@@ -5,8 +5,12 @@ class NomenclatureChange::CascadingNotesProcessor
   end
 
   def run
-    return false unless @input_or_output.taxon_concept
-    @taxon_concept = @input_or_output.taxon_concept
+    @taxon_concept = if @input_or_output.kind_of? NomenclatureChange::Output
+      @input_or_output.new_taxon_concept || @input_or_output.taxon_concept
+    else
+      @input_or_output.taxon_concept
+    end
+    return false unless @taxon_concept
     descendents_for_note_cascading(@taxon_concept).each do |d|
       Rails.logger.debug("Processing note for descendant #{d.full_name} of input #{@taxon_concept.full_name}")
       append_nomenclature_notes(d, @input_or_output)

--- a/app/models/nomenclature_change/lump/processor.rb
+++ b/app/models/nomenclature_change/lump/processor.rb
@@ -18,12 +18,14 @@ class NomenclatureChange::Lump::Processor < NomenclatureChange::Processor
     chain = []
     chain << NomenclatureChange::OutputTaxonConceptProcessor.new(@output)
     @inputs.each do |input|
-      unless input.taxon_concept_id == @output.taxon_concept_id && !@output.will_create_taxon?
+      if !(input.taxon_concept_id == @output.taxon_concept_id && !@output.will_create_taxon?)
+        chain << NomenclatureChange::InputTaxonConceptProcessor.new(input)
+        chain << NomenclatureChange::CascadingNotesProcessor.new(input)
         chain << NomenclatureChange::ReassignmentTransferProcessor.new(input, @output)
         chain << NomenclatureChange::StatusDowngradeProcessor.new(input, [@output])
-        chain << NomenclatureChange::InputTaxonConceptProcessor.new(input)
       end
     end
+    chain << NomenclatureChange::CascadingNotesProcessor.new(@output)
     chain
   end
 

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -26,15 +26,15 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       end
       if output.will_create_taxon?
         # for the case when an existing accepted subspecies is turned into a species
-        if ['A', 'N'].include?(output.name_status)
+        if output.name_status == 'A'
           chain << NomenclatureChange::ReassignmentTransferProcessor.new(output, output)
 
           chain << NomenclatureChange::StatusDowngradeProcessor.new(output)
         # for the case when an existing synonym subspecies is turned into a species
-        elsif ['S', 'T'].include?(output.name_status)
+        elsif output.name_status == 'S'
           chain << NomenclatureChange::StatusDowngradeProcessor.new(output, [output])
         end
-      elsif !output.will_create_taxon? && ['S', 'T'].include?(output.name_status)
+      elsif !output.will_create_taxon? && output.name_status == 'S'
         chain << NomenclatureChange::StatusUpgradeProcessor.new(output)
       end
       unless @input.taxon_concept_id == output.taxon_concept_id && !output.will_create_taxon?

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -20,6 +20,7 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       map(&:taxon_concept_id).include?(@input.taxon_concept_id)
 
     chain << NomenclatureChange::InputTaxonConceptProcessor.new(@input)
+    chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
     @outputs.each_with_index do |output, idx|
       if @input.taxon_concept_id != output.taxon_concept_id
         chain << NomenclatureChange::OutputTaxonConceptProcessor.new(output)
@@ -47,6 +48,7 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
           chain << NomenclatureChange::ReassignmentCopyProcessor.new(@input, output)
         end
       end
+      chain << NomenclatureChange::CascadingNotesProcessor.new(output)
     end
     unless input_is_one_of_outputs
       chain << NomenclatureChange::StatusDowngradeProcessor.new(@input, @outputs)

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -60,6 +60,61 @@ describe NomenclatureChange::Lump::Processor do
         specify{ expect(lump.output.new_taxon_concept.shipments).to include(@shipment) }
       end
     end
+    context "when input with children that change name" do
+      let!(:input_species1_child){
+        create_cites_eu_subspecies(parent: input_species1)
+      }
+      let(:lump){
+        create(:nomenclature_change_lump,
+          inputs_attributes: {
+            0 => {
+              taxon_concept_id: input_species1.id,
+              note_en: 'input EN note',
+              internal_note: 'input internal note'
+            },
+            1 => { taxon_concept_id: input_species2.id }
+          },
+          output_attributes: {
+            taxon_concept_id: output_species.id,
+            note_en: 'output EN note',
+            internal_note: 'output internal note'
+          },
+          status: NomenclatureChange::Lump::LEGISLATION
+        )
+      }
+      let(:input){ lump.inputs.first }
+      let(:output){ lump.output }
+      let(:reassignment){
+        create(:nomenclature_change_parent_reassignment,
+          input: input,
+          reassignable_id: input_species1_child.id
+        )
+      }
+      let!(:reassignment_target){
+        create(:nomenclature_change_reassignment_target,
+          reassignment: reassignment,
+          output: output
+        )
+      }
+      let(:output_species_child){ output_species.children.first.reload }
+      before(:each){ processor.run }
+      specify do
+        expect(input_species1.reload.nomenclature_note_en).to eq(' input EN note')
+        expect(input_species1_child.reload.nomenclature_note_en).to eq(input_species1.nomenclature_note_en)
+      end
+      specify do
+        expect(input_species1.nomenclature_comment.note).to eq(' input internal note')
+        expect(input_species1_child.nomenclature_comment.note).to eq(input_species1.nomenclature_comment.note)
+      end
+      specify do
+        expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
+        expect(output_species_child.reload.nomenclature_note_en).to eq(output_species.nomenclature_note_en)
+      end
+      specify do
+        expect(output_species.nomenclature_comment.note).to eq(' output internal note')
+        expect(output_species_child.nomenclature_comment.note).to eq(output_species.nomenclature_comment.note)
+      end
+    end
   end
   describe :summary do
     let(:lump){ lump_with_inputs_and_output_existing_taxon }


### PR DESCRIPTION
This implements the behaviour of cascading taxon-level nomenclature notes from genera and species in cases of splits and lumps (nomenclature_note_[en|es|fr] fields in taxon concepts, which show in the admin taxon concept edit modal and Species+ names tab, as well as the nomenclature change internal comment, which only shows in the admin tool on the notes page)

https://www.pivotaltracker.com/story/show/115759819