### PR TITLE
Some 'end's mismatching was causing the final step of split to fail

### DIFF
--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -67,7 +67,6 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
     end
     # taggings
     copy_distribution_taggings(reassignable, copied_object)
-    end
   end
 
   def copy_distribution_taggings(reassignable, copied_object)
@@ -82,6 +81,7 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
       !copied_object.new_record? && tagging.duplicates({
         taggable_id: copied_object.id
       }).first || copied_object.taggings.build(tagging.comparison_attributes)
+    end
 
   end
 


### PR DESCRIPTION
A bug was reported in [this story](https://www.pivotaltracker.com/story/show/115606167). Should be fixed now