### PR TITLE
Add nomenclature notes to swap

### DIFF
--- a/app/controllers/admin/nomenclature_changes/status_swap_controller.rb
+++ b/app/controllers/admin/nomenclature_changes/status_swap_controller.rb
@@ -12,6 +12,8 @@ class Admin::NomenclatureChanges::StatusSwapController < Admin::NomenclatureChan
     when :swap
       set_taxonomy
       builder.build_secondary_output
+    when :notes
+      builder.build_output_notes
     when :legislation
       builder.build_legislation_reassignments
       skip_or_previous_step if @nomenclature_change.input.legislation_reassignments.empty?

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -133,13 +133,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
       @nomenclature_change.primary_output.note_en = primary_note[:en]
       @nomenclature_change.primary_output.note_es = primary_note[:es]
       @nomenclature_change.primary_output.note_fr = primary_note[:fr]
-    else
-      primary_note = private_output_note(
-        @nomenclature_change.primary_output,
-        @event,
-        :en
-      )
-      @nomenclature_change.primary_output.internal_note = primary_note
     end
   end
 

--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -22,7 +22,7 @@
 class NomenclatureChange::StatusSwap < NomenclatureChange
   include NomenclatureChange::StatusChangeHelpers
   build_steps(
-    :primary_output, :swap, :legislation, :summary
+    :primary_output, :swap, :notes, :legislation, :summary
   )
   validates :status, inclusion: {
     in: self.status_dict,

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -16,13 +16,6 @@ class NomenclatureChange::StatusSwap::Constructor
       @nomenclature_change.secondary_output.note_en = secondary_note[:en]
       @nomenclature_change.secondary_output.note_es = secondary_note[:es]
       @nomenclature_change.secondary_output.note_fr = secondary_note[:fr]
-    else
-      secondary_note = private_output_note(
-        @nomenclature_change.secondary_output,
-        @event,
-        :en
-      )
-      @nomenclature_change.secondary_output.internal_note = secondary_note
     end
   end
 

--- a/app/views/admin/nomenclature_changes/status_swap/notes.html.erb
+++ b/app/views/admin/nomenclature_changes/status_swap/notes.html.erb
@@ -1,12 +1,12 @@
 <h2>New status swap: nomenclature change notes</h2>
 <%= status_change_blurb %>
 <%= nomenclature_change_form do |f| %>
-<h3>Input</h3>
+<h3>Primary output</h3>
   <p>
     <i class="icon-info-sign"></i>
     Original taxon concept being swapped
   </p>
-  <%= f.fields_for :input do |ff| %>
+  <%= f.fields_for :primary_output do |ff| %>
     <div class="control-group">
       <label class="control-label">
         <%= ff.object.taxon_concept.try(:full_name) %>
@@ -19,12 +19,12 @@
     </div>
   <% end %>
 
-<h3>Output</h3>
+<h3>Secondary output</h3>
   <p>
     <i class="icon-info-sign"></i>
     Taxon resulting from the swap
   </p>
-  <%= f.fields_for :primary_output do |ff| %>
+  <%= f.fields_for :secondary_output do |ff| %>
     <div class="control-group">
       <label class="control-label">
         <%= ff.object.display_full_name %>

--- a/app/views/admin/nomenclature_changes/status_swap/notes.html.erb
+++ b/app/views/admin/nomenclature_changes/status_swap/notes.html.erb
@@ -1,0 +1,39 @@
+<h2>New status swap: nomenclature change notes</h2>
+<%= status_change_blurb %>
+<%= nomenclature_change_form do |f| %>
+<h3>Input</h3>
+  <p>
+    <i class="icon-info-sign"></i>
+    Original taxon concept being swapped
+  </p>
+  <%= f.fields_for :input do |ff| %>
+    <div class="control-group">
+      <label class="control-label">
+        <%= ff.object.taxon_concept.try(:full_name) %>
+      </label>
+      <div class="controls">
+        <%= render partial: 'admin/nomenclature_changes/build/nomenclature_notes',
+          locals: {ff: ff}
+        %>
+      </div>
+    </div>
+  <% end %>
+
+<h3>Output</h3>
+  <p>
+    <i class="icon-info-sign"></i>
+    Taxon resulting from the swap
+  </p>
+  <%= f.fields_for :primary_output do |ff| %>
+    <div class="control-group">
+      <label class="control-label">
+        <%= ff.object.display_full_name %>
+      </label>
+      <div class="controls">
+        <%= render partial: 'admin/nomenclature_changes/build/nomenclature_notes',
+          locals: {ff: ff}
+        %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/spec/models/nomenclature_change/status_swap/constructor_spec.rb
+++ b/spec/models/nomenclature_change/status_swap/constructor_spec.rb
@@ -46,7 +46,7 @@ describe NomenclatureChange::StatusSwap::Constructor do
     end
     let(:status_change){ a_to_s_with_swap }
     context "when previously no notes in place" do
-      specify{ expect(primary_output.internal_note).not_to be_blank }
+      specify{ expect(primary_output.internal_note).to be_blank }
       specify{ expect(secondary_output.note_en).not_to be_blank }
     end
     context "when previously notes in place" do

--- a/spec/models/nomenclature_change/status_to_synonym/constructor_spec.rb
+++ b/spec/models/nomenclature_change/status_to_synonym/constructor_spec.rb
@@ -32,7 +32,7 @@ describe NomenclatureChange::StatusToSynonym::Constructor do
 
     let(:status_change){ n_to_s_with_input_and_secondary_output }
     context "when previously no notes in place" do
-      specify{ expect(primary_output.internal_note).not_to be_blank }
+      specify{ expect(primary_output.internal_note).to be_blank }
       specify{ expect(secondary_output.note_en).to be_blank }
     end
     context "when previously notes in place" do


### PR DESCRIPTION
This [adds nomenclature notes to swap](https://www.pivotaltracker.com/story/show/116024057).
As partially discussed with the Species teams, it's seems better to leave the internal notes blank and specify the public nomenclature notes automatically just for new accepted names.