### PR TITLE
Fix taxon concept edit modals

### DIFF
--- a/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
+++ b/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
@@ -18,12 +18,6 @@ $(document).ready ->
 
 class AdminEditor
   init: () ->
-    $('.modal .modal-footer .save-button').click () ->
-      $(@).closest('.modal').find('form').submit()
-    $('.modal').on 'hidden', () =>
-      $('.modal.hide.fade').each((idx, element) =>
-        @clearModalForm($(element))
-      )
     @initModals()
     @initSearchTypeahead()
     $("[rel='tooltip']").tooltip()
@@ -39,6 +33,12 @@ class AdminEditor
       autoclose: true
 
   initModals: () ->
+    $('.modal .modal-footer .save-button').click () ->
+      $(@).closest('.modal').find('form').submit()
+    $('.modal').on 'hidden', () =>
+      $('.modal.hide.fade').each((idx, element) =>
+        @clearModalForm($(element))
+      )
     $(@).find('.alert').remove()
 
   alertSuccess: (txt) ->
@@ -115,7 +115,6 @@ class AdminEditor
     $('.taxon-concept').select2(window.defaultTaxonSelect2Options)
     $('.taxon-concept-multiple').select2($.extend({}, window.defaultTaxonSelect2Options,window.multiTaxonSelect2Options))
     $('.taxon-concept-multiple-max-2').select2($.extend({}, window.defaultTaxonSelect2Options, window.multiTaxonSelect2Options, window.max2Select2Options))
-
 
 class AdminInPlaceEditor extends AdminEditor
   init: () ->

--- a/app/controllers/admin/names_controller.rb
+++ b/app/controllers/admin/names_controller.rb
@@ -18,4 +18,5 @@ class Admin::NamesController < Admin::SimpleCrudController
     @hybrid_relationships = @taxon_concept.hybrid_relationships.
       includes(:other_taxon_concept).order('taxon_concepts.full_name')
   end
+
 end

--- a/app/controllers/admin/simple_crud_controller.rb
+++ b/app/controllers/admin/simple_crud_controller.rb
@@ -40,12 +40,20 @@ class Admin::SimpleCrudController < Admin::AdminController
     def load_associations; end
 
     def load_search
-      @taxonomies ||= Taxonomy.order(:name)
+      load_taxonomies
       @taxon_concept ||= TaxonConcept.find(params[:taxon_concept_id])
       @search_params = SearchParams.new(
           { :taxonomy => { :id => @taxon_concept.taxonomy_id },
             :scientific_name => @taxon_concept.full_name,
             :name_status => @taxon_concept.name_status
         })
+    end
+
+    def load_taxonomies
+      @taxonomies ||= Taxonomy.order(:name)
+    end
+
+    def load_ranks
+      @ranks = Rank.order(:taxonomic_position)
     end
 end

--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -111,7 +111,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
         params[:taxon_concept].has_key?(ids_list_key) &&
         (stringified_ids_list = params[:taxon_concept][ids_list_key]) &&
         stringified_ids_list.is_a?(String)
-        params[:taxon_concept][ids_list_key] = stringified_ids_list.split(',')
+        params[:taxon_concept][ids_list_key] = stringified_ids_list.split(',').map(&:to_i)
       end
     end
 

--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -8,14 +8,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
   before_filter :split_stringified_ids_lists, only: [:create, :update]
 
   def index
-    @taxon_concept = TaxonConcept.new(name_status: 'A')
-    @taxon_concept.build_taxon_name
-    @synonym = TaxonConcept.new(name_status: 'S')
-    @synonym.build_taxon_name
-    @hybrid = TaxonConcept.new(name_status: 'H')
-    @hybrid.build_taxon_name
-    @n_name = TaxonConcept.new(name_status: 'N')
-    @n_name.build_taxon_name
+    @taxon_concept = TaxonConcept.new
     @taxon_concepts = TaxonConceptMatcher.new(@search_params).taxon_concepts.
       includes([:rank, :taxonomy, :taxon_name, :parent]).
       order("taxon_concepts.taxonomic_position").page(params[:page])
@@ -124,16 +117,12 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
 
     def render_new_by_name_status
       if @taxon_concept.is_synonym?
-        @synonym = @taxon_concept
         render('new_synonym')
       elsif @taxon_concept.is_hybrid?
-        @hybrid = @taxon_concept
         render('new_hybrid')
       elsif @taxon_concept.is_trade_name?
-        @trade_name = @taxon_concept
         render('new_trade_name')
       elsif @taxon_concept.name_status == 'N'
-        @n_name = @taxon_concept
         render('new_n_name')
       else
         render('new')

--- a/app/controllers/admin/taxon_concepts_controller.rb
+++ b/app/controllers/admin/taxon_concepts_controller.rb
@@ -30,7 +30,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
     @ranks = Rank.order(:taxonomic_position)
     edit! do |format|
       load_search
-      format.js { render 'new' }
+      format.js { render_new_by_name_status }
     end
   end
 
@@ -39,20 +39,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
       @taxonomies = Taxonomy.order(:name)
       @ranks = Rank.order(:taxonomic_position)
       success.js { render('create') }
-      failure.js {
-        if @taxon_concept.is_synonym?
-          @synonym = @taxon_concept
-          render('new_synonym')
-        elsif @taxon_concept.is_hybrid?
-          @hybrid = @taxon_concept
-          render('new_hybrid')
-        elsif @taxon_concept.name_status == 'N'
-          @n_name = @taxon_concept
-          render('new_n_name')
-        else
-          render('new')
-        end
-      }
+      failure.js { render_new_by_name_status }
     end
   end
 
@@ -68,7 +55,7 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
         @taxonomies = Taxonomy.order(:name)
         @ranks = Rank.order(:taxonomic_position)
         load_tags
-        render 'new'
+        render_new_by_name_status
       }
       success.html {
         UpdateTaxonomyWorker.perform_async if rebuild_taxonomy
@@ -132,4 +119,23 @@ class Admin::TaxonConceptsController < Admin::StandardAuthorizationController
         params[:taxon_concept][ids_list_key] = stringified_ids_list.split(',')
       end
     end
+
+    def render_new_by_name_status
+      if @taxon_concept.is_synonym?
+        @synonym = @taxon_concept
+        render('new_synonym')
+      elsif @taxon_concept.is_hybrid?
+        @hybrid = @taxon_concept
+        render('new_hybrid')
+      elsif @taxon_concept.is_trade_name?
+        @trade_name = @taxon_concept
+        render('new_trade_name')
+      elsif @taxon_concept.name_status == 'N'
+        @n_name = @taxon_concept
+        render('new_n_name')
+      else
+        render('new')
+      end
+    end
+
 end

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -75,10 +75,31 @@ module TaxonConceptHelper
     ){ nested ? '' : render('synonym_form') }
   end
 
-  def admin_new_trade_name_modal
+  def admin_new_trade_name_modal(nested = false)
     admin_new_modal(
       :resource => 'taxon_concept_trade_name',
       :title => 'Add new Trade name'
+    ){ nested ? '' : render('trade_name_form') }
+  end
+
+  def admin_new_hybrid_modal(nested = false)
+    admin_new_modal(
+      :resource => 'taxon_concept_hybrid',
+      :title => 'Add new Hybrid'
+    ){ nested ? '' : render('hybrid_form') }
+  end
+
+  def admin_new_n_name_modal
+    admin_new_modal(
+      resource: 'taxon_concept_n_name',
+      title: 'Add new N name'
+    ){ render('n_name_form') }
+  end
+
+  def admin_new_taxon_concept_modal options= {}
+    admin_new_modal(
+      :resource => 'taxon_concept',
+      :title => options[:title] || nil
     ){ '' }
   end
 
@@ -119,20 +140,6 @@ module TaxonConceptHelper
     ){ nested ? '' : render('admin/distributions/form') }
   end
 
-  def admin_new_hybrid_modal(nested = false)
-    admin_new_modal(
-      :resource => 'taxon_concept_hybrid',
-      :title => 'Add new Hybrid'
-    ){ nested ? '' : render('hybrid_form') }
-  end
-
-  def admin_new_n_name_modal
-    admin_new_modal(
-      resource: 'taxon_concept_n_name',
-      title: 'Add new N name'
-    ){ render('n_name_form') }
-  end
-
   def admin_add_new_reference_button
     admin_add_new_button(
       :resource => 'taxon_concept_reference',
@@ -149,13 +156,6 @@ module TaxonConceptHelper
       :resource => 'taxon_concept_reference',
       :save_and_reopen => true
     )
-  end
-
-  def admin_new_taxon_concept_modal options= {}
-    admin_new_modal(
-      :resource => 'taxon_concept',
-      :title => options[:title] || nil
-    ){ '' }
   end
 
   def admin_new_cites_suspension_modal

--- a/app/helpers/taxon_concept_helper.rb
+++ b/app/helpers/taxon_concept_helper.rb
@@ -68,39 +68,44 @@ module TaxonConceptHelper
     )
   end
 
-  def admin_new_synonym_modal(nested = false)
+  def admin_new_synonym_modal(options = {})
+    nested = options[:nested] || false
     admin_new_modal(
       resource: 'taxon_concept_synonym',
-      title: 'Add new Synonym'
+      title: options[:title] || nil
     ){ nested ? '' : render('synonym_form') }
   end
 
-  def admin_new_trade_name_modal(nested = false)
+  def admin_new_trade_name_modal(options = {})
+    nested = options[:nested] || false
     admin_new_modal(
-      :resource => 'taxon_concept_trade_name',
-      :title => 'Add new Trade name'
+      resource: 'taxon_concept_trade_name',
+      title: options[:title] || nil
     ){ nested ? '' : render('trade_name_form') }
   end
 
-  def admin_new_hybrid_modal(nested = false)
+  def admin_new_hybrid_modal(options = {})
+    nested = options[:nested] || false
     admin_new_modal(
-      :resource => 'taxon_concept_hybrid',
-      :title => 'Add new Hybrid'
+      resource: 'taxon_concept_hybrid',
+      title: options[:title] || nil
     ){ nested ? '' : render('hybrid_form') }
   end
 
-  def admin_new_n_name_modal
+  def admin_new_n_name_modal(options = {})
+    nested = options[:nested] || false
     admin_new_modal(
       resource: 'taxon_concept_n_name',
-      title: 'Add new N name'
-    ){ render('n_name_form') }
+      title: options[:title] || nil
+    ){ nested ? '' : render('n_name_form') }
   end
 
-  def admin_new_taxon_concept_modal options= {}
+  def admin_new_taxon_concept_modal(options = {})
+    nested = options[:nested] || false
     admin_new_modal(
-      :resource => 'taxon_concept',
-      :title => options[:title] || nil
-    ){ '' }
+      resource: 'taxon_concept',
+      title: options[:title] || nil
+    ){ nested ? '' : render('form') }
   end
 
   def admin_add_new_distribution_button

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -341,7 +341,7 @@ class TaxonConcept < ActiveRecord::Base
         ' var. '
       else
         ' '
-      end + self.taxon_name.try(:scientific_name).try(:downcase)
+      end + (self.taxon_name.try(:scientific_name).try(:downcase) || '')
     else
       self.full_name
     end

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -389,7 +389,7 @@ class TaxonConcept < ActiveRecord::Base
       taxon_concept.taxon_relationships.
         where('other_taxon_concept_id = ? AND
               taxon_relationship_type_id = ?', id, rel_type.id).
-        destroy
+        destroy_all
     end
 
     new_taxa.each do |taxon_concept|

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -179,7 +179,7 @@ class TaxonConcept < ActiveRecord::Base
       tc.name_status == 'A' || tc.name_status.blank?
     )
   }
-  validate :parent_is_an_accepted_name, :if => lambda { |tc| tc.parent }
+  validate :parent_is_an_accepted_name, :if => lambda { |tc| tc.parent && tc.name_status == 'A' }
   validate :maximum_2_hybrid_parents,
     :if => lambda { |tc| tc.name_status == 'H' }
   validates :taxon_name_id, :presence => true,

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -508,20 +508,6 @@ class TaxonConcept < ActiveRecord::Base
     true
   end
 
-  def self.find_by_full_name_and_name_status(full_name, name_status, taxonomy_id=nil)
-    full_name = TaxonConcept.sanitize_full_name(full_name)
-    res = TaxonConcept.
-      where([
-        "UPPER(full_name) = UPPER(BTRIM(?)) AND name_status = ?",
-        full_name,
-        name_status
-      ])
-    if taxonomy_id
-      res = res.where(:taxonomy_id => taxonomy_id)
-    end
-    res.first
-  end
-
   def ensure_taxonomic_position
     if new_record? && fixed_order_required? && taxonomic_position.blank?
       prev_taxonomic_position =

--- a/app/views/admin/names/index.html.erb
+++ b/app/views/admin/names/index.html.erb
@@ -16,7 +16,7 @@
 
     <h3>Trade names</h3>
     <%= admin_add_new_trade_name_button %>
-    <%= admin_new_trade_name_modal %>
+    <%= admin_new_trade_name_modal(true) %>
     <hr>
     <div id="trade_names-list">
       <% if @taxon_concept.has_trade_names? %>

--- a/app/views/admin/names/index.html.erb
+++ b/app/views/admin/names/index.html.erb
@@ -3,7 +3,7 @@
   <div class="span4">
     <h3>Synonyms</h3>
     <%= admin_add_new_synonym_button %>
-    <%= admin_new_synonym_modal(true) %>
+    <%= admin_new_synonym_modal(nested: true) %>
     <hr>
     <div id="synonyms-list">
       <% if @taxon_concept.has_synonyms? %>
@@ -16,7 +16,7 @@
 
     <h3>Trade names</h3>
     <%= admin_add_new_trade_name_button %>
-    <%= admin_new_trade_name_modal(true) %>
+    <%= admin_new_trade_name_modal(nested: true) %>
     <hr>
     <div id="trade_names-list">
       <% if @taxon_concept.has_trade_names? %>
@@ -43,7 +43,7 @@
   <div class="span4">
     <h3>Hybrids</h3>
     <%= admin_add_new_hybrid_button %>
-    <%= admin_new_hybrid_modal(true) %>
+    <%= admin_new_hybrid_modal(nested: true) %>
     <hr>
     <div id="hybrids-list">
       <% if @taxon_concept.has_hybrids? %>

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -81,7 +81,18 @@
   <%= ancestors_path(@taxon_concept) %>
 </div>
 
-<%= admin_new_taxon_concept_modal(:title => 'Edit Taxon Concept') %>
+<% case @taxon_concept.name_status %>
+<% when 'A' %>
+  <%= admin_new_taxon_concept_modal(:title => 'Edit Taxon Concept') %>
+<% when 'N' %>
+  <%= admin_new_n_name_modal(:title => 'Edit Taxon Concept') %>
+<% when 'S' %>
+  <%= admin_new_synonym_modal(:title => 'Edit Taxon Concept') %>
+<% when 'T' %>
+  <%= admin_new_trade_name_modal(:title => 'Edit Taxon Concept') %>
+<% when 'H' %>
+  <%= admin_new_hybrid_modal(:title => 'Edit Taxon Concept') %>
+<% end %>
 <% unless @taxon_concept.is_synonym? || @taxon_concept.is_hybrid? || @taxon_concept.is_trade_name? %>
 <ul id="taxon-concept-tabs" class="nav nav-tabs">
 

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -30,7 +30,8 @@
         <% @taxon_concept.inverse_synonym_relationships.includes(:taxon_concept).each do |rel| %>
           <li>
             <%= link_to rel.taxon_concept.try(:full_name),
-              params.merge(:taxon_concept_id => rel.taxon_concept_id) %>
+              admin_taxon_concept_names_url(taxon_concept_id: rel.taxon_concept_id)
+            %>
             <% if can? :destroy, rel %>
               <%= link_to delete_icon,
                 admin_taxon_concept_synonym_relationship_url(rel.taxon_concept, rel),
@@ -48,7 +49,8 @@
         <% @taxon_concept.inverse_hybrid_relationships.includes(:taxon_concept).each do |rel| %>
           <li>
             <%= link_to rel.taxon_concept.try(:full_name),
-              params.merge(:taxon_concept_id => rel.taxon_concept_id) %>
+              admin_taxon_concept_names_url(taxon_concept_id: rel.taxon_concept_id)
+            %>
             <% if can? :destroy, rel %>
               <%= link_to delete_icon,
                 admin_taxon_concept_hybrid_relationship_url(rel.taxon_concept, rel),
@@ -66,7 +68,8 @@
         <% @taxon_concept.inverse_trade_name_relationships.includes(:taxon_concept).each do |rel| %>
           <li>
             <%= link_to rel.taxon_concept.try(:full_name),
-              params.merge(:taxon_concept_id => rel.taxon_concept_id) %>
+              admin_taxon_concept_names_url(taxon_concept_id: rel.taxon_concept_id)
+            %>
             <% if can? :destroy, rel %>
               <%= link_to delete_icon,
                 admin_taxon_concept_trade_name_relationship_url(rel.taxon_concept, rel),

--- a/app/views/admin/taxon_concepts/_basic_info.html.erb
+++ b/app/views/admin/taxon_concepts/_basic_info.html.erb
@@ -83,15 +83,15 @@
 
 <% case @taxon_concept.name_status %>
 <% when 'A' %>
-  <%= admin_new_taxon_concept_modal(:title => 'Edit Taxon Concept') %>
+  <%= admin_new_taxon_concept_modal(nested: true, title: 'Edit Taxon Concept') %>
 <% when 'N' %>
-  <%= admin_new_n_name_modal(:title => 'Edit Taxon Concept') %>
+  <%= admin_new_n_name_modal(nested: true, title: 'Edit Taxon Concept') %>
 <% when 'S' %>
-  <%= admin_new_synonym_modal(:title => 'Edit Taxon Concept') %>
+  <%= admin_new_synonym_modal(nested: true, title: 'Edit Taxon Concept') %>
 <% when 'T' %>
-  <%= admin_new_trade_name_modal(:title => 'Edit Taxon Concept') %>
+  <%= admin_new_trade_name_modal(nested: true, title: 'Edit Taxon Concept') %>
 <% when 'H' %>
-  <%= admin_new_hybrid_modal(:title => 'Edit Taxon Concept') %>
+  <%= admin_new_hybrid_modal(nested: true, title: 'Edit Taxon Concept') %>
 <% end %>
 <% unless @taxon_concept.is_synonym? || @taxon_concept.is_hybrid? || @taxon_concept.is_trade_name? %>
 <ul id="taxon-concept-tabs" class="nav nav-tabs">

--- a/app/views/admin/taxon_concepts/_form.html.erb
+++ b/app/views/admin/taxon_concepts/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [:admin, @taxon_concept], :remote => true do |f| %>
 
   <%= error_messages_for(@taxon_concept) %>
-  <%= f.hidden_field :name_status %>
+  <%= f.hidden_field :name_status, value: 'A' %>
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,

--- a/app/views/admin/taxon_concepts/_hybrid_form.html.erb
+++ b/app/views/admin/taxon_concepts/_hybrid_form.html.erb
@@ -1,12 +1,12 @@
-<%= form_for [:admin, @hybrid], :remote => true, :namespace => 'hybrid' do |f| %>
-  <%= error_messages_for(@hybrid) %>
-  <%= f.hidden_field :name_status %>
+<%= form_for [:admin, @taxon_concept], :remote => true, :namespace => 'hybrid' do |f| %>
+  <%= error_messages_for(@taxon_concept) %>
+  <%= f.hidden_field :name_status, value: 'H' %>
 
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,
       options_from_collection_for_select(
-        @taxonomies, :id, :name, @hybrid && @hybrid.taxonomy_id
+        @taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id
       ),
       {},
       {class: 'taxonomy-selector'}
@@ -16,7 +16,7 @@
     <label>Rank</label>
     <%= f.select :rank_id,
       options_from_collection_for_select(
-        @ranks, :id, :name, @hybrid && @hybrid.rank_id
+        @ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id
       ),
       {},
       {class: 'rank-selector'}
@@ -30,7 +30,7 @@
         :'data-name-status-filter' => ['A'].to_json,
         :'data-name-status' => 'A',
         :'data-rank-scope' => 'self_and_ancestors',
-        :'data-name' => TaxonConcept.where(id: @hybrid.hybrid_parents_ids).pluck(:full_name).to_s
+        :'data-name' => TaxonConcept.where(id: @taxon_concept.hybrid_parents_ids).pluck(:full_name).to_s
       } %>
     </div>
   </div>

--- a/app/views/admin/taxon_concepts/_n_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_n_name_form.html.erb
@@ -1,12 +1,12 @@
-<%= form_for [:admin, @n_name], :remote => true do |f| %>
+<%= form_for [:admin, @taxon_concept], :remote => true do |f| %>
 
-  <%= error_messages_for(@n_name) %>
-  <%= f.hidden_field :name_status %>
+  <%= error_messages_for(@taxon_concept) %>
+  <%= f.hidden_field :name_status, value: 'N' %>
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,
       options_from_collection_for_select(
-        @taxonomies, :id, :name, @n_name && @n_name.taxonomy_id
+        @taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id
       ),
       {},
       {class: 'taxonomy-selector'}
@@ -16,7 +16,7 @@
     <label>Rank</label>
     <%= f.select :rank_id,
       options_from_collection_for_select(
-        @ranks, :id, :name, @n_name && @n_name.rank_id
+        @ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id
       ),
       {},
       {class: 'rank-selector'}
@@ -27,8 +27,8 @@
     <div class="controls">
       <%= f.text_field :parent_id, {
         class: 'taxon-concept parent-taxon',
-        :'data-name' => @n_name.parent.try(:full_name),
-        :'data-name-status' => @n_name.parent.try(:name_status),
+        :'data-name' => @taxon_concept.parent.try(:full_name),
+        :'data-name-status' => @taxon_concept.parent.try(:name_status),
         :'data-name-status-filter' => ['A', 'N'].to_json,
         :'data-rank-scope' => 'parent'
       } %>
@@ -45,7 +45,7 @@
         @tags,
         :name,
         :name,
-        @n_name.tag_list
+        @taxon_concept.tag_list
       ), {},
       { :multiple => true, :class => 'tags', :style => "width: 220px"}
     %>

--- a/app/views/admin/taxon_concepts/_synonym_form.html.erb
+++ b/app/views/admin/taxon_concepts/_synonym_form.html.erb
@@ -1,12 +1,12 @@
-<%= form_for [:admin, @synonym], :remote => true, :namespace => 'synonym' do |f| %>
-  <%= error_messages_for(@synonym) %>
-  <%= f.hidden_field :name_status %>
+<%= form_for [:admin, @taxon_concept], :remote => true, :namespace => 'synonym' do |f| %>
+  <%= error_messages_for(@taxon_concept) %>
+  <%= f.hidden_field :name_status, value: 'S' %>
 
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,
       options_from_collection_for_select(
-        @taxonomies, :id, :name, @synonym && @synonym.taxonomy_id
+        @taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id
       ),
       {},
       {class: 'taxonomy-selector'}
@@ -16,7 +16,7 @@
     <label>Rank</label>
     <%= f.select :rank_id,
       options_from_collection_for_select(
-        @ranks, :id, :name, @synonym && @synonym.rank_id
+        @ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id
       ),
       {},
       {class: 'rank-selector'}
@@ -29,7 +29,7 @@
         class: 'taxon-concept-multiple',
         :'data-name-status-filter' => ['A'].to_json,
         :'data-name-status' => 'A',
-        :'data-name' => TaxonConcept.where(id: @synonym.accepted_names_ids).pluck(:full_name).to_s
+        :'data-name' => TaxonConcept.where(id: @taxon_concept.accepted_names_ids).pluck(:full_name).to_s
       } %>
     </div>
   </div>

--- a/app/views/admin/taxon_concepts/_trade_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_trade_name_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_for [:admin, @trade_name], :remote => true, :namespace => 'trade_name' do |f| %>
+  <%= error_messages_for(@trade_name) %>
+  <%= f.hidden_field :name_status %>
+
+  <div class="control-group">
+    <label>Taxonomy</label>
+    <%= f.select :taxonomy_id,
+      options_from_collection_for_select(
+        @taxonomies, :id, :name, @trade_name && @trade_name.taxonomy_id
+      ),
+      {},
+      {class: 'taxonomy-selector'}
+    %>
+  </div>
+  <div class="control-group">
+    <label>Rank</label>
+    <%= f.select :rank_id,
+      options_from_collection_for_select(
+        @ranks, :id, :name, @trade_name && @trade_name.rank_id
+      ),
+      {},
+      {class: 'rank-selector'}
+    %>
+  </div>
+  <div class="control-group">
+    <label class="control-label">Accepted names</label>
+    <div class="controls">
+      <%= f.text_field :accepted_names_for_trade_name_ids, {
+        class: 'taxon-concept-multiple',
+        :'data-name-status-filter' => ['A'].to_json,
+        :'data-name-status' => 'A',
+        :'data-name' => TaxonConcept.where(id: @trade_name.accepted_names_for_trade_name_ids).pluck(:full_name).to_s
+      } %>
+    </div>
+  </div>
+  <div class="control-group">
+    <label>Trade name</label>
+    <%= f.text_field :full_name %>
+  </div>
+  <div class="control-group">
+    <label>Author & year</label>
+    <%= f.text_field :author_year %>
+  </div>
+<% end %>

--- a/app/views/admin/taxon_concepts/_trade_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_trade_name_form.html.erb
@@ -1,12 +1,12 @@
-<%= form_for [:admin, @trade_name], :remote => true, :namespace => 'trade_name' do |f| %>
-  <%= error_messages_for(@trade_name) %>
-  <%= f.hidden_field :name_status %>
+<%= form_for [:admin, @taxon_concept], :remote => true, :namespace => 'trade_name' do |f| %>
+  <%= error_messages_for(@taxon_concept) %>
+  <%= f.hidden_field :name_status, value: 'T' %>
 
   <div class="control-group">
     <label>Taxonomy</label>
     <%= f.select :taxonomy_id,
       options_from_collection_for_select(
-        @taxonomies, :id, :name, @trade_name && @trade_name.taxonomy_id
+        @taxonomies, :id, :name, @taxon_concept && @taxon_concept.taxonomy_id
       ),
       {},
       {class: 'taxonomy-selector'}
@@ -16,7 +16,7 @@
     <label>Rank</label>
     <%= f.select :rank_id,
       options_from_collection_for_select(
-        @ranks, :id, :name, @trade_name && @trade_name.rank_id
+        @ranks, :id, :name, @taxon_concept && @taxon_concept.rank_id
       ),
       {},
       {class: 'rank-selector'}
@@ -29,7 +29,7 @@
         class: 'taxon-concept-multiple',
         :'data-name-status-filter' => ['A'].to_json,
         :'data-name-status' => 'A',
-        :'data-name' => TaxonConcept.where(id: @trade_name.accepted_names_for_trade_name_ids).pluck(:full_name).to_s
+        :'data-name' => TaxonConcept.where(id: @taxon_concept.accepted_names_for_trade_name_ids).pluck(:full_name).to_s
       } %>
     </div>
   </div>

--- a/app/views/admin/taxon_concepts/new_hybrid.js.erb
+++ b/app/views/admin/taxon_concepts/new_hybrid.js.erb
@@ -1,4 +1,6 @@
-$('#admin-new-taxon_concept_hybrid-form').html(
-  "<%= escape_javascript(render('hybrid_form')) %>");
+var form = $("<%= escape_javascript(render('hybrid_form')) %>");
+form.find('.tags').select2();
+
+$('#admin-new-taxon_concept_hybrid-form').html(form);
 $('#new-taxon_concept_hybrid').modal('show');
 window.adminEditor.initSelect2Inputs();

--- a/app/views/admin/taxon_concepts/new_n_name.js.erb
+++ b/app/views/admin/taxon_concepts/new_n_name.js.erb
@@ -1,4 +1,6 @@
-$('#admin-new-taxon_concept_n_name-form').html(
-  "<%= escape_javascript(render('n_name_form')) %>");
+var form = $("<%= escape_javascript(render('n_name_form')) %>");
+form.find('.tags').select2();
+
+$('#admin-new-taxon_concept_n_name-form').html(form);
 $('#new-taxon_concept_n_name').modal('show');
 window.adminEditor.initSelect2Inputs();

--- a/app/views/admin/taxon_concepts/new_trade_name.js.erb
+++ b/app/views/admin/taxon_concepts/new_trade_name.js.erb
@@ -1,0 +1,4 @@
+$('#admin-new-taxon_concept_trade_name-form').html(
+  "<%= escape_javascript(render('trade_name_form')) %>");
+$('#new-taxon_concept_trade_name').modal('show');
+window.adminEditor.initSelect2Inputs();

--- a/app/views/admin/taxon_concepts/update.js.erb
+++ b/app/views/admin/taxon_concepts/update.js.erb
@@ -1,5 +1,5 @@
 $('.modal').modal('hide');
 $('#basic-info').html("<%= escape_javascript(render('basic_info')) %>");
-window.adminEditor.initEditors();
+window.adminEditor.initModals();
 window.adminEditor.alertSuccess("Operation successful");
 $("[rel='tooltip']").tooltip();

--- a/app/views/admin/taxon_concepts/update.js.erb
+++ b/app/views/admin/taxon_concepts/update.js.erb
@@ -1,5 +1,1 @@
-$('.modal').modal('hide');
-$('#basic-info').html("<%= escape_javascript(render('basic_info')) %>");
-window.adminEditor.initModals();
-window.adminEditor.alertSuccess("Operation successful");
-$("[rel='tooltip']").tooltip();
+window.location.href="<%= admin_taxon_concept_names_url(@taxon_concept) %>";


### PR DESCRIPTION
I extracted this from a branch that I'm working on to reduce the number of changes under review. The purpose of the changes here is to fix the "edit taxon concept" modals, which so far have only been working correctly for accepted names and N names. The crux of the matter was to render the correct view depending on name status, both in the edit and failed update scenarios. I aso needed to add a trade name edit form, which was previously missing. Related simplifications of the controllers were also possible. Small changes to modal window helpers were necessary to allow rendering the correct window title.

There were some smaller and bigger issues that I fixed while testing the update, e.g. the tag selector initialisers were missing for hybrids and N names,  the save button would not work on a consecutive update, and the links to accepted taxa would get malformed following an update. Also, relationships would be cleared during an update, which is a bug I introduced recently.