### PR TITLE
Trade summaries

### DIFF
--- a/app/models/nomenclature_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/constructor_helpers.rb
@@ -169,22 +169,6 @@ module NomenclatureChange::ConstructorHelpers
     end
   end
 
-  def _build_trade_reassignments(input, output)
-    input_class = input.reassignment_class
-    unless input.reassignments.where(
-      reassignable_type: 'Trade::Shipment'
-    ).first || input.taxon_concept.shipments.limit(1).count == 0
-      reassignment = input.reassignment_class.new(
-        reassignable_type: 'Trade::Shipment',
-        type: input_class.to_s
-      )
-      if input.is_a?(NomenclatureChange::Input)
-        _build_single_target(reassignment, output)
-      end
-      input.reassignments << reassignment
-    end
-  end
-
   def following_taxonomic_changes(event, lng)
     I18n.with_locale(lng) do
       I18n.translate(

--- a/app/models/nomenclature_change/delete_unreassigned_processor.rb
+++ b/app/models/nomenclature_change/delete_unreassigned_processor.rb
@@ -39,7 +39,6 @@ class NomenclatureChange::DeleteUnreassignedProcessor
     end
   end
 
-  def summary
-  end
+  def summary; []; end
 
 end

--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -18,9 +18,6 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
     if reassignment.kind_of?(NomenclatureChange::ParentReassignment)
       reassignable.parent_id = new_taxon_concept.id
       reassignable
-    elsif reassignable.kind_of?(Trade::Shipment)
-      reassignable.taxon_concept_id = new_taxon_concept.id
-      reassignable
     elsif reassignable.is_a?(TaxonRelationship) &&
       reassignable.taxon_relationship_type.name == TaxonRelationshipType::HAS_TRADE_NAME
 

--- a/app/models/nomenclature_change/reassignment_summarizer.rb
+++ b/app/models/nomenclature_change/reassignment_summarizer.rb
@@ -37,8 +37,7 @@ class NomenclatureChange::ReassignmentSummarizer
       output_generic_summary(
         @input.taxon_concept.taxon_concept_references,
         'TaxonConceptReference', 'references'
-      ),
-      output_shipments_summary
+      )
     ].compact
   end
 
@@ -107,17 +106,6 @@ class NomenclatureChange::ReassignmentSummarizer
         'nomenclature_change_reassignment_targets.nomenclature_change_output_id' => @output.id
       ).where(:reassignable_type => reassignable_type).count
     "#{(cnt == 1 || @input.is_a?(NomenclatureChange::Output) ? objects_cnt : 0)} (of #{objects_cnt}) #{title}"
-  end
-
-  def output_shipments_summary
-    shipments_cnt = @input.taxon_concept.shipments.count
-    return nil unless shipments_cnt > 0
-    default_output = if @output.nomenclature_change.respond_to?(:outputs)
-                      @output.nomenclature_change.outputs.first
-                    else
-                      @output
-                    end
-    "#{(default_output.id == @output.id || @input.is_a?(NomenclatureChange::Output) ? shipments_cnt : 0)} (of #{shipments_cnt} shipments)"
   end
 
 end

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -20,9 +20,6 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
       reassignment.kind_of?(NomenclatureChange::OutputParentReassignment)
       reassignable.parent_id = new_taxon_concept.id
       reassignable
-    elsif reassignable.kind_of?(Trade::Shipment)
-      reassignable.taxon_concept_id = new_taxon_concept.id
-      reassignable
     else
       # Each reassignable object implements find_duplicate,
       # which is called from here to make sure we're not adding a duplicate.

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -68,12 +68,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     end
   end
 
-  def build_trade_reassignments
-    input_output_for_reassignment do |input, output|
-      _build_trade_reassignments(input, output)
-    end
-  end
-
   def status_change_note(locale_key, output, lng)
     output_html = taxon_concept_html(
       output.display_full_name,

--- a/app/models/nomenclature_change/status_change_processor.rb
+++ b/app/models/nomenclature_change/status_change_processor.rb
@@ -26,7 +26,12 @@ class NomenclatureChange::StatusChangeProcessor
       ]
     else
       [summary_line]
-    end
+    end + [
+      "#{@trade_to_reassign.count} shipments will be reassigned
+      from #{@where_to_reassign_trade_from.taxon_concept.full_name}
+      to #{@where_to_reassign_trade_to.display_full_name}
+      (accepted taxon concept)"
+    ]
   end
 
   private

--- a/app/models/nomenclature_change/status_change_processor.rb
+++ b/app/models/nomenclature_change/status_change_processor.rb
@@ -15,10 +15,10 @@ class NomenclatureChange::StatusChangeProcessor
       [
         summary_line_long,
         @linked_inputs_or_outputs.map do |l|
-          if l.taxon_concept
+          if l.kind_of?(NomenclatureChange::Output)
+            l.display_full_name
+          elsif l.taxon_concept
             l.taxon_concept.full_name
-          elsif l.new_taxon_concept
-            l.new_taxon_concept.full_name
           else
             l.new_full_name
           end

--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -70,7 +70,6 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
       builder.build_legislation_reassignments
       builder.build_common_names_reassignments
       builder.build_references_reassignments
-      builder.build_trade_reassignments
     end
     true
   end

--- a/app/models/nomenclature_change/status_to_synonym.rb
+++ b/app/models/nomenclature_change/status_to_synonym.rb
@@ -90,7 +90,6 @@ class NomenclatureChange::StatusToSynonym < NomenclatureChange
       builder.build_legislation_reassignments
       builder.build_common_names_reassignments
       builder.build_references_reassignments
-      builder.build_trade_reassignments
     end
     true
   end

--- a/app/models/nomenclature_change/status_upgrade_processor.rb
+++ b/app/models/nomenclature_change/status_upgrade_processor.rb
@@ -1,5 +1,16 @@
 class NomenclatureChange::StatusUpgradeProcessor < NomenclatureChange::StatusChangeProcessor
 
+  def initialize(input_or_output, linked_inputs_or_outputs = [])
+    super(input_or_output, linked_inputs_or_outputs)
+    @where_to_reassign_trade_from = @input_or_output
+    @where_to_reassign_trade_to = @input_or_output
+    @trade_to_reassign = Trade::Shipment.where([
+      "taxon_concept_id = :taxon_concept_id OR
+      reported_taxon_concept_id = :taxon_concept_id",
+      taxon_concept_id: @where_to_reassign_trade_from.taxon_concept_id
+    ])
+  end
+
   def run
     Rails.logger.debug "#{@input_or_output.taxon_concept.full_name} status upgrade from #{@old_status}"
     @linked_names = @linked_inputs_or_outputs.map do |an|
@@ -12,6 +23,12 @@ class NomenclatureChange::StatusUpgradeProcessor < NomenclatureChange::StatusCha
       run_s_to_a
     elsif @old_status == 'T'
       run_t_to_a
+    end
+
+    default_accepted_name = @where_to_reassign_trade_to.taxon_concept
+    if default_accepted_name
+      Rails.logger.debug "Updating shipments to have taxon concept = #{default_accepted_name.full_name}"
+      @trade_to_reassign.update_all(taxon_concept_id: default_accepted_name.id)
     end
   end
 
@@ -35,11 +52,6 @@ class NomenclatureChange::StatusUpgradeProcessor < NomenclatureChange::StatusCha
       find_by_name(TaxonRelationshipType::HAS_SYNONYM)
     # set input_or_input_or_output as accepted name of synonyms
     create_relationships(@input_or_output.taxon_concept, rel_type)
-    Rails.logger.debug "Updating shipments where reported taxon concept = #{@input_or_output.taxon_concept.full_name} to have taxon concept = #{@input_or_output.taxon_concept.full_name}"
-    Trade::Shipment.update_all(
-      {taxon_concept_id: @input_or_output.taxon_concept_id},
-      {reported_taxon_concept_id: @input_or_output.taxon_concept_id}
-    )
   end
 
   def run_t_to_a
@@ -52,11 +64,6 @@ class NomenclatureChange::StatusUpgradeProcessor < NomenclatureChange::StatusCha
       find_by_name(TaxonRelationshipType::HAS_TRADE_NAME)
     # set input_or_input_or_output as accepted name of trade_names
     create_relationships(@input_or_output.taxon_concept, rel_type)
-    Rails.logger.debug "Updating shipments where reported taxon concept = #{@input_or_output.taxon_concept.full_name} to have taxon concept = #{@input_or_output.taxon_concept.full_name}"
-    Trade::Shipment.update_all(
-      {taxon_concept_id: @input_or_output.taxon_concept_id},
-      {reported_taxon_concept_id: @input_or_output.taxon_concept_id}
-    )
   end
 
 end


### PR DESCRIPTION
This changes the way trade reassignments are carried out, and has effect on all nomenclature changes rather than just T -> S as mentioned in this story:

https://www.pivotaltracker.com/story/show/115586627

The source of inconsistency was in the fact that some trade reassignments were carried out implicitly as part of status upgrades / downgrades, which was not reported in the summaries. Once that reporting was added, it turns out that for those nomenclature changes which had explicit trade reassignments it was double reporting, so it was possible to remove the old logic of processing and reporting trade reassignments completely.