### PR TITLE
Add nomenclature notes to checklist history downloads

### DIFF
--- a/app/models/checklist/column_display_name_mapping.rb
+++ b/app/models/checklist/column_display_name_mapping.rb
@@ -11,6 +11,7 @@ module Checklist::ColumnDisplayNameMapping
     :short_note_en => 'AnnotationEnglish',
     :short_note_es => 'AnnotationSpanish',
     :short_note_fr => 'AnnotationFrench',
+    :nomenclature_note_en => 'NomenclatureNote',
     :kingdom_name => 'Kingdom',
     :phylum_name => 'Phylum',
     :class_name => 'Class',

--- a/app/models/checklist/csv/history.rb
+++ b/app/models/checklist/csv/history.rb
@@ -47,7 +47,8 @@ class Checklist::Csv::History < Checklist::History
       "(strip_tags(cites_listing_changes_mview.full_note_en) || ' ' || strip_tags(cites_listing_changes_mview.nomenclature_note_en)) AS full_note_en",
       "strip_tags(cites_listing_changes_mview.short_note_en) AS short_note_en",
       "strip_tags(cites_listing_changes_mview.short_note_es) AS short_note_es",
-      "strip_tags(cites_listing_changes_mview.short_note_fr) AS short_note_fr"
+      "strip_tags(cites_listing_changes_mview.short_note_fr) AS short_note_fr",
+      "strip_tags(cites_listing_changes_mview.nomenclature_note_en) AS nomenclature_note_en"
     ]
   end
  
@@ -65,7 +66,8 @@ class Checklist::Csv::History < Checklist::History
       :species_listing_name, :party_iso_code, :party_full_name,
       :change_type_name, :effective_at_formatted, :is_current,
       :hash_ann_symbol, :hash_full_note_en,
-      :full_note_en, :short_note_en, :short_note_es, :short_note_fr
+      :full_note_en, :short_note_en, :short_note_es, :short_note_fr,
+      :nomenclature_note_en
     ]
   end
 

--- a/app/models/checklist/pdf/history_content.rb
+++ b/app/models/checklist/pdf/history_content.rb
@@ -97,15 +97,19 @@ module Checklist::Pdf::HistoryContent
   end
 
   def annotation_for_language(listing_change, lng)
-    short_note = listing_change.send("short_note_#{lng}")
-    short_note = LatexToPdf.html2latex(short_note)
+    short_note = LatexToPdf.html2latex(
+      listing_change.send("short_note_#{lng}")
+    )
+    nomenclature_note = LatexToPdf.html2latex(
+      listing_change.nomenclature_note_en
+    )
     if listing_change.display_in_footnote
       full_note = listing_change.send("full_note_#{lng}")
       full_note && full_note.gsub!(/[\n\r]/, ' ')
       full_note = LatexToPdf.html2latex(full_note)
-      "#{short_note}\\footnote{#{full_note}}"
+      "#{short_note}\n\n#{nomenclature_note}\\footnote{#{full_note}}"
     else
-      short_note
+      "#{short_note}\n\n#{nomenclature_note}"
     end
   end
 

--- a/spec/models/checklist/pdf/history_spec.rb
+++ b/spec/models/checklist/pdf/history_spec.rb
@@ -81,7 +81,7 @@ describe Checklist::Pdf::History do
         create(
           :annotation,
           :short_note_en => 'Except <i>Foobarus cracoviensis</i>',
-          :full_note_en => 'They have plenty of <i>Foobarus cracoviensis</i> in Kraków',
+          :full_note_en => '...',
           :display_in_footnote => true
         )
       }
@@ -90,15 +90,15 @@ describe Checklist::Pdf::History do
         lc = create_cites_I_addition(
           :taxon_concept_id => tc.id,
           :annotation_id => annotation.id,
-          :is_current => true
+          :is_current => true,
+          :nomenclature_note_en => 'Previously listed as <i>Foobarus polonicus</i>.'
         )
         Sapi::StoredProcedures.rebuild_cites_taxonomy_and_listings
         MCitesListingChange.find(lc.id)
       }
       subject{ Checklist::Pdf::History.new({}) }
       specify{
-        LatexToPdf.stub(:html2latex).and_return('x')
-        subject.annotation_for_language(lc, 'en').should == 'x\footnote{x}'
+        subject.annotation_for_language(lc, 'en').should == "Except \\textit{Foobarus cracoviensis}\n\nPreviously listed as \\textit{Foobarus polonicus}.\\footnote{...}"
       }
     end
   end


### PR DESCRIPTION
Adds nomenclature note (English only, consistently with how we did that fro checklist popups) to the CSV and PDF history downloads. The JSON download already had it, as it uses the same serializer as the popups.

Ideally to be merged after #597 to allow reviewing https://www.pivotaltracker.com/story/show/117697129 without the cascading issues.