### PR TITLE
Fix nomenclature notes not updating

### DIFF
--- a/app/models/nomenclature_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/constructor_helpers.rb
@@ -129,8 +129,7 @@ module NomenclatureChange::ConstructorHelpers
   def _build_legislation_type_reassignment(legislation_collection_name, input)
     legislation_type = legislation_collection_name.to_s.singularize.camelize
     public_note = send(:"multi_lingual_#{legislation_collection_name.to_s.singularize}_note")
-    input.send(:"#{legislation_collection_name}_reassignments").first ||
-      input.taxon_concept.send(legislation_collection_name).limit(1).count > 0 &&
+    input.taxon_concept.send(legislation_collection_name).limit(1).count > 0 &&
       input.legislation_reassignment_class.new(
         reassignable_type: legislation_type,
         note_en: public_note[:en],

--- a/app/models/nomenclature_change/lump/constructor.rb
+++ b/app/models/nomenclature_change/lump/constructor.rb
@@ -109,19 +109,15 @@ class NomenclatureChange::Lump::Constructor
     output = @nomenclature_change.output
     event = @nomenclature_change.event
     @nomenclature_change.inputs_except_outputs.each do |input|
-      if input.note_en.blank?
         note = multi_lingual_input_note(input, output, event)
         input.note_en = note[:en]
         input.note_es = note[:es]
         input.note_fr = note[:fr]
-      end
     end
-    if output.note_en.blank?
-      note = multi_lingual_output_note(output, @nomenclature_change.inputs, event)
-        output.note_en = note[:en]
-        output.note_es = note[:es]
-        output.note_fr = note[:fr]
-    end
+    note = multi_lingual_output_note(output, @nomenclature_change.inputs, event)
+    output.note_en = note[:en]
+    output.note_es = note[:es]
+    output.note_fr = note[:fr]
   end
 
   def legislation_note(lng)

--- a/app/models/nomenclature_change/lump/constructor.rb
+++ b/app/models/nomenclature_change/lump/constructor.rb
@@ -109,10 +109,10 @@ class NomenclatureChange::Lump::Constructor
     output = @nomenclature_change.output
     event = @nomenclature_change.event
     @nomenclature_change.inputs_except_outputs.each do |input|
-        note = multi_lingual_input_note(input, output, event)
-        input.note_en = note[:en]
-        input.note_es = note[:es]
-        input.note_fr = note[:fr]
+      note = multi_lingual_input_note(input, output, event)
+      input.note_en = note[:en]
+      input.note_es = note[:es]
+      input.note_fr = note[:fr]
     end
     note = multi_lingual_output_note(output, @nomenclature_change.inputs, event)
     output.note_en = note[:en]

--- a/app/models/nomenclature_change/split/constructor.rb
+++ b/app/models/nomenclature_change/split/constructor.rb
@@ -148,19 +148,15 @@ class NomenclatureChange::Split::Constructor
   def build_input_and_output_notes
     input = @nomenclature_change.input
     event = @nomenclature_change.event
-    if input.note_en.blank?
-      note = multi_lingual_input_note(input, @nomenclature_change.outputs, event)
-      input.note_en = note[:en]
-      input.note_es = note[:es]
-      input.note_fr = note[:fr]
-    end
+    note = multi_lingual_input_note(input, @nomenclature_change.outputs, event)
+    input.note_en = note[:en]
+    input.note_es = note[:es]
+    input.note_fr = note[:fr]
     @nomenclature_change.outputs_except_inputs.each do |output|
-      if output.note_en.blank?
-        note = multi_lingual_output_note(output, input, event)
-        output.note_en = note[:en]
-        output.note_es = note[:es]
-        output.note_fr = note[:fr]
-      end
+      note = multi_lingual_output_note(output, input, event)
+      output.note_en = note[:en]
+      output.note_es = note[:es]
+      output.note_fr = note[:fr]
     end
   end
 

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -125,23 +125,21 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
   end
 
   def build_primary_output_note
-    if @nomenclature_change.primary_output.note_en.blank?
-      if @nomenclature_change.primary_output.needs_public_note?
-        primary_note = multi_lingual_public_output_note(
-          @nomenclature_change.primary_output,
-          @event
-        )
-        @nomenclature_change.primary_output.note_en = primary_note[:en]
-        @nomenclature_change.primary_output.note_es = primary_note[:es]
-        @nomenclature_change.primary_output.note_fr = primary_note[:fr]
-      else
-        primary_note = private_output_note(
-          @nomenclature_change.primary_output,
-          @event,
-          :en
-        )
-        @nomenclature_change.primary_output.internal_note = primary_note
-      end
+    if @nomenclature_change.primary_output.needs_public_note?
+      primary_note = multi_lingual_public_output_note(
+        @nomenclature_change.primary_output,
+        @event
+      )
+      @nomenclature_change.primary_output.note_en = primary_note[:en]
+      @nomenclature_change.primary_output.note_es = primary_note[:es]
+      @nomenclature_change.primary_output.note_fr = primary_note[:fr]
+    else
+      primary_note = private_output_note(
+        @nomenclature_change.primary_output,
+        @event,
+        :en
+      )
+      @nomenclature_change.primary_output.internal_note = primary_note
     end
   end
 

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -8,23 +8,21 @@ class NomenclatureChange::StatusSwap::Constructor
   end
 
   def build_secondary_output_note
-    if @nomenclature_change.secondary_output.note_en.blank?
-      if @nomenclature_change.secondary_output.needs_public_note?
-        secondary_note = multi_lingual_public_output_note(
-          @nomenclature_change.secondary_output,
-          @event
-        )
-        @nomenclature_change.secondary_output.note_en = secondary_note[:en]
-        @nomenclature_change.secondary_output.note_es = secondary_note[:es]
-        @nomenclature_change.secondary_output.note_fr = secondary_note[:fr]
-      else
-        secondary_note = private_output_note(
-          @nomenclature_change.secondary_output,
-          @event,
-          :en
-        )
-        @nomenclature_change.secondary_output.internal_note = secondary_note
-      end
+    if @nomenclature_change.secondary_output.needs_public_note?
+      secondary_note = multi_lingual_public_output_note(
+        @nomenclature_change.secondary_output,
+        @event
+      )
+      @nomenclature_change.secondary_output.note_en = secondary_note[:en]
+      @nomenclature_change.secondary_output.note_es = secondary_note[:es]
+      @nomenclature_change.secondary_output.note_fr = secondary_note[:fr]
+    else
+      secondary_note = private_output_note(
+        @nomenclature_change.secondary_output,
+        @event,
+        :en
+      )
+      @nomenclature_change.secondary_output.internal_note = secondary_note
     end
   end
 


### PR DESCRIPTION
This is about [nomenclature notes not updating when going back through the wizard](https://www.pivotaltracker.com/story/show/115606167).
I've removed some conditions for lump, split, status change and swap, so we keep creating new notes if we go back to change something, rather than checking if the notes have already been created