### PR TITLE
Order of distribution tags

### DIFF
--- a/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
@@ -15,7 +15,7 @@ Ember.Handlebars.helper "formattedTags", (value, options) ->
   escaped = Handlebars.Utils.escapeExpression(value)
   formatted = escaped.split(',').map((item) ->
   	"<span class=\"tage\">" + item + "</span>"
-  ).join ""
+  ).reverse().join ""
   new Handlebars.SafeString(formatted)
 
 Ember.Handlebars.registerHelper('highlight', (suggestion, options) ->

--- a/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
+++ b/app/assets/javascripts/species/helpers/handlebars_helpers.js.coffee
@@ -13,9 +13,13 @@ Ember.Handlebars.registerHelper "eachPart", (arr, options) ->
 
 Ember.Handlebars.helper "formattedTags", (value, options) ->
   escaped = Handlebars.Utils.escapeExpression(value)
-  formatted = escaped.split(',').map((item) ->
-  	"<span class=\"tage\">" + item + "</span>"
-  ).reverse().join ""
+  split = escaped.split(',')
+  formatted = if split.length == 1 && split[0] == ''
+    ''
+  else
+    split.map((item) ->
+      "<span class=\"tage\">" + item + "</span>"
+    ).join ""
   new Handlebars.SafeString(formatted)
 
 Ember.Handlebars.registerHelper('highlight', (suggestion, options) ->

--- a/app/assets/javascripts/species/templates/taxon_concept/distribution.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/distribution.handlebars
@@ -10,17 +10,23 @@
       <div class="three-columns">
         <ul class="col">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=0}}
-            <li>{{name}} {{formattedTags tags_list}}</li>
+            <li class="distribution-with-tags">
+              <span class="distribution">{{name}}</span>{{formattedTags tags_list}}
+            </li>
           {{/eachPart}}
         </ul>
         <ul class="col">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=1}}
-            <li>{{name}} {{formattedTags tags_list}}</li>
+            <li class="distribution-with-tags">
+              <span class="distribution">{{name}}</span>{{formattedTags tags_list}}
+            </li>
           {{/eachPart}}
         </ul>
         <ul class="col last-child">
           {{#eachPart controllers.taxonConcept.distributions parts=3 page=2}}
-            <li>{{name}} {{formattedTags tags_list}}</li>
+            <li class="distribution-with-tags">
+              <span class="distribution">{{name}}</span>{{formattedTags tags_list}}
+            </li>
           {{/eachPart}}
         </ul>
       </div>

--- a/app/assets/stylesheets/species/all.css
+++ b/app/assets/stylesheets/species/all.css
@@ -1316,8 +1316,14 @@ html.lt-ie9 #main .tabset > li > ul >li.first {
 	content: "";
 	clear: both;
 }
+.distribution-with-tags {
+  text-align:right;
+}
+.distribution {
+  float:left;
+  text-align: left;
+}
 #main .block06 .three-columns .col li .tage {
-	float: right;
 	padding: 0 5px;
 	margin: 3px 0 0 5px;
 	line-height: 15px;

--- a/db/migrate/20160421083820_fix_order_of_distribution_tags_in_public_distribution_tab.rb
+++ b/db/migrate/20160421083820_fix_order_of_distribution_tags_in_public_distribution_tab.rb
@@ -1,0 +1,11 @@
+class FixOrderOfDistributionTagsInPublicDistributionTab < ActiveRecord::Migration
+  def up
+    execute "DROP VIEW IF EXISTS api_distributions_view"
+    execute "CREATE VIEW api_distributions_view AS #{view_sql('20160421083820', 'api_distributions_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_distributions_view"
+    execute "CREATE VIEW api_distributions_view AS #{view_sql('20150112093954', 'api_distributions_view')}"
+  end
+end

--- a/db/views/api_distributions_view/20160421083820.sql
+++ b/db/views/api_distributions_view/20160421083820.sql
@@ -1,0 +1,24 @@
+SELECT
+  d.*,
+  g.name_en,
+  g.name_es,
+  g.name_fr,
+  g.iso_code2,
+  gt.name AS geo_entity_type,
+  ARRAY_AGG_NOTNULL(r.citation ORDER BY r.citation) AS citations
+FROM (
+  SELECT
+    d.id,
+    d.taxon_concept_id,
+    d.geo_entity_id,
+    ARRAY_AGG_NOTNULL(tags.name ORDER BY taggings.created_at) AS tags
+  FROM distributions d
+  LEFT JOIN taggings ON taggings.taggable_type='Distribution' AND taggings.taggable_id=d.id
+  LEFT JOIN tags on tags.id = taggings.tag_id
+  GROUP BY d.id, d.taxon_concept_id, d.geo_entity_id
+) d
+JOIN geo_entities g ON g.id = d.geo_entity_id
+JOIN geo_entity_types gt ON gt.id = g.geo_entity_type_id
+LEFT JOIN distribution_references dr ON dr.distribution_id = d.id
+LEFT JOIN "references" r ON r.id = dr.reference_id
+GROUP BY d.id, d.taxon_concept_id, d.geo_entity_id, d.tags, g.name_en, g.name_es, g.name_fr, g.iso_code2, gt.name;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/117903417

Order fixed in the underlying database view (which is used for both the Species+ distributions tab and the Species+ API. Additionally, for the distributions tab order is reversed to account for float:right on tag elements.