### PR TITLE
Build auto-reassignments when notes step rather than legislation

### DIFF
--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -30,7 +30,7 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
   validate :required_primary_output_name_status, if: :primary_output_or_submitting?
   validate :required_secondary_output_name_status, if: :secondary_output_or_submitting?
   before_save :build_input_for_auto_reassignments, if: :secondary_output?
-  before_save :build_auto_reassignments, if: :legislation?
+  before_save :build_auto_reassignments, if: :notes?
 
   def required_secondary_output
     if secondary_output.nil?

--- a/app/models/nomenclature_change/status_to_synonym.rb
+++ b/app/models/nomenclature_change/status_to_synonym.rb
@@ -31,7 +31,7 @@ class NomenclatureChange::StatusToSynonym < NomenclatureChange
   validate :required_primary_output_name_status, if: :primary_output_or_submitting?
   validate :required_secondary_output, if: :relay_or_submitting?
   before_save :build_input_for_relay, if: :relay?
-  before_save :build_auto_reassignments, if: :legislation?
+  after_save :build_auto_reassignments, if: :relay?
   before_validation :ensure_new_name_status, if: :primary_output?
 
   def ensure_new_name_status


### PR DESCRIPTION
This seems to be the only change necessary to fix [this story](https://www.pivotaltracker.com/story/show/116201141).
Since the legislation step is not always happening, I moved the build_auto_reassignment procedure to the notes step, which is always happening in the wizard.