### PR TITLE
Display commission notes only when signed in

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -62,6 +62,10 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
     !@get('selectedEventType.id')?
   ).property('selectedEventType')
 
+  isSignedIn: ( ->
+    $.cookie('speciesplus.signed_in') == '1'
+  ).property()
+
   actions:
     openSearchPage:->
       @transitionToRoute('documents', {queryParams: @getFilters()})

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -51,8 +51,13 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
   ).property('selectedEventType.id')
 
   interSessionalDocumentTypes: ( ->
-    @get('controllers.events.interSessionalDocumentTypes')
-  ).property()
+    nonPublicTypes = @get('controllers.events.interSessionalNonPublicDocumentTypes')
+    publicTypes = @get('controllers.events.interSessionalDocumentTypes')
+    if @get('isSignedIn')
+      nonPublicTypes.pushObjects(publicTypes)
+    else
+      publicTypes
+  ).property('isSignedIn')
 
   documentTypeDropdownVisible: ( ->
     @get('selectedEventType.id') == 'EcSrg'

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -63,11 +63,14 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
     }
   ]
 
-  interSessionalDocumentTypes: [
+  interSessionalNonPublicDocumentTypes: [
     {
       id: 'Document::CommissionNotes',
       name: 'Commission Notes'
-    },
+    }
+  ]
+
+  interSessionalDocumentTypes: [
     {
       id: 'Document::NonDetrimentFindings',
       name: 'Non-Detriment Findings'
@@ -77,7 +80,6 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
       name: 'UNEP-WCMC Report'
     }
   ]
-
 
   load: ->
     unless @get('loaded')

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,4 +266,13 @@ Devise.setup do |config|
   config.warden do |manager|
    manager.failure_app = CustomFailure
   end
+
+  Warden::Manager.after_set_user do |user,auth,opts|
+    auth.cookies[:"speciesplus.signed_in"] = 1
+  end
+
+  Warden::Manager.before_logout do |user,auth,opts|
+    auth.cookies.delete :"speciesplus.signed_in"
+  end
+
 end


### PR DESCRIPTION
Remove the option "Commission Notes" from the Intersessional documents when not logged in

https://www.pivotaltracker.com/story/show/118046013