### PR TITLE
Add uniqueness index on taxon_concept_references

### DIFF
--- a/db/migrate/20160406101826_change_unique_index_on_taxon_concept_references.rb
+++ b/db/migrate/20160406101826_change_unique_index_on_taxon_concept_references.rb
@@ -1,0 +1,21 @@
+class ChangeUniqueIndexOnTaxonConceptReferences < ActiveRecord::Migration
+  def up
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded"
+
+    add_index "taxon_concept_references", ["taxon_concept_id", "reference_id", "is_standard", "is_cascaded"], name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded", unique: true
+
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id"
+  end
+
+  def down
+    remove_index "taxon_concept_references",
+      name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded"
+
+    add_index "taxon_concept_references", ["taxon_concept_id", "reference_id", "is_standard", "is_cascaded"], name: "index_taxon_concept_references_on_tc_id_is_std_is_cascaded"
+
+    add_index "taxon_concept_references", ["taxon_concept_id", "reference_id"],
+      name: "index_taxon_concept_references_on_taxon_concept_id_and_ref_id"
+  end
+end


### PR DESCRIPTION
This is to fix an [uniqueness exception about references thrown after lumping](https://www.pivotaltracker.com/story/show/116759675).
The existing uniqueness index was just about the taxon_concept_id and reference_id, while we need more attributes to be included, such as is_standard and is_cascaded.
An index like that was already existing as well, but with no unique option provided; so I changed that and remove the one with just taxon_concept_id and reference_id