### PR TITLE
Prevent name change when editing taxon concepts

### DIFF
--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -139,25 +139,26 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def tmp_taxon_concept
     name_status_to_save = (new_name_status.present? ? new_name_status : name_status)
+    scientific_name = if ['A', 'N'].include?(name_status_to_save)
+      display_full_name.split.last
+    else
+      display_full_name
+    end
     taxon_concept_attrs = {
       parent_id: new_parent_id || parent_id,
       rank_id: new_rank_id || rank_id,
       author_year: (new_author_year.present? ? new_author_year : author_year),
-      name_status: name_status_to_save
+      name_status: name_status_to_save,
+      scientific_name: scientific_name
     }
+
     if will_create_taxon?
       taxonomy = (taxonomy_id.present? ? Taxonomy.find(taxonomy_id) :
         Taxonomy.find_by_name(Taxonomy::CITES_EU)
       )
-      scientific_name = if ['A', 'N'].include?(name_status_to_save)
-        display_full_name.split.last
-      else
-        display_full_name
-      end
       TaxonConcept.new(
         taxon_concept_attrs.merge({
           taxonomy_id: taxonomy.id,
-          scientific_name: scientific_name,
           tag_list: tag_list
         })
       )

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -180,6 +180,7 @@ class TaxonConcept < ActiveRecord::Base
   validates :taxon_name_id, :presence => true,
     :unless => lambda { |tc| tc.taxon_name.try(:valid?) }
   validates :full_name, :uniqueness => { :scope => [:taxonomy_id, :author_year] }
+  validate :full_name_cannot_be_changed, on: :update
   validates :taxonomic_position,
     :presence => true,
     :format => { :with => /\A\d(\.\d*)*\z/, :message => "Use prefix notation, e.g. 1.2" },
@@ -530,6 +531,14 @@ class TaxonConcept < ActiveRecord::Base
       prev_taxonomic_position_parts = prev_taxonomic_position.split('.')
       prev_taxonomic_position_parts << (prev_taxonomic_position_parts.pop || 0).to_i + 1
       self.taxonomic_position = prev_taxonomic_position_parts.join('.')
+    end
+    true
+  end
+
+  def full_name_cannot_be_changed
+    if full_name != full_name_was
+      errors.add(:full_name, "cannot be changed")
+      return false
     end
     true
   end

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -189,7 +189,6 @@ class TaxonConcept < ActiveRecord::Base
     tc.taxonomy && tc.taxonomy_id_changed?
   }
 
-  before_validation :set_full_name
   before_validation :ensure_taxonomic_position
 
   translates :nomenclature_note
@@ -257,29 +256,6 @@ class TaxonConcept < ActiveRecord::Base
 
   def scientific_name
     taxon_name.try(:scientific_name)
-  end
-
-  def set_full_name
-    self.full_name = current_full_name
-  end
-
-  def current_full_name
-    if self.rank && self.parent && ['A', 'N'].include?(self.name_status)
-      rank_name = self.rank.name
-      parent_full_name = self.parent.full_name
-      name = self.scientific_name
-      if name.blank?
-        nil
-      elsif [Rank::SPECIES, Rank::SUBSPECIES].include?(rank_name)
-         "#{parent_full_name} #{name.downcase}"
-      elsif rank_name == Rank::VARIETY
-        "#{parent_full_name} var. #{name.downcase}"
-      else
-        name
-      end
-    else
-      self.scientific_name
-    end
   end
 
   def has_comments?

--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -174,11 +174,6 @@ class TaxonConcept < ActiveRecord::Base
   validate :parent_in_same_taxonomy, :if => lambda { |tc| tc.parent }
   validate :parent_at_immediately_higher_rank,
     :if => lambda { |tc| tc.parent && tc.name_status == 'A' }
-  validate :parent_name_compatible, :if => lambda { |tc|
-    tc.parent && tc.rank && tc.full_name && (
-      tc.name_status == 'A' || tc.name_status.blank?
-    )
-  }
   validate :parent_is_an_accepted_name, :if => lambda { |tc| tc.parent && tc.name_status == 'A' }
   validate :maximum_2_hybrid_parents,
     :if => lambda { |tc| tc.name_status == 'H' }
@@ -485,15 +480,6 @@ class TaxonConcept < ActiveRecord::Base
   def taxonomy_can_be_changed
     if !can_be_deleted?
       errors.add(:taxonomy_id, "dependent objects present, unable to change taxonomy")
-      return false
-    end
-  end
-
-  def parent_name_compatible
-    self.full_name = TaxonConcept.sanitize_full_name(full_name)
-    if Rank.in_range(Rank::VARIETY, Rank::SPECIES).include?(rank.name) &&
-      full_name != expected_full_name(parent)
-      errors.add(:parent_id, "must have compatible name if rank is species, subspecies or variety")
       return false
     end
   end

--- a/app/models/taxon_concept_observer.rb
+++ b/app/models/taxon_concept_observer.rb
@@ -23,7 +23,7 @@ class TaxonConceptObserver < ActiveRecord::Observer
         name
       end
     else
-      taxon_concept.full_name || taxon_concept.scientific_name
+      taxon_concept.scientific_name
     end
   end
 

--- a/app/models/taxon_concept_observer.rb
+++ b/app/models/taxon_concept_observer.rb
@@ -1,27 +1,5 @@
 class TaxonConceptObserver < ActiveRecord::Observer
 
-  #initializes full name with values from parent
-  def before_validation(taxon_concept)
-    return true unless taxon_concept.new_record?
-    taxon_concept.full_name = if taxon_concept.rank && taxon_concept.parent &&
-      ['A', 'N'].include?(taxon_concept.name_status)
-      rank_name = taxon_concept.rank.name
-      parent_full_name = taxon_concept.parent.full_name
-      name = taxon_concept.taxon_name && taxon_concept.taxon_name.scientific_name
-      if name.blank?
-        nil
-      elsif [Rank::SPECIES, Rank::SUBSPECIES].include?(rank_name)
-         "#{parent_full_name} #{name.downcase}"
-      elsif rank_name == Rank::VARIETY
-        "#{parent_full_name} var. #{name.downcase}"
-      else
-        name
-      end
-    else
-      taxon_concept.taxon_name && taxon_concept.taxon_name.scientific_name
-    end
-  end
-
   def after_create(taxon_concept)
     ensure_species_touched(taxon_concept)
     Species::Search.increment_cache_iterator

--- a/app/models/taxon_concept_observer.rb
+++ b/app/models/taxon_concept_observer.rb
@@ -7,6 +7,12 @@ class TaxonConceptObserver < ActiveRecord::Observer
       rank_name = taxon_concept.rank.name
       parent_full_name = taxon_concept.parent.full_name
       name = taxon_concept.scientific_name
+      # if name is present, just in case it is a multipart name
+      # e.g. when changing status from S, T, H
+      # make sure to only use last part
+      if name.present?
+        name = TaxonName.sanitize_scientific_name(name)
+      end
       if name.blank?
         nil
       elsif [Rank::SPECIES, Rank::SUBSPECIES].include?(rank_name)

--- a/app/views/admin/taxon_concepts/_form.html.erb
+++ b/app/views/admin/taxon_concepts/_form.html.erb
@@ -36,7 +36,7 @@
   </div>
   <div class="control-group">
     <label>Scientific name</label>
-    <%= f.text_field :full_name %>
+    <%= f.text_field :scientific_name %>
   </div>
   <div class="control-group">
     <label>Tags</label>

--- a/app/views/admin/taxon_concepts/_hybrid_form.html.erb
+++ b/app/views/admin/taxon_concepts/_hybrid_form.html.erb
@@ -36,7 +36,7 @@
   </div>
   <div class="control-group">
     <label>Hybrid</label>
-    <%= f.text_field :full_name %>
+    <%= f.text_field :scientific_name %>
   </div>
   <div class="control-group">
     <label>Tags</label>

--- a/app/views/admin/taxon_concepts/_n_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_n_name_form.html.erb
@@ -36,7 +36,7 @@
   </div>
   <div class="control-group">
     <label>Scientific name</label>
-    <%= f.text_field :full_name %>
+    <%= f.text_field :scientific_name %>
   </div>
   <div class="control-group">
     <label>Tags</label>

--- a/app/views/admin/taxon_concepts/_synonym_form.html.erb
+++ b/app/views/admin/taxon_concepts/_synonym_form.html.erb
@@ -35,7 +35,7 @@
   </div>
   <div class="control-group">
     <label>Synonym</label>
-    <%= f.text_field :full_name %>
+    <%= f.text_field :scientific_name %>
   </div>
   <div class="control-group">
     <label>Author & year</label>

--- a/app/views/admin/taxon_concepts/_trade_name_form.html.erb
+++ b/app/views/admin/taxon_concepts/_trade_name_form.html.erb
@@ -35,7 +35,7 @@
   </div>
   <div class="control-group">
     <label>Trade name</label>
-    <%= f.text_field :full_name %>
+    <%= f.text_field :scientific_name %>
   </div>
   <div class="control-group">
     <label>Author & year</label>

--- a/spec/controllers/admin/taxon_concepts_controller_spec.rb
+++ b/spec/controllers/admin/taxon_concepts_controller_spec.rb
@@ -40,7 +40,7 @@ describe Admin::TaxonConceptsController do
           name_status: 'A',
           taxonomy_id: cites_eu.id,
           rank_id: create(:rank, name: Rank::GENUS),
-          full_name: 'Canis',
+          scientific_name: 'Canis',
           parent_id: create_cites_eu_family,
         }
       response.should render_template("create")

--- a/spec/models/checklist/pdf/index_fetcher_spec.rb
+++ b/spec/models/checklist/pdf/index_fetcher_spec.rb
@@ -53,7 +53,7 @@ describe Checklist::Pdf::IndexFetcher do
       create(
         :taxon_concept,
         :name_status => 'S',
-        :full_name => 'Catus fluffianus'
+        scientific_name: 'Catus fluffianus'
       )
     }
     let!(:synonymy_rel){

--- a/spec/models/hybrid_relationship_spec.rb
+++ b/spec/models/hybrid_relationship_spec.rb
@@ -24,14 +24,14 @@ describe TaxonRelationship do
       create_cites_eu_species(
         name_status: 'H',
         author_year: 'Hemulen 2013',
-        full_name: 'Lolcatus lolatus x lolcatus'
+        scientific_name: 'Lolcatus lolatus x lolcatus'
       )
     }
     let(:another_hybrid){
       create_cites_eu_species(
         name_status: 'H',
         author_year: 'Hemulen 2013',
-        full_name: 'Lolcatus lolcatus x ?'
+        scientific_name: 'Lolcatus lolcatus x ?'
       )
     }
     let(:hybrid_rel){

--- a/spec/models/synonym_relationship_spec.rb
+++ b/spec/models/synonym_relationship_spec.rb
@@ -23,14 +23,14 @@ describe TaxonRelationship do
       create_cites_eu_species(
         name_status: 'S',
         author_year: 'Hemulen 2013',
-        full_name: 'Lolcatus lolus'
+        scientific_name: 'Lolcatus lolus'
       )
     }
     let(:another_synonym){
       create_cites_eu_species(
         name_status: 'S',
         author_year: 'Hemulen 2013',
-        full_name: 'Lolcatus lolatus'
+        scientific_name: 'Lolcatus lolatus'
       )
     }
     let(:synonymy_rel){

--- a/spec/models/taxon_concept/synonyms_spec.rb
+++ b/spec/models/taxon_concept/synonyms_spec.rb
@@ -74,7 +74,7 @@ describe TaxonConcept do
           :parent_id => tc.id,
           :name_status => 'S',
           :author_year => 'Taxonomus 2013',
-          :full_name => 'Lolcatus lolus furiatus'
+          scientific_name: 'Lolcatus lolus furiatus'
         )
         create(
           :taxon_relationship,

--- a/spec/models/taxon_concept/trade_names_spec.rb
+++ b/spec/models/taxon_concept/trade_names_spec.rb
@@ -74,7 +74,7 @@ describe TaxonConcept do
           :parent_id => tc.id,
           :name_status => 'T',
           :author_year => 'Taxonomus 2013',
-          :full_name => 'Lolcatus lolus furiatus'
+          scientific_name: 'Lolcatus lolus furiatus'
         )
         create(
           :taxon_relationship,

--- a/spec/models/taxon_concept/validation_spec.rb
+++ b/spec/models/taxon_concept/validation_spec.rb
@@ -27,31 +27,6 @@ describe TaxonConcept do
       }
       specify { tc.should have(1).error_on(:parent_id) }
     end
-    context "parent name is incompatible" do
-      let(:genus_tc){
-        create_genus(
-          :taxonomy_id => cites_eu.id,
-          :taxon_name => build(:taxon_name, :scientific_name => 'Foobarus')
-        )
-      }
-      let(:another_genus_tc){
-        create_genus(
-          :taxonomy_id => cites_eu.id,
-          :taxon_name => build(:taxon_name, :scientific_name => 'Foobaria')
-        )
-      }
-      let(:tc) {
-        create_species(
-          :taxonomy_id => cites_eu.id,
-          :parent_id => genus_tc.id
-        )
-      }
-      let(:tc_with_incompatible_parent){
-        tc.parent = another_genus_tc
-        tc
-      }
-      specify { tc_with_incompatible_parent.should have(1).error_on(:parent_id) }
-    end
     context "parent is not an accepted name" do
       let(:genus_tc){
         create_genus(

--- a/spec/models/trade/annual_report_upload_spec.rb
+++ b/spec/models/trade/annual_report_upload_spec.rb
@@ -209,7 +209,7 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
       before(:each) do
         @synonym = create_cites_eu_species(
           :name_status => 'S',
-          :full_name => 'Acipenser stenorrhynchus'
+          scientific_name: 'Acipenser stenorrhynchus'
         )
         create(:taxon_relationship,
           :taxon_relationship_type_id => synonym_relationship_type.id,

--- a/spec/models/trade/shipment_spec.rb
+++ b/spec/models/trade/shipment_spec.rb
@@ -448,7 +448,6 @@ describe Trade::Shipment do
           create(
             :shipment,
             :taxon_concept => @taxon_concept,
-            :taxon_concept => @taxon_concept,
             :source => @wild
           )
         }

--- a/spec/shared/boa_constrictor.rb
+++ b/spec/shared/boa_constrictor.rb
@@ -33,7 +33,7 @@ shared_context "Boa constrictor" do
       :parent => @species
     )
     @synonym = create_cites_eu_species(
-      :full_name => 'Constrictor constrictor',
+      scientific_name: 'Constrictor constrictor',
       :name_status => 'S'
     )
     create(

--- a/spec/shared/caiman_latirostris.rb
+++ b/spec/shared/caiman_latirostris.rb
@@ -45,7 +45,7 @@ shared_context "Caiman latirostris" do
       ]
     )
     @species1 = create_cites_eu_species(
-      :full_name => 'Alligator cynocephalus',
+      scientific_name: 'Alligator cynocephalus',
       :name_status => 'S'
     )
 


### PR DESCRIPTION
This change affects creating / editing taxa via the modal windows as well as nomenclature changes processors which create new taxa / change name status of taxa.

The most important change is that the `full_name` attribute is no longer writable, in its place there's now a setter for `scientific_name`. Here's the difference:
- status A, N species `full_name` =_ Canis lupus_, `scientific_name` = Lupus
- status S, T, H species `full_name` = _Canis dingo_, `scientific_name` = Canis dingo

When we edit A and N taxa, a parent is always required and for the lower ranks the `full_name` is constructed using a combination of parent and own scientific names. This was previously handled inconsistently, i.e. when creating a new A, N taxon you would need to enter just the name part, whereas when editing you'd have to provide the full name - now it should be `scientific_name` in both cases. And for S, T, H taxa `scientific_name` always == `full_name`, regardless if parent is present or not.

Obviously when the name status changes during a nomenclature change, the name might require amendments. For example, if we had a synonym _Canis lupus_ (full_name == scientific_name == _Canis lupus_) that turns into A, we need to update the `scientific_name` to Lupus and provided the parent was correctly set to Canis, the full_name will remain intact.

Having sorted that, it became easier to validate whether or not the `full_name` is being changed. There is a `before_validation` callback that sets the `full_name` (taking into consideration potential status changes) and then the validation becomes a trivial comparison.