### PR TITLE
Downgrade to synonym should not detach old parent

### DIFF
--- a/app/models/nomenclature_change/reassignment_processor.rb
+++ b/app/models/nomenclature_change/reassignment_processor.rb
@@ -87,7 +87,7 @@ class NomenclatureChange::ReassignmentProcessor
   def post_process(reassigned_object, object_before_reassignment)
     Rails.logger.warn("Reassignment post processing BEGIN")
     if reassigned_object.is_a?(TaxonConcept)
-      resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(reassigned_object)
+      resolver = NomenclatureChange::TaxonomicTreeNameResolver.new(reassigned_object, object_before_reassignment)
       resolver.process
     elsif reassigned_object.is_a?(TaxonRelationship)
       resolver = NomenclatureChange::TradeShipmentsResolver.new(reassigned_object, object_before_reassignment)

--- a/app/models/nomenclature_change/status_downgrade_processor.rb
+++ b/app/models/nomenclature_change/status_downgrade_processor.rb
@@ -9,20 +9,9 @@ class NomenclatureChange::StatusDowngradeProcessor < NomenclatureChange::StatusC
     if @input_or_output.kind_of?(NomenclatureChange::Output) && @input_or_output.new_taxon_concept
       @linked_names << @input_or_output.new_taxon_concept
     end
-    higher_taxa_hstore_fields = Rank.in_range(nil, nil).map do |r|
-      ["#{r.downcase}_id", "#{r.downcase}_name"]
-    end.flatten
-    new_data = @input_or_output.taxon_concept.data &&
-      @input_or_output.taxon_concept.data.except(*higher_taxa_hstore_fields) ||
-      {}
 
-    # work-around to avoid 3 separate update_column calls
     TaxonConcept.where(id: @input_or_output.taxon_concept_id).update_all(
-      name_status: 'S',
-      parent_id: nil,
-      data: ActiveRecord::Coders::Hstore.dump(
-        new_data
-      )
+      name_status: 'S'
     )
 
     if @old_status == 'T'

--- a/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
+++ b/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
@@ -1,7 +1,8 @@
 class NomenclatureChange::TaxonomicTreeNameResolver
 
-  def initialize(taxon_concept)
+  def initialize(taxon_concept, taxon_concept_old_copy)
     @node = taxon_concept
+    @node_old_copy = taxon_concept_old_copy
   end
 
   # turn taxa into synonyms when name changes involved
@@ -36,13 +37,13 @@ class NomenclatureChange::TaxonomicTreeNameResolver
           t.process
         end
       end
+      # restore old parent, even though this ends up as a synonym it should
+      # have sane ancestry
+      node.update_attribute(:parent_id, @node_old_copy.parent_id)
       r = NomenclatureChange::FullReassignment.new(node, compatible_node)
       r.process
       t = NomenclatureChange::ToSynonymTransformation.new(node, compatible_node)
       t.process
-      node.children.each do |child|
-        child.update_attribute(:parent_id, compatible_node.id)
-      end
     else
       compatible_node = node
     end

--- a/app/models/nomenclature_change/to_synonym_transformation.rb
+++ b/app/models/nomenclature_change/to_synonym_transformation.rb
@@ -12,8 +12,7 @@ class NomenclatureChange::ToSynonymTransformation
     relink_relationships(
       @accepted_taxon_concept.trade_name_relationships, @new_accepted_name
     )
-    # detach from parent and turn into a synonym
-    @accepted_taxon_concept.update_attributes(parent_id: nil, name_status: 'S')
+    @accepted_taxon_concept.update_attribute(:name_status, 'S')
     # turn current name into synonym of new name
     rel_type = TaxonRelationshipType.find_by_name(TaxonRelationshipType::HAS_SYNONYM)
     @new_accepted_name.taxon_relationships << TaxonRelationship.new(

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -48,6 +48,8 @@ describe NomenclatureChange::Lump::Processor do
       end
     end
     context "when output is existing taxon with new name" do
+      let(:input_genus1){ create_cites_eu_genus }
+      let(:input_species1){ create_cites_eu_species(parent: input_genus1) }
       let(:output_species2){ create_cites_eu_subspecies }
       let!(:lump){ lump_with_inputs_and_output_name_change }
       specify { expect{ processor.run }.to change(TaxonConcept, :count).by(1) }
@@ -55,7 +57,7 @@ describe NomenclatureChange::Lump::Processor do
       context "relationships and trade" do
         before(:each){ processor.run }
         specify{ expect(input_species1.reload).to be_is_synonym }
-        specify{ expect(input_species1.reload.parent_id).to be_nil }
+        specify{ expect(input_species1.reload.parent).to eq(input_genus1) }
         specify{ expect(input_species1.accepted_names).to include(lump.output.new_taxon_concept) }
         specify{ expect(lump.output.new_taxon_concept.shipments).to include(@shipment) }
       end

--- a/spec/models/nomenclature_change/shared/parent_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/parent_reassignments_processor_examples.rb
@@ -19,7 +19,7 @@ shared_context 'parent_reassignments_processor_examples' do
     processor.run
     input_species_child.reload
   end
-  specify{ expect(input_species_child.parent).to be_nil }
+  specify{ expect(input_species_child.parent).to eq(input_species) }
   specify{ expect(input_species_child.name_status).to eq('S') }
   specify{ expect(input_species.children.count).to eq(0) }
   specify do

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -70,7 +70,7 @@ describe NomenclatureChange::Split::Processor do
       context "relationships and trade" do
         before(:each){ processor.run }
         specify{ expect(input_species.reload).to be_is_synonym }
-        specify{ expect(input_species.reload.parent_id).to be_nil }
+        specify{ expect(input_species.reload.parent).to eq(genus1) }
         specify{ expect(input_species.accepted_names).to include(split.outputs.last.new_taxon_concept) }
         specify{ expect(output_species1.shipments).to include(@shipment) }
       end

--- a/spec/models/nomenclature_change/status_swap/processor_spec.rb
+++ b/spec/models/nomenclature_change/status_swap/processor_spec.rb
@@ -23,6 +23,8 @@ describe NomenclatureChange::StatusSwap::Processor do
 
   describe :run do
     context "from accepted name" do
+      let(:accepted_name_parent){ create_cites_eu_genus }
+      let(:accepted_name){ create_cites_eu_species(parent: accepted_name_parent) }
       let(:status_change){ a_to_s_with_swap }
       before(:each){
         @shipment = create(:shipment,
@@ -32,6 +34,7 @@ describe NomenclatureChange::StatusSwap::Processor do
         processor.run
       }
       specify{ expect(primary_output_taxon_concept).to be_is_synonym }
+      specify{ expect(primary_output_taxon_concept.parent).to eq(accepted_name_parent) }
       specify{ expect(secondary_output_taxon_concept.name_status).to eq('A') }
       specify{ expect(primary_output_taxon_concept.accepted_names).to include(secondary_output_taxon_concept) }
     end

--- a/spec/models/nomenclature_change/status_to_synonym/processor_spec.rb
+++ b/spec/models/nomenclature_change/status_to_synonym/processor_spec.rb
@@ -11,6 +11,8 @@ describe NomenclatureChange::StatusToSynonym::Processor do
 
   describe :run do
     context "from N name" do
+      let(:input_species_parent){ create_cites_eu_genus }
+      let(:input_species){ create_cites_eu_species(parent: input_species_parent) }
       let(:status_change){ n_to_s_with_input_and_secondary_output }
       before(:each){
         @shipment = create(:shipment,
@@ -20,6 +22,7 @@ describe NomenclatureChange::StatusToSynonym::Processor do
         processor.run
       }
       specify{ expect(primary_output_taxon_concept).to be_is_synonym }
+      specify{ expect(primary_output_taxon_concept.parent).to eq(input_species_parent) }
       specify{ expect(primary_output_taxon_concept.accepted_names).to include(secondary_output_taxon_concept) }
       specify{ expect(primary_output_taxon_concept.shipments).to be_empty }
       specify{ expect(primary_output_taxon_concept.reported_shipments).to include(@shipment) }


### PR DESCRIPTION
This is to suppress unnecessary clearing / resetting of taxonomic ancestors for taxa turning into synonyms and their children. This caused messed up ancestry for some synonyms as described in this story: https://www.pivotaltracker.com/story/show/115610827

In fact this behaviour would also affect cases of split with input that is not one of the outputs, status swap a -> s and status change t, n -> a.