### PR TITLE
quick fix for distribution tags spec

### DIFF
--- a/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/distribution_reassignments_processor_examples.rb
@@ -76,7 +76,7 @@ shared_context 'distribution_reassignments_processor_examples' do
   specify{ expect(output_species1.distributions.count).to eq(4) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id)).not_to be_nil }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).tag_list).to eq([]) }
-  specify{ expect(output_species1.distributions.find_by_geo_entity_id(italy.id).tag_list).to eq(['extinct', 'reintroduced']) }
+  specify{ expect(output_species1.distributions.find_by_geo_entity_id(italy.id).tag_list).to match_array(['extinct', 'reintroduced']) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(united_kingdom.id).tag_list).to eq([]) }
   specify{ expect(output_species1.distributions.find_by_geo_entity_id(poland.id).distribution_references.count).to eq(2) }
 end


### PR DESCRIPTION
This is a quick fix for distribution tags spec that was failing sometimes because of the different ordering of the elements in the array. So here I'm just checking that those elements exist regardless of their order