### PR TITLE
Fix additional split output behaviour

### DIFF
--- a/app/assets/stylesheets/admin/nomenclature_changes.scss
+++ b/app/assets/stylesheets/admin/nomenclature_changes.scss
@@ -13,3 +13,11 @@ form {
 .outputs_selection span {
   margin-right: 10px
 }
+
+.more-split-outputs {
+  .existing-taxon-input {
+    .control-label, .input-taxon {
+      display:none;
+    }
+  }
+}

--- a/app/views/admin/nomenclature_changes/split/outputs.html.erb
+++ b/app/views/admin/nomenclature_changes/split/outputs.html.erb
@@ -9,7 +9,7 @@
 
     <li>
     <%= outputs_selection ff %>
-    <div class="control-group">
+    <div class="control-group existing-taxon-input">
       <label class="control-label">Existing taxon concept:</label>
       <div class="controls">
         <%= ff.text_field :taxon_concept_id, {
@@ -43,6 +43,7 @@
     </div>
     </li>
   <% end %>
-  <p><%= f.link_to_add 'Add another output', :outputs %></p>
+  <div class='more-split-outputs'></div>
+  <p><%= f.link_to_add 'Add another output', :outputs, data: {target: '.more-split-outputs'} %></p>
   </ol>
 <% end %>


### PR DESCRIPTION
This fixes the bug reported in [this story](https://www.pivotaltracker.com/story/show/105461840)
To apply de default behaviour to new split outputs fields I've just added a new div where to add those, and then hide the existing taxon input since the `new taxon` option is selected by default to begin with