### PR TITLE
Do not transfer or copy distribution tag if target or original does not have any

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -18,6 +18,8 @@ class Distribution < ActiveRecord::Base
     :references_attributes, :internal_notes, :created_by_id, :updated_by_id
   acts_as_taggable
 
+  normalise_blank_values
+
   belongs_to :geo_entity
   belongs_to :taxon_concept
   has_many :distribution_references, :dependent => :destroy

--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -66,11 +66,23 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
       }).first || copied_object.distribution_references.build(distr_ref.comparison_attributes)
     end
     # taggings
+    copy_distribution_taggings(reassignable, copied_object)
+    end
+  end
+
+  def copy_distribution_taggings(reassignable, copied_object)
+    if reassignable.taggings.count == 0
+      copied_object.taggings.destroy_all if copied_object.taggings.count > 0
+      return
+    elsif copied_object.taggings.count == 0
+      return
+    end
+
     reassignable.taggings.each do |tagging|
       !copied_object.new_record? && tagging.duplicates({
         taggable_id: copied_object.id
       }).first || copied_object.taggings.build(tagging.comparison_attributes)
-    end
+
   end
 
   def build_listing_change_associations(reassignable, copied_object)

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -81,15 +81,17 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
   end
 
   def transfer_distribution_taggings(reassigned_object, reassignable)
-    return if reassignable.taggings.count == 0
-    taggings_to_transfer = reassignable.taggings
-    if reassigned_object.taggings.count > 0
-      taggings_to_transfer = taggings_to_transfer.
-      where(
-        'tag_id NOT IN (?)',
-        reassigned_object.taggings.select(:tag_id).map(&:tag_id)
-      )
+    if reassignable.taggings.count == 0
+      reassigned_object.taggings.destroy_all if reassigned_object.taggings.count > 0
+      return
+    elsif reassigned_object.taggings.count == 0
+      return
     end
+    taggings_to_transfer = reassignable.taggings.
+    where(
+      'tag_id NOT IN (?)',
+      reassigned_object.taggings.select(:tag_id).map(&:tag_id)
+    )
     taggings_to_transfer.update_all(taggable_id: reassigned_object.id)
   end
 

--- a/config/initializers/normalise_blank_values.rb
+++ b/config/initializers/normalise_blank_values.rb
@@ -1,0 +1,21 @@
+module NormaliseBlankValues extend ActiveSupport::Concern
+
+  def self.included(base)
+    base.extend ClassMethods
+  end
+
+  def normalise_blank_values
+    attributes.each do |column, value|
+      self[column].present? || self[column] = nil
+    end
+  end
+
+  module ClassMethods
+    def normalise_blank_values
+      before_save :normalise_blank_values
+    end
+  end
+
+end
+
+ActiveRecord::Base.send(:include, NormaliseBlankValues)

--- a/db/migrate/20160406150331_set_distributions_empty_internal_notes_to_nil.rb
+++ b/db/migrate/20160406150331_set_distributions_empty_internal_notes_to_nil.rb
@@ -1,0 +1,11 @@
+class SetDistributionsEmptyInternalNotesToNil < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        UPDATE distributions
+        SET internal_notes=NULL
+        WHERE internal_notes=''
+      SQL
+    )
+  end
+end

--- a/spec/models/nomenclature_change/reassignment_copy_processor_spec.rb
+++ b/spec/models/nomenclature_change/reassignment_copy_processor_spec.rb
@@ -19,7 +19,7 @@ describe NomenclatureChange::ReassignmentCopyProcessor do
     end
     context "when distribution" do
       include_context 'distribution_reassignments_processor_examples'
-      specify{ expect(input_species.distributions.count).to eq(2) }
+      specify{ expect(input_species.distributions.count).to eq(4) }
     end
     context "when legislation" do
       include_context 'legislation_reassignments_processor_examples'

--- a/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
@@ -18,11 +18,37 @@ shared_context 'distribution_reassignments_processor_examples' do
       iso_code2: 'PL'
     )
   }
+  let(:italy){
+    create(
+      :geo_entity,
+      geo_entity_type_id: country_geo_entity_type.id,
+      iso_code2: 'IT'
+    )
+  }
+  let(:united_kingdom){
+    create(
+      :geo_entity,
+      geo_entity_type_id: country_geo_entity_type.id,
+      iso_code2: 'UK'
+    )
+  }
   before(:each) do
     original_d = create(
       :distribution,
       taxon_concept: output_species1,
       geo_entity: poland
+    )
+    original_d2 = create(
+      :distribution,
+      taxon_concept: output_species1,
+      geo_entity: italy,
+      tag_list: ['reintroduced']
+    )
+    original_d3 = create(
+      :distribution,
+      taxon_concept: output_species1,
+      geo_entity: united_kingdom,
+      tag_list: ['introduced']
     )
     original_d.distribution_references.create(reference_id: create(:reference).id)
     create(:preset_tag, model: 'Distribution', name: 'extinct')
@@ -32,12 +58,25 @@ shared_context 'distribution_reassignments_processor_examples' do
       geo_entity: poland,
       tag_list: ['extinct']
     )
+    d2 = create(
+      :distribution,
+      taxon_concept: input_species,
+      geo_entity: italy,
+      tag_list: ['extinct']
+    )
+    d3 = create(
+      :distribution,
+      taxon_concept: input_species,
+      geo_entity: united_kingdom
+    )
     d.distribution_references.create(reference_id: create(:reference).id)
     create(:distribution, taxon_concept: input_species)
     processor.run
   end
-  specify{ expect(output_species1.distributions.count).to eq(2) }
+  specify{ expect(output_species1.distributions.count).to eq(4) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id)).not_to be_nil }
-  specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).tag_list).to eq(['extinct']) }
+  specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).tag_list).to eq([]) }
+  specify{ expect(output_species1.distributions.find_by_geo_entity_id(italy.id).tag_list).to eq(['extinct', 'reintroduced']) }
+  specify{ expect(output_species1.distributions.find_by_geo_entity_id(united_kingdom.id).tag_list).to eq([]) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).distribution_references.count).to eq(2) }
 end


### PR DESCRIPTION
As described by [this story](https://www.pivotaltracker.com/story/show/116890429), if the target distribution or the original one contains no tags, then this takes priority over any tag.
Fixed also a bug causing duplicated distribution because of inconsistency between the value of internal notes. This value has been normalised to nil with a migration and I've also created a module that will automatically prevent empty string to be saved, in favour of nil. This module uses `before_save` and can be easily included in any model if needed