### PR TITLE
Fix higher taxa in admin downloads

### DIFF
--- a/app/models/taxon_concept_data.rb
+++ b/app/models/taxon_concept_data.rb
@@ -1,7 +1,7 @@
 class TaxonConceptData
 
   def initialize(taxon_concept)
-    @taxon_concept = taxon_concept
+    @taxon_concept = taxon_concept.reload
     @rank_name = taxon_concept.rank && taxon_concept.rank.name
     @higher_taxa = higher_taxa
   end
@@ -30,7 +30,7 @@ class TaxonConceptData
     return nil unless @rank_name
     {
       "#{@rank_name.downcase}_id" => @taxon_concept.id,
-      "#{@rank_name.downcase}_name" => @taxon_concept.full_name
+      "#{@rank_name.downcase}_name" => @taxon_concept.taxon_name.try(:scientific_name)
     }
   end
 

--- a/db/migrate/20160405104833_fix_synonyms_and_trade_names_view_to_exclude_inter_taxonomic_relationships.rb
+++ b/db/migrate/20160405104833_fix_synonyms_and_trade_names_view_to_exclude_inter_taxonomic_relationships.rb
@@ -1,0 +1,11 @@
+class FixSynonymsAndTradeNamesViewToExcludeInterTaxonomicRelationships < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS synonyms_and_trade_names_view"
+    execute "CREATE VIEW synonyms_and_trade_names_view AS #{view_sql('20160405104833', 'synonyms_and_trade_names_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS synonyms_and_trade_names_view"
+    execute "CREATE VIEW synonyms_and_trade_names_view AS #{view_sql('20150310140649', 'synonyms_and_trade_names_view')}"
+  end
+end

--- a/db/views/synonyms_and_trade_names_view/20160405104833.sql
+++ b/db/views/synonyms_and_trade_names_view/20160405104833.sql
@@ -1,0 +1,60 @@
+SELECT
+  st.name_status,
+  st.id,
+  st.legacy_id,
+  st.legacy_trade_code,
+  st.data->'rank_name' AS rank_name,
+  st.full_name,
+  st.author_year,
+  a.full_name AS accepted_full_name,
+  a.author_year AS accepted_author_year,
+  a.id AS accepted_id,
+  a.data->'rank_name' AS accepted_rank_name,
+  a.name_status AS accepted_name_status,
+  a.data->'kingdom_name' AS accepted_kingdom_name,
+  a.data->'phylum_name' AS accepted_phylum_name,
+  a.data->'class_name' AS accepted_class_name,
+  a.data->'order_name' AS accepted_order_name,
+  a.data->'family_name' AS accepted_family_name,
+  a.data->'genus_name' AS accepted_genus_name,
+  a.data->'species_name' AS accepted_species_name,
+  taxonomies.id AS taxonomy_id,
+  taxonomies.name AS taxonomy_name,
+  ARRAY_TO_STRING(
+    ARRAY[
+      general_note.note,
+      nomenclature_note.note,
+      distribution_note.note
+    ],
+    E'\n'
+  ) AS internal_notes,
+  to_char(st.created_at, 'DD/MM/YYYY HH24:MI') AS created_at,
+  uc.name AS created_by,
+  to_char(st.updated_at, 'DD/MM/YYYY HH24:MI') AS updated_at,
+  uu.name AS updated_by,
+  to_char(st.dependents_updated_at, 'DD/MM/YYYY HH24:MI') AS dependents_updated_at,
+  uud.name AS dependents_updated_by
+FROM taxon_concepts st
+JOIN taxonomies ON taxonomies.id = st.taxonomy_id
+LEFT JOIN taxon_relationships
+ON taxon_relationships.other_taxon_concept_id = st.id
+LEFT JOIN taxon_relationship_types trt
+ON trt.id = taxon_relationships.taxon_relationship_type_id
+LEFT JOIN taxon_concepts a
+ON taxon_relationships.taxon_concept_id = a.id
+LEFT JOIN  comments general_note
+  ON general_note.commentable_id = st.id
+  AND general_note.commentable_type = 'TaxonConcept'
+  AND general_note.comment_type = 'General'
+LEFT JOIN  comments nomenclature_note
+  ON nomenclature_note.commentable_id = st.id
+  AND nomenclature_note.commentable_type = 'TaxonConcept'
+  AND nomenclature_note.comment_type = 'Nomenclature'
+LEFT JOIN  comments distribution_note
+  ON distribution_note.commentable_id = st.id
+  AND distribution_note.commentable_type = 'TaxonConcept'
+  AND distribution_note.comment_type = 'Distribution'
+LEFT JOIN users uc ON st.created_by_id = uc.id
+LEFT JOIN users uu ON st.updated_by_id = uu.id
+LEFT JOIN users uud ON st.dependents_updated_by_id = uud.id
+WHERE st.name_status IN ('S', 'T') AND trt.name IN ('HAS_SYNONYM', 'HAS_TRADE_NAME');

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -109,34 +109,44 @@ describe NomenclatureChange::Lump::Processor do
         output_species_children.where('id != ?', output_species_child.id).first
       }
       before(:each){ processor.run }
-      specify do
+      specify "input species has public nomenclature note set" do
         expect(input_species1.reload.nomenclature_note_en).to eq(' input EN note')
+      end
+      specify "child of input species inherits public nomenclature note" do
         expect(
           input_species1_child.reload.nomenclature_note_en
-        ).to eq(input_species1.nomenclature_note_en)
+        ).to eq(input_species1.reload.nomenclature_note_en)
       end
-      specify do
+      specify "input species has internal nomenclature note set" do
         expect(input_species1.nomenclature_comment.note).to eq(' input internal note')
+      end
+      specify "child of input species inherits internal nomenclature note" do
         expect(
           input_species1_child.nomenclature_comment.note
         ).to eq(input_species1.nomenclature_comment.note)
       end
-      specify do
+      specify "output species has public nomenclature note set" do
         expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
-        expect(
-          output_species_child.reload.nomenclature_note_en
-        ).to eq(output_species.nomenclature_note_en)
       end
-      specify do
-        expect(output_species.nomenclature_comment.note).to eq(' output internal note')
+      specify "child of output species inherits public nomenclature note" do
         expect(
-          output_species_child.nomenclature_comment.note
+          output_species1_child.reload.nomenclature_note_en
+        ).to eq(output_species.reload.nomenclature_note_en)
+      end
+      specify "output species has internal nomenclature note set" do
+        expect(output_species.nomenclature_comment.note).to eq(' output internal note')
+      end
+      specify "output species child inherits internal nomenclature note" do
+        expect(
+          output_species1_child.nomenclature_comment.note
         ).to eq(output_species.nomenclature_comment.note)
       end
-      specify do
-        expect(output_species_child.listing_changes.count).to eq(1)
+      specify "output species child has listing changes from input species child transferred" do
+        expect(output_species1_child.listing_changes.count).to eq(1)
+      end
+      specify "output species child has legislation nomenclature note set" do
         expect(
-          output_species_child.listing_changes.first.nomenclature_note_en
+          output_species1_child.listing_changes.first.nomenclature_note_en
         ).to include(output_species.reload.nomenclature_note_en)
       end
       let(:output_species_genus_name){ output_species.parent.full_name }

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -118,34 +118,46 @@ describe NomenclatureChange::Split::Processor do
         )
       }
       let(:output_species){ output.taxon_concept.reload }
-      let(:output_species_child){ output.taxon_concept.children.first.reload }
+      let(:output_species_child) do
+        output.taxon_concept.children.where(['id != ?', output_species1_child.id]).first
+      end
       before(:each){ processor.run }
-      specify do
+      specify "input species has public nomenclature note set" do
         expect(input_species.reload.nomenclature_note_en).to eq(' input EN note')
+      end
+      specify "child of input species inherits public nomenclature note" do
         expect(
           input_species_child.reload.nomenclature_note_en
-        ).to eq(input_species.nomenclature_note_en)
+        ).to eq(input_species.reload.nomenclature_note_en)
       end
-      specify do
+      specify "input species has internal nomenclature note set" do
         expect(input_species.nomenclature_comment.note).to eq(' input internal note')
+      end
+      specify "child of input species inherits internal nomenclature note" do
         expect(
           input_species_child.nomenclature_comment.note
         ).to eq(input_species.nomenclature_comment.note)
       end
-      specify do
+      specify "output species has public nomenclature note set" do
         expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
+      end
+      specify "child of output species inherits public nomenclature note" do
         expect(
           output_species_child.reload.nomenclature_note_en
         ).to eq(output_species.nomenclature_note_en)
       end
-      specify do
+      specify "output species has internal nomenclature note set" do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
+      end
+      specify "output species child inherits internal nomenclature note" do
         expect(
           output_species_child.nomenclature_comment.note
         ).to eq(output_species.nomenclature_comment.note)
       end
-      specify do
+      specify "output species child has listing changes from input species child transferred" do
         expect(output_species_child.listing_changes.count).to eq(1)
+      end
+      specify "output species child has legislation nomenclature note set" do
         expect(
           output_species_child.listing_changes.first.nomenclature_note_en
         ).to include(output_species.nomenclature_note_en)

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -82,6 +82,9 @@ describe NomenclatureChange::Split::Processor do
       let!(:input_species_child_listing){
         create_cites_I_addition(taxon_concept: input_species_child)
       }
+      let!(:output_species1_child){
+        create_cites_eu_subspecies(parent: output_species1)
+      }
       let(:split){
         create(:nomenclature_change_split,
           input_attributes: {
@@ -146,6 +149,19 @@ describe NomenclatureChange::Split::Processor do
         expect(
           output_species_child.listing_changes.first.nomenclature_note_en
         ).to include(output_species.nomenclature_note_en)
+      end
+      let(:output_species1_genus_name){ output_species1.parent.full_name }
+      specify "original output species child retains higher taxa intact" do
+        expect(output_species_child.data['genus_name']).to eq(output_species1_genus_name)
+      end
+      specify "new output species child has higher taxa set correctly" do
+        expect(output_species1_child.data['genus_name']).to eq(output_species1_genus_name)
+      end
+      specify "original input species child retains higher taxa intact" do
+        expect(input_species_child.data['genus_name']).to eq(input_species.parent.full_name)
+      end
+      specify "original input species child is a synonym" do
+        expect(input_species_child.reload.name_status).to eq('S')
       end
     end
   end


### PR DESCRIPTION
This fixes issues with missing higher taxa names in the admin species names downloads:

https://www.pivotaltracker.com/story/show/115610827

The problem of higher taxa gone missing altogether was addressed by reloading the taxon concept record in the after_save callback, as stale values caused issues there. The callback now uses the scientific_name rather than full_name to populate ancestors fields (that caused the full species name to appear in the 'species' column). There are some additional tests around those concerns.

Also, while checking those test scenarios in the 'synonyms and trade names' download I noticed it erroneously considers all relationships rather than just HAS_SYNONYM and HAS_TRADE_NAME, which caused records representing e.g. equality relationship between taxa from different taxonomies to show up as synonym relationships in this file.