### PR TITLE
Fixes to cascading legislation notes

### DIFF
--- a/app/models/nomenclature_change/lump/processor.rb
+++ b/app/models/nomenclature_change/lump/processor.rb
@@ -24,7 +24,7 @@ class NomenclatureChange::Lump::Processor < NomenclatureChange::Processor
       chain << NomenclatureChange::InputTaxonConceptProcessor.new(input)
       chain << NomenclatureChange::CascadingNotesProcessor.new(input)
     end
-    if !@output.will_create_taxon?
+    if !@output.will_create_taxon? && @nc.inputs_intersect_outputs.empty?
       chain << NomenclatureChange::CascadingNotesProcessor.new(@output)
     end
     inputs_that_are_not_output.each do |input|

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -20,9 +20,6 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       map(&:taxon_concept_id).include?(@input.taxon_concept_id)
 
     chain << NomenclatureChange::InputTaxonConceptProcessor.new(@input)
-    if !input_is_one_of_outputs
-      chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
-    end
     @outputs.each_with_index do |output, idx|
       if @input.taxon_concept_id != output.taxon_concept_id
         chain << NomenclatureChange::OutputTaxonConceptProcessor.new(output)
@@ -51,6 +48,9 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
         end
       end
       chain << NomenclatureChange::CascadingNotesProcessor.new(output)
+    end
+    if !input_is_one_of_outputs
+      chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
     end
     unless input_is_one_of_outputs
       chain << NomenclatureChange::StatusDowngradeProcessor.new(@input, @outputs)

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -47,7 +47,9 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
           chain << NomenclatureChange::ReassignmentCopyProcessor.new(@input, output)
         end
       end
-      chain << NomenclatureChange::CascadingNotesProcessor.new(output)
+      if @input.taxon_concept_id != output.taxon_concept_id
+        chain << NomenclatureChange::CascadingNotesProcessor.new(output)
+      end
     end
     if !input_is_one_of_outputs
       chain << NomenclatureChange::CascadingNotesProcessor.new(@input)

--- a/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
+++ b/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
@@ -35,8 +35,14 @@ class NomenclatureChange::TaxonomicTreeNameResolver
           parent_id: node.parent_id,
           name_status: node.name_status,
           rank_id: node.rank_id,
-          author_year: node.author_year
+          author_year: node.author_year,
+          nomenclature_note_en: node.nomenclature_note_en,
+          nomenclature_note_es: node.nomenclature_note_es,
+          nomenclature_note_fr: node.nomenclature_note_fr
         )
+        if node.nomenclature_comment
+          compatible_node.create_nomenclature_comment(note: node.nomenclature_comment.note)
+        end
       else
         unless ['A', 'N'].include?(compatible_node.name_status)
           t = NomenclatureChange::ToAcceptedNameTransformation.new(compatible_node, node.parent)

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -77,14 +77,14 @@ describe NomenclatureChange::Lump::Processor do
           inputs_attributes: {
             0 => {
               taxon_concept_id: input_species1.id,
-              note_en: 'input EN note',
+              note_en: 'input species 1 has been lumped into output species',
               internal_note: 'input internal note'
             },
             1 => { taxon_concept_id: input_species2.id }
           },
           output_attributes: {
             taxon_concept_id: output_species.id,
-            note_en: 'output EN note',
+            note_en: 'output species was lumped from input species 1 and input species 2',
             internal_note: 'output internal note'
           },
           status: NomenclatureChange::Lump::LEGISLATION
@@ -110,7 +110,7 @@ describe NomenclatureChange::Lump::Processor do
       }
       before(:each){ processor.run }
       specify "input species has public nomenclature note set" do
-        expect(input_species1.reload.nomenclature_note_en).to eq(' input EN note')
+        expect(input_species1.reload.nomenclature_note_en).to eq(' input species 1 has been lumped into output species')
       end
       specify "child of input species inherits public nomenclature note" do
         expect(
@@ -126,28 +126,28 @@ describe NomenclatureChange::Lump::Processor do
         ).to eq(input_species1.nomenclature_comment.note)
       end
       specify "output species has public nomenclature note set" do
-        expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
+        expect(output_species.reload.nomenclature_note_en).to eq(' output species was lumped from input species 1 and input species 2')
       end
-      specify "child of output species inherits public nomenclature note" do
+      specify "child of output species inherits public nomenclature note from input" do
         expect(
           output_species1_child.reload.nomenclature_note_en
-        ).to eq(output_species.reload.nomenclature_note_en)
+        ).to eq(input_species1.reload.nomenclature_note_en)
       end
       specify "output species has internal nomenclature note set" do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
       end
-      specify "output species child inherits internal nomenclature note" do
+      specify "child of output species inherits internal nomenclature note from input" do
         expect(
           output_species1_child.nomenclature_comment.note
-        ).to eq(output_species.nomenclature_comment.note)
+        ).to eq(input_species1.nomenclature_comment.note)
       end
       specify "output species child has listing changes from input species child transferred" do
         expect(output_species1_child.listing_changes.count).to eq(1)
       end
-      specify "output species child has legislation nomenclature note set" do
+      specify "child of output species has legislation nomenclature note copied from input species" do
         expect(
           output_species1_child.listing_changes.first.nomenclature_note_en
-        ).to include(output_species.reload.nomenclature_note_en)
+        ).to eq(input_species1.reload.nomenclature_note_en)
       end
       let(:output_species_genus_name){ output_species.parent.full_name }
       specify "original output species child retains higher taxa intact" do

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -89,13 +89,13 @@ describe NomenclatureChange::Split::Processor do
         create(:nomenclature_change_split,
           input_attributes: {
             taxon_concept_id: input_species.id,
-            note_en: 'input EN note',
+            note_en: 'input species was split into output species 1 and output species 2',
             internal_note: 'input internal note'
           },
           outputs_attributes: {
             0 => {
               taxon_concept_id: output_species1.id,
-              note_en: 'output EN note',
+              note_en: 'output species 1 was split from input species',
               internal_note: 'output internal note'
             },
             1 => { taxon_concept_id: output_species2.id }
@@ -123,7 +123,7 @@ describe NomenclatureChange::Split::Processor do
       end
       before(:each){ processor.run }
       specify "input species has public nomenclature note set" do
-        expect(input_species.reload.nomenclature_note_en).to eq(' input EN note')
+        expect(input_species.reload.nomenclature_note_en).to eq(' input species was split into output species 1 and output species 2')
       end
       specify "child of input species inherits public nomenclature note" do
         expect(
@@ -139,9 +139,9 @@ describe NomenclatureChange::Split::Processor do
         ).to eq(input_species.nomenclature_comment.note)
       end
       specify "output species has public nomenclature note set" do
-        expect(output_species.reload.nomenclature_note_en).to eq(' output EN note')
+        expect(output_species.reload.nomenclature_note_en).to eq(' output species 1 was split from input species')
       end
-      specify "child of output species inherits public nomenclature note" do
+      specify "child of output species inherits public nomenclature note from output" do
         expect(
           output_species_child.reload.nomenclature_note_en
         ).to eq(output_species.nomenclature_note_en)
@@ -149,7 +149,7 @@ describe NomenclatureChange::Split::Processor do
       specify "output species has internal nomenclature note set" do
         expect(output_species.nomenclature_comment.note).to eq(' output internal note')
       end
-      specify "output species child inherits internal nomenclature note" do
+      specify "child of output species inherits internal nomenclature note from output" do
         expect(
           output_species_child.nomenclature_comment.note
         ).to eq(output_species.nomenclature_comment.note)
@@ -157,10 +157,10 @@ describe NomenclatureChange::Split::Processor do
       specify "output species child has listing changes from input species child transferred" do
         expect(output_species_child.listing_changes.count).to eq(1)
       end
-      specify "output species child has legislation nomenclature note set" do
+      specify "output species child has legislation nomenclature note copied from output species" do
         expect(
           output_species_child.listing_changes.first.nomenclature_note_en
-        ).to include(output_species.nomenclature_note_en)
+        ).to eq(output_species.nomenclature_note_en)
       end
       let(:output_species1_genus_name){ output_species1.parent.full_name }
       specify "original output species child retains higher taxa intact" do


### PR DESCRIPTION
Addresses issues with excessive cascading of legislation notes (https://www.pivotaltracker.com/story/show/85788920). Below are examples of how the issues manifested themselves - there were 2 concerns here:

- legislation nomenclature notes were duplicated, because the notes cascading would run twice on the same records. That is because parent reassignment happened in between cascading notes for inputs / outputs. The solution to that was to make sure reassignments are processed after notes are cascaded.
- where the name of children does not change, the notes should not cascade. The solution was to ensure that notes are not cascaded for outputs where output is one of the inputs and output does not create a new taxon concept.

Examples:
- lump 1
  - inputs:
    - _Equus zebra_ (has subspecies _E. z. hartmannae_)
    - _Equus hemionus_ (has subspecies _E. h. hemionus_)
  - output: _Equus novus_ (new taxon concept)
  - incorrect behaviour: _E. n. hartmannae_ gets a double nomenclature note:
      - _Equus zebra_ was lumped into _Equus novus_ (...)
      - _Equus novus_ was lumped from _Equus hemionus, Equus zebra_ (...)
  - expected behaviour: only 1 note
      - _Equus zebra_ was lumped into _Equus novus_ (...)

- lump 2
  - inputs:
    - _Felis silvestris_ (has subspecies _F. s. lybica_)
    - _Lynx rufus_ (has subspecies _L. r. escuinapae_)
  - output: _Felis silvestris_
  - incorrect behaviour: 
    - _F. s. lybica_ gets a  legislation nomenclature note (e..g historic CITES listing)
      - _Felis silvestris_ was lumped from _Felis silvestris_, _Lynx rufus_ (...)
    - _F. s. escuinapae_ gets a double legislation nomenclature note:
      - _Lynx rufus_ was lumped into _Felis silvestris_ (...)
      - _Felis silvestris_ was lumped from _Felis silvestris_, _Lynx rufus_ (...)
   - correct behaviour:
     - _F. s. lybica_ gets no  legislation nomenclature note
     - _F. s. escuinapae_ gets a single legislation nomenclature note:
       - _Lynx rufus_ was lumped into _Felis silvestris_ (...)
- split
  - input: _Alisterus chloropterus_ (has subspecies _A. c. chloropterus_, which gets reassigned to output _Aprosmictus chloropterus_, and _A. c. mozskowskii_ reassgned to output _Alisterus kinga_)
  - outputs:
    - _Aprosmictus chloropterus_ (S)
    - _Alisterus angelous_ (new taxon concept)
    - _Alisterus kinga_ (new taxon concept)
  - incorrect behaviour:
    - subspecies _A. c. chloropterus_ gets a double legislation nomenclature note (e.g. EU decisions):
      - _Alisterus chloropterus_ was split into _Aprosmictus chloropterus_, _Alisterus angelous_, _Alisterus kinga_ (...)
      - _Aprosmictus chloropterus_ was split from _Alisterus chloropterus_ (...)
  - correct behaviour:
    - subspecies _A. c. chloropterus_ gets a single legislation nomenclature note:
      - _Aprosmictus chloropterus_ was split from _Alisterus chloropterus_ (...)