### PR TITLE
Cascading legislation notes

### DIFF
--- a/app/models/nomenclature_change/cascading_notes_processor.rb
+++ b/app/models/nomenclature_change/cascading_notes_processor.rb
@@ -69,7 +69,7 @@ class NomenclatureChange::CascadingNotesProcessor
   def append_nomenclature_notes(tc, input_or_output)
     tc.nomenclature_note_en = "#{tc.nomenclature_note_en} #{input_or_output.note_en}"
     tc.nomenclature_note_es = "#{tc.nomenclature_note_es} #{input_or_output.note_es}"
-    tc.nomenclature_note_fr = "#{tc.nomenclature_note_es} #{input_or_output.note_fr}"
+    tc.nomenclature_note_fr = "#{tc.nomenclature_note_fr} #{input_or_output.note_fr}"
     tc.save(validate: false)
     nomenclature_comment = tc.nomenclature_comment ||
       tc.create_nomenclature_comment
@@ -82,7 +82,7 @@ class NomenclatureChange::CascadingNotesProcessor
   def append_nomenclature_notes_to_legislation(legislation, input_or_output)
     legislation.nomenclature_note_en = "#{legislation.nomenclature_note_en} #{input_or_output.note_en}"
     legislation.nomenclature_note_es = "#{legislation.nomenclature_note_es} #{input_or_output.note_es}"
-    legislation.nomenclature_note_fr = "#{legislation.nomenclature_note_es} #{input_or_output.note_fr}"
+    legislation.nomenclature_note_fr = "#{legislation.nomenclature_note_fr} #{input_or_output.note_fr}"
     legislation.internal_notes = "#{legislation.internal_notes} #{input_or_output.internal_note}"
     legislation.save(validate: false)
   end

--- a/app/models/nomenclature_change/cascading_notes_processor.rb
+++ b/app/models/nomenclature_change/cascading_notes_processor.rb
@@ -14,6 +14,15 @@ class NomenclatureChange::CascadingNotesProcessor
     descendents_for_note_cascading(@taxon_concept).each do |d|
       Rails.logger.debug("Processing note for descendant #{d.full_name} of input #{@taxon_concept.full_name}")
       append_nomenclature_notes(d, @input_or_output)
+      (
+        d.listing_changes +
+        d.cites_suspensions +
+        d.quotas +
+        d.eu_opinions +
+        d.eu_suspensions
+      ).each do |legislation|
+        append_nomenclature_notes_to_legislation(legislation, @input_or_output)
+      end
     end
   end
 
@@ -68,6 +77,14 @@ class NomenclatureChange::CascadingNotesProcessor
       :note,
       "#{nomenclature_comment.note} #{input_or_output.internal_note}"
     )
+  end
+
+  def append_nomenclature_notes_to_legislation(legislation, input_or_output)
+    legislation.nomenclature_note_en = "#{legislation.nomenclature_note_en} #{input_or_output.note_en}"
+    legislation.nomenclature_note_es = "#{legislation.nomenclature_note_es} #{input_or_output.note_es}"
+    legislation.nomenclature_note_fr = "#{legislation.nomenclature_note_es} #{input_or_output.note_fr}"
+    legislation.internal_notes = "#{legislation.internal_notes} #{input_or_output.internal_note}"
+    legislation.save(validate: false)
   end
 
 end

--- a/app/models/nomenclature_change/lump/processor.rb
+++ b/app/models/nomenclature_change/lump/processor.rb
@@ -20,7 +20,9 @@ class NomenclatureChange::Lump::Processor < NomenclatureChange::Processor
     @inputs.each do |input|
       if input.taxon_concept_id != @output.taxon_concept_id || @output.will_create_taxon?
         chain << NomenclatureChange::InputTaxonConceptProcessor.new(input)
-        chain << NomenclatureChange::CascadingNotesProcessor.new(input)
+        if input.taxon_concept_id != @output.taxon_concept_id
+          chain << NomenclatureChange::CascadingNotesProcessor.new(input)
+        end
         chain << NomenclatureChange::ReassignmentTransferProcessor.new(input, @output)
         chain << NomenclatureChange::StatusDowngradeProcessor.new(input, [@output])
       end

--- a/app/models/nomenclature_change/lump/processor.rb
+++ b/app/models/nomenclature_change/lump/processor.rb
@@ -18,7 +18,7 @@ class NomenclatureChange::Lump::Processor < NomenclatureChange::Processor
     chain = []
     chain << NomenclatureChange::OutputTaxonConceptProcessor.new(@output)
     @inputs.each do |input|
-      if !(input.taxon_concept_id == @output.taxon_concept_id && !@output.will_create_taxon?)
+      if input.taxon_concept_id != @output.taxon_concept_id || @output.will_create_taxon?
         chain << NomenclatureChange::InputTaxonConceptProcessor.new(input)
         chain << NomenclatureChange::CascadingNotesProcessor.new(input)
         chain << NomenclatureChange::ReassignmentTransferProcessor.new(input, @output)

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -20,7 +20,9 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       map(&:taxon_concept_id).include?(@input.taxon_concept_id)
 
     chain << NomenclatureChange::InputTaxonConceptProcessor.new(@input)
-    chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
+    if !input_is_one_of_outputs
+      chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
+    end
     @outputs.each_with_index do |output, idx|
       if @input.taxon_concept_id != output.taxon_concept_id
         chain << NomenclatureChange::OutputTaxonConceptProcessor.new(output)

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -38,7 +38,7 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       elsif !output.will_create_taxon? && output.name_status == 'S'
         chain << NomenclatureChange::StatusUpgradeProcessor.new(output)
       end
-      unless @input.taxon_concept_id == output.taxon_concept_id && !output.will_create_taxon?
+      if @input.taxon_concept_id != output.taxon_concept_id || output.will_create_taxon?
         # if input is not one of outputs and this is the last output
         # transfer the associations rather than copy them
         transfer = !input_is_one_of_outputs && (idx == (@outputs.length - 1))

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -66,6 +66,9 @@ describe NomenclatureChange::Lump::Processor do
       let!(:input_species1_child){
         create_cites_eu_subspecies(parent: input_species1)
       }
+      let!(:input_species1_child_listing){
+        create_cites_I_addition(taxon_concept: input_species1_child)
+      }
       let(:lump){
         create(:nomenclature_change_lump,
           inputs_attributes: {
@@ -115,6 +118,12 @@ describe NomenclatureChange::Lump::Processor do
       specify do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
         expect(output_species_child.nomenclature_comment.note).to eq(output_species.nomenclature_comment.note)
+      end
+      specify do
+        expect(output_species_child.listing_changes.count).to eq(1)
+        expect(
+          output_species_child.listing_changes.first.nomenclature_note_en
+        ).to include(output_species.reload.nomenclature_note_en)
       end
     end
   end

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -105,19 +105,27 @@ describe NomenclatureChange::Lump::Processor do
       before(:each){ processor.run }
       specify do
         expect(input_species1.reload.nomenclature_note_en).to eq(' input EN note')
-        expect(input_species1_child.reload.nomenclature_note_en).to eq(input_species1.nomenclature_note_en)
+        expect(
+          input_species1_child.reload.nomenclature_note_en
+        ).to eq(input_species1.nomenclature_note_en)
       end
       specify do
         expect(input_species1.nomenclature_comment.note).to eq(' input internal note')
-        expect(input_species1_child.nomenclature_comment.note).to eq(input_species1.nomenclature_comment.note)
+        expect(
+          input_species1_child.nomenclature_comment.note
+        ).to eq(input_species1.nomenclature_comment.note)
       end
       specify do
         expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
-        expect(output_species_child.reload.nomenclature_note_en).to eq(output_species.nomenclature_note_en)
+        expect(
+          output_species_child.reload.nomenclature_note_en
+        ).to eq(output_species.nomenclature_note_en)
       end
       specify do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
-        expect(output_species_child.nomenclature_comment.note).to eq(output_species.nomenclature_comment.note)
+        expect(
+          output_species_child.nomenclature_comment.note
+        ).to eq(output_species.nomenclature_comment.note)
       end
       specify do
         expect(output_species_child.listing_changes.count).to eq(1)

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -79,6 +79,9 @@ describe NomenclatureChange::Split::Processor do
       let!(:input_species_child){
         create_cites_eu_subspecies(parent: input_species)
       }
+      let!(:input_species_child_listing){
+        create_cites_I_addition(taxon_concept: input_species_child)
+      }
       let(:split){
         create(:nomenclature_change_split,
           input_attributes: {
@@ -129,6 +132,12 @@ describe NomenclatureChange::Split::Processor do
       specify do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
         expect(output_species_child.nomenclature_comment.note).to eq(output_species.nomenclature_comment.note)
+      end
+      specify do
+        expect(output_species_child.listing_changes.count).to eq(1)
+        expect(
+          output_species_child.listing_changes.first.nomenclature_note_en
+        ).to include(output_species.nomenclature_note_en)
       end
     end
   end

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -119,19 +119,27 @@ describe NomenclatureChange::Split::Processor do
       before(:each){ processor.run }
       specify do
         expect(input_species.reload.nomenclature_note_en).to eq(' input EN note')
-        expect(input_species_child.reload.nomenclature_note_en).to eq(input_species.nomenclature_note_en)
+        expect(
+          input_species_child.reload.nomenclature_note_en
+        ).to eq(input_species.nomenclature_note_en)
       end
       specify do
         expect(input_species.nomenclature_comment.note).to eq(' input internal note')
-        expect(input_species_child.nomenclature_comment.note).to eq(input_species.nomenclature_comment.note)
+        expect(
+          input_species_child.nomenclature_comment.note
+        ).to eq(input_species.nomenclature_comment.note)
       end
       specify do
         expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
-        expect(output_species_child.reload.nomenclature_note_en).to eq(output_species.nomenclature_note_en)
+        expect(
+          output_species_child.reload.nomenclature_note_en
+        ).to eq(output_species.nomenclature_note_en)
       end
       specify do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
-        expect(output_species_child.nomenclature_comment.note).to eq(output_species.nomenclature_comment.note)
+        expect(
+          output_species_child.nomenclature_comment.note
+        ).to eq(output_species.nomenclature_comment.note)
       end
       specify do
         expect(output_species_child.listing_changes.count).to eq(1)


### PR DESCRIPTION
This is less intuitive than it sounds: the problem affects legislation records issued below the level of the split / lump. For example, let's say we have species Canis lupus, which has a listing on species level saying "Except domesticated forms of Canis lupus". Now someone comes in and performs a split of the Canis genus, into Canis and Supercanis, with Canis lupus becoming Supercanis lupus. The Supercanis genus will get a taxon-level note saying "Supercanis was split from Canis", and the same taxon-level note will cascade to Supercanis lupus, but the old listing change will still read "Except domesticated form of Canis lupus", which makes little sense with the new name. To make that listing more understandable, I propose to append the taxon-level note to the listing (Supercanis was split from Canis), as this will explain what happened to the name. I think it is not intuitive because what is being cascaded is in fact not the legislation note, but the taxon note, appended to legislation nomenclature notes.