### PR TITLE
removed validation for name uniqueness in split & lump

### DIFF
--- a/app/models/nomenclature_change/lump.rb
+++ b/app/models/nomenclature_change/lump.rb
@@ -61,13 +61,6 @@ class NomenclatureChange::Lump < NomenclatureChange
     end
   end
 
-  def required_different_name
-    if output.taxon_name_already_existing? && !output.new_full_name.nil?
-      errors.add(:output, "Name already existing")
-      return false
-    end
-  end
-
   def set_output_name_status
     if output.new_name_status.blank? && (
       output.new_scientific_name.present? ||

--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -186,10 +186,6 @@ class NomenclatureChange::Output < ActiveRecord::Base
     end
   end
 
-  def taxon_name_already_existing?
-    return !TaxonConcept.where("lower(full_name) = ?", display_full_name.downcase).empty?
-  end
-
   def expected_parent_name
     if rank.name == Rank::SPECIES
       display_full_name.split[0]

--- a/app/models/nomenclature_change/split.rb
+++ b/app/models/nomenclature_change/split.rb
@@ -34,7 +34,6 @@ class NomenclatureChange::Split < NomenclatureChange
   validate :required_inputs, if: :inputs_or_submitting?
   validate :required_outputs, if: :outputs_or_submitting?
   validate :required_ranks, if: :outputs_or_submitting?
-  validate :required_different_name, if: :outputs_or_submitting?
   before_validation :set_outputs_name_status, if: :outputs_or_submitting?
   before_validation :set_outputs_rank_id, if: :outputs_or_submitting?
   before_save :build_auto_reassignments, if: :notes?
@@ -69,15 +68,6 @@ class NomenclatureChange::Split < NomenclatureChange
         o.try(:new_rank_id) || o.try(:taxon_concept).try(:rank_id)
       end.uniq - [input.try(:taxon_concept).try(:rank_id)]).empty?
       errors.add(:outputs, "Must be at same rank as input")
-      return false
-    end
-  end
-
-  def required_different_name
-    if outputs.any? do |output|
-        output.taxon_name_already_existing? && !output.new_full_name.nil?
-      end
-      errors.add(:outputs, "Name already existing")
       return false
     end
   end


### PR DESCRIPTION
That validation happens anyway as part of output taxon concept validation; as a matter of fact the check for `taxon_name_already_existing? ` was to strict anyway, because it only took into consideration the name, and it should be checking the taxonomy and author year as well. Better to leave this to the TaxonConcept class rather than duplicate the logic (which in case of lumps was not even active).