### PR TITLE
Fixed updating internal note

### DIFF
--- a/app/models/nomenclature_change/output_taxon_concept_processor.rb
+++ b/app/models/nomenclature_change/output_taxon_concept_processor.rb
@@ -17,6 +17,7 @@ class NomenclatureChange::OutputTaxonConceptProcessor
       Rails.logger.warn "FAILED to save taxon #{tc.errors.inspect}"
       return false
     end
+    nomenclature_comment.save
     if new_record
       Rails.logger.debug("UPDATE NEW TAXON ID #{tc.id}")
       @output.update_column(:new_taxon_concept_id, tc.id)

--- a/app/models/nomenclature_change/status_swap/constructor.rb
+++ b/app/models/nomenclature_change/status_swap/constructor.rb
@@ -21,11 +21,7 @@ class NomenclatureChange::StatusSwap::Constructor
   private
   def legislation_note(lng)
     input = @nomenclature_change.input
-    output = if @nomenclature_change.needs_to_relay_associations?
-      @nomenclature_change.secondary_output
-    elsif @nomenclature_change.needs_to_receive_associations?
-      @nomenclature_change.primary_output
-    end
+    output = @nomenclature_change.secondary_output
     output = taxon_concept_html(output.display_full_name, output.display_rank_name)
     input = taxon_concept_html(input.taxon_concept.full_name, input.taxon_concept.rank.name)
     note = '<p>'

--- a/app/models/nomenclature_change/status_swap/processor.rb
+++ b/app/models/nomenclature_change/status_swap/processor.rb
@@ -7,15 +7,10 @@ class NomenclatureChange::StatusSwap::Processor < NomenclatureChange::Processor
   # A subprocessor needs to respond to #run
   def prepare_chain
     chain = []
-    output = if @nc.needs_to_relay_associations?
-      @secondary_output
-    elsif @nc.needs_to_receive_associations?
-      @primary_output
-    end
     chain << NomenclatureChange::OutputTaxonConceptProcessor.new(@primary_output)
     chain << NomenclatureChange::OutputTaxonConceptProcessor.new(@secondary_output)
 
-    chain << reassignment_processor(output)
+    chain << reassignment_processor(@secondary_output)
 
     chain << if @primary_output.new_name_status == 'A'
       linked_names = @secondary_output ? [@secondary_output] : []

--- a/spec/models/nomenclature_change/shared/status_change_definitions.rb
+++ b/spec/models/nomenclature_change/shared/status_change_definitions.rb
@@ -105,7 +105,9 @@ shared_context 'status_change_definitions' do
         is_primary_output: false,
         taxon_concept_id: input_synonym.id,
         new_name_status: 'A',
-        new_parent_id: input_synonym_genus.id
+        new_parent_id: input_synonym_genus.id,
+        note_en: 'public',
+        internal_note: 'internal'
       },
       status: NomenclatureChange::StatusSwap::SECONDARY_OUTPUT
     ).reload

--- a/spec/models/nomenclature_change/status_swap/processor_spec.rb
+++ b/spec/models/nomenclature_change/status_swap/processor_spec.rb
@@ -31,12 +31,19 @@ describe NomenclatureChange::StatusSwap::Processor do
           taxon_concept: primary_output_taxon_concept,
           reported_taxon_concept: primary_output_taxon_concept
         )
+        secondary_output_taxon_concept.create_nomenclature_comment
         processor.run
       }
       specify{ expect(primary_output_taxon_concept).to be_is_synonym }
       specify{ expect(primary_output_taxon_concept.parent).to eq(accepted_name_parent) }
       specify{ expect(secondary_output_taxon_concept.name_status).to eq('A') }
       specify{ expect(primary_output_taxon_concept.accepted_names).to include(secondary_output_taxon_concept) }
+      specify "public nomenclature note is set" do
+        expect(secondary_output_taxon_concept.nomenclature_note_en).to eq(' public')
+      end
+      specify "internal nomenclature note is set" do
+        expect(secondary_output_taxon_concept.nomenclature_comment.try(:note)).to eq(' internal')
+      end
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/118548989

The bug would only manifest itself where a `nomenclature_comment` object existed before the nomenclature change. Where none existed, it would be created with the internal note correctly, but if it existed before, the changes to the text would not save on `tc.save` - it needed an extra `nomenclature_comment.save`