### PR TITLE
Fix wording of swap nomenclature note

### DIFF
--- a/app/controllers/admin/nomenclature_changes/status_swap_controller.rb
+++ b/app/controllers/admin/nomenclature_changes/status_swap_controller.rb
@@ -14,7 +14,7 @@ class Admin::NomenclatureChanges::StatusSwapController < Admin::NomenclatureChan
       set_ranks
       builder.build_secondary_output
     when :notes
-      builder.build_output_notes
+      builder.build_secondary_output_note
     when :legislation
       builder.build_legislation_reassignments
       skip_or_previous_step if @nomenclature_change.input.legislation_reassignments.empty?

--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -183,16 +183,6 @@ class NomenclatureChange::Output < ActiveRecord::Base
     end
   end
 
-  def needs_public_note?
-    if nomenclature_change.is_a?(NomenclatureChange::StatusToSynonym) ||
-      nomenclature_change.is_a?(NomenclatureChange::StatusSwap) &&
-      new_name_status != 'A'
-      false
-    else
-      true
-    end
-  end
-
   def expected_parent_name
     if rank.name == Rank::SPECIES
       display_full_name.split[0]

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -109,15 +109,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     note
   end
 
-  def private_output_note(output, event, lng)
-    note = '<p>'
-    note << status_change_from_to(output, lng)
-    note << in_year(event, lng)
-    note << following_taxonomic_changes(event, lng) if event
-    note << '.</p>'
-    note
-  end
-
   def build_primary_output_note
     if @nomenclature_change.primary_output.needs_public_note?
       primary_note = multi_lingual_public_output_note(

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -68,37 +68,36 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     end
   end
 
-  def status_change_note(locale_key, output, lng)
-    output_html = taxon_concept_html(
-      output.display_full_name,
-      output.display_rank_name
+  def status_elevated_to_accepted_name(output_new, output_old, lng)
+    output_new_html = taxon_concept_html(
+      output_new.display_full_name,
+      output_new.display_rank_name
+    )
+    output_old_html = taxon_concept_html(
+      output_old.display_full_name,
+      output_old.display_rank_name
     )
     I18n.with_locale(lng) do
       I18n.translate(
-        "status_change.#{locale_key}",
-        output_taxon: output_html,
-        old_status: output.taxon_concept.name_status,
-        new_status: output.new_name_status,
+        "status_change.status_elevated_to_accepted_name",
+        output_new_taxon: output_new_html,
+        output_old_taxon: output_old_html,
         default: 'Translation missing'
       )
     end
   end
 
-  def status_elevated_to_accepted_name(output, lng)
-    status_change_note('status_elevated_to_accepted_name', output, lng)
-  end
-
-  def multi_lingual_public_output_note(output, event)
+  def multi_lingual_public_output_note(output_new, output_old, event)
     result = {}
     [:en, :es, :fr].each do |lng|
-      result[lng] = public_output_note(output, event, lng)
+      result[lng] = public_output_note(output_new, output_old, event, lng)
     end
     result
   end
 
-  def public_output_note(output, event, lng)
+  def public_output_note(output_new, output_old, event, lng)
     note = '<p>'
-    note << status_elevated_to_accepted_name(output, lng)
+    note << status_elevated_to_accepted_name(output_new, output_old, lng)
     note << in_year(event, lng)
     note << following_taxonomic_changes(event, lng) if event
     note << '.</p>'

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -109,18 +109,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     note
   end
 
-  def build_primary_output_note
-    if @nomenclature_change.primary_output.needs_public_note?
-      primary_note = multi_lingual_public_output_note(
-        @nomenclature_change.primary_output,
-        @event
-      )
-      @nomenclature_change.primary_output.note_en = primary_note[:en]
-      @nomenclature_change.primary_output.note_es = primary_note[:es]
-      @nomenclature_change.primary_output.note_fr = primary_note[:fr]
-    end
-  end
-
   def multi_lingual_listing_change_note
     multi_lingual_legislation_note('status_change.listing_change')
   end

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -121,10 +121,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     end
   end
 
-  def build_output_notes
-    build_primary_output_note
-  end
-
   def multi_lingual_listing_change_note
     multi_lingual_legislation_note('status_change.listing_change')
   end

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -84,10 +84,6 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     end
   end
 
-  def status_change_from_to(output, lng)
-    status_change_note('status_change_from_to', output, lng)
-  end
-
   def status_elevated_to_accepted_name(output, lng)
     status_change_note('status_elevated_to_accepted_name', output, lng)
   end

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -10,6 +10,7 @@ class NomenclatureChange::StatusSwap::Constructor
   def build_secondary_output_note
     secondary_note = multi_lingual_public_output_note(
       @nomenclature_change.secondary_output,
+      @nomenclature_change.primary_output,
       @event
     )
     @nomenclature_change.secondary_output.note_en = secondary_note[:en]

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -8,15 +8,13 @@ class NomenclatureChange::StatusSwap::Constructor
   end
 
   def build_secondary_output_note
-    if @nomenclature_change.secondary_output.needs_public_note?
-      secondary_note = multi_lingual_public_output_note(
-        @nomenclature_change.secondary_output,
-        @event
-      )
-      @nomenclature_change.secondary_output.note_en = secondary_note[:en]
-      @nomenclature_change.secondary_output.note_es = secondary_note[:es]
-      @nomenclature_change.secondary_output.note_fr = secondary_note[:fr]
-    end
+    secondary_note = multi_lingual_public_output_note(
+      @nomenclature_change.secondary_output,
+      @event
+    )
+    @nomenclature_change.secondary_output.note_en = secondary_note[:en]
+    @nomenclature_change.secondary_output.note_es = secondary_note[:es]
+    @nomenclature_change.secondary_output.note_fr = secondary_note[:fr]
   end
 
   private

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -19,10 +19,6 @@ class NomenclatureChange::StatusSwap::Constructor
     end
   end
 
-  def build_output_notes
-    build_secondary_output_note
-  end
-
   private
   def legislation_note(lng)
     input = @nomenclature_change.input

--- a/config/locales/nomenclature_change_notes.yml
+++ b/config/locales/nomenclature_change_notes.yml
@@ -19,7 +19,6 @@ en:
     quota: 'Quota originally formed for %{input_taxon}, which was lumped into %{output_taxon}'
   status_change:
     status_elevated_to_accepted_name: '%{output_taxon} was elevated to an accepted name'
-    status_change_from_to: '%{output_taxon} status change from %{old_status} to %{new_status}'
     listing_change: 'Originally listed as %{input_taxon}, which became a synonym of %{output_taxon}'
     suspension: 'Suspension originally formed for %{input_taxon}, which became a synonym of %{output_taxon}'
     opinion: 'Opinion originally formed for %{input_taxon}, which became a synonym of %{output_taxon}'

--- a/config/locales/nomenclature_change_notes.yml
+++ b/config/locales/nomenclature_change_notes.yml
@@ -18,7 +18,7 @@ en:
     opinion: 'Opinion originally formed for %{input_taxon}, which was lumped into %{output_taxon}'
     quota: 'Quota originally formed for %{input_taxon}, which was lumped into %{output_taxon}'
   status_change:
-    status_elevated_to_accepted_name: '%{output_taxon} was elevated to an accepted name'
+    status_elevated_to_accepted_name: '%{output_new_taxon} was originally listed as %{output_old_taxon}, which was subject to a nomenclature change'
     listing_change: 'Originally listed as %{input_taxon}, which became a synonym of %{output_taxon}'
     suspension: 'Suspension originally formed for %{input_taxon}, which became a synonym of %{output_taxon}'
     opinion: 'Opinion originally formed for %{input_taxon}, which became a synonym of %{output_taxon}'

--- a/spec/models/nomenclature_change/status_swap/constructor_spec.rb
+++ b/spec/models/nomenclature_change/status_swap/constructor_spec.rb
@@ -36,13 +36,13 @@ describe NomenclatureChange::StatusSwap::Constructor do
     end
   end
 
-  describe :build_output_notes do
+  describe :build_secondary_output_note do
     let(:primary_output){ status_change.primary_output }
     let(:secondary_output){ status_change.secondary_output }
     before(:each) do
       @old_primary_output_note = primary_output.internal_note
       @old_secondary_output_note = secondary_output.note_en
-      constructor.build_output_notes
+      constructor.build_secondary_output_note
     end
     let(:status_change){ a_to_s_with_swap }
     context "when previously no notes in place" do

--- a/spec/models/nomenclature_change/status_to_synonym/constructor_spec.rb
+++ b/spec/models/nomenclature_change/status_to_synonym/constructor_spec.rb
@@ -21,26 +21,4 @@ describe NomenclatureChange::StatusToSynonym::Constructor do
     end
   end
 
-  describe :build_output_notes do
-    let(:primary_output){ status_change.primary_output }
-    let(:secondary_output){ status_change.secondary_output }
-    before(:each) do
-      @old_primary_output_note = primary_output.internal_note
-      @old_secondary_output_note = secondary_output.note_en
-      constructor.build_output_notes
-    end
-
-    let(:status_change){ n_to_s_with_input_and_secondary_output }
-    context "when previously no notes in place" do
-      specify{ expect(primary_output.internal_note).to be_blank }
-      specify{ expect(secondary_output.note_en).to be_blank }
-    end
-    context "when previously notes in place" do
-      let(:primary_output){
-        create(:nomenclature_change_input, nomenclature_change: status_change, internal_note: 'blah')
-      }
-      specify{ expect(primary_output.internal_note).to eq(@old_primary_output_note) }
-    end
-  end
-
 end


### PR DESCRIPTION
This is to address the comment in https://www.pivotaltracker.com/story/show/116024057 about rewording the public nomenclature note for the swap. To apply the change I needed to pass both the primary and secondary output into the note generating method (previously only 1 output) and so I wanted to make sure this change won't break any other status changes. After a quick look around it seems currently only the swap uses the public note generator, whereas other status changes don't require one so it was possible to simplify things and remove some obsolete code.