### PR TITLE
Fix subspecies reassignments when input is a genus

### DIFF
--- a/app/models/nomenclature_change/full_reassignment.rb
+++ b/app/models/nomenclature_change/full_reassignment.rb
@@ -7,55 +7,44 @@ class NomenclatureChange::FullReassignment
 
   def process
     Rails.logger.debug "FULL REASSIGNMENT #{@old_taxon_concept.full_name} to #{@new_taxon_concept.full_name}"
+    update_timestamp = Time.now
     update_attrs = {
-      taxon_concept_id: @new_taxon_concept.id
+      taxon_concept_id: @new_taxon_concept.id,
+      updated_at: update_timestamp,
+      updated_by_id: nil
     }
     # distributions
     Rails.logger.debug "FULL REASSIGNMENT Distributions (#{@old_taxon_concept.distributions.count})"
-    @old_taxon_concept.distributions.each do |d|
-      d.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.distributions.update_all(update_attrs)
     # references
     Rails.logger.debug "FULL REASSIGNMENT References (#{@old_taxon_concept.taxon_concept_references.count})"
-    @old_taxon_concept.taxon_concept_references.each do |tcr|
-      tcr.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.taxon_concept_references.update_all(update_attrs)
     # listing changes
     Rails.logger.debug "FULL REASSIGNMENT Listing Changes (#{@old_taxon_concept.listing_changes.count})"
-    @old_taxon_concept.listing_changes.each do |lc|
-      lc.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.listing_changes.update_all(update_attrs)
     # EU opinions
     Rails.logger.debug "FULL REASSIGNMENT EU Opinions (#{@old_taxon_concept.eu_opinions.count})"
-    @old_taxon_concept.eu_opinions.each do |ed|
-      ed.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.eu_opinions.update_all(update_attrs)
     # EU suspensions
     Rails.logger.debug "FULL REASSIGNMENT EU Suspensions (#{@old_taxon_concept.eu_suspensions.count})"
-    @old_taxon_concept.eu_suspensions.each do |ed|
-      ed.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.eu_suspensions.update_all(update_attrs)
     # CITES quotas
     Rails.logger.debug "FULL REASSIGNMENT CITES Quotas (#{@old_taxon_concept.quotas.count})"
-    @old_taxon_concept.quotas.each do |tr|
-      tr.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.quotas.update_all(update_attrs)
     # CITES suspensions
     Rails.logger.debug "FULL REASSIGNMENT CITES Suspensions (#{@old_taxon_concept.cites_suspensions.count})"
-    @old_taxon_concept.cites_suspensions.each do |tr|
-      tr.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.cites_suspensions.update_all(update_attrs)
     # common names
     Rails.logger.debug "FULL REASSIGNMENT Common names (#{@old_taxon_concept.taxon_commons.count})"
-    @old_taxon_concept.taxon_commons.each do |tc|
-      tc.update_attributes(update_attrs)
-    end
+    @old_taxon_concept.taxon_commons.update_all(update_attrs)
     # shipments
     Rails.logger.debug "FULL REASSIGNMENT Shipments"
     Trade::Shipment.update_all(
       update_attrs,
       {taxon_concept_id: @old_taxon_concept.id}
     )
+    @old_taxon_concept.update_attributes(dependents_updated_at: update_timestamp)
+    @new_taxon_concept.update_attributes(dependents_updated_at: update_timestamp)
   end
 
 end

--- a/app/models/nomenclature_change/full_reassignment.rb
+++ b/app/models/nomenclature_change/full_reassignment.rb
@@ -44,6 +44,7 @@ class NomenclatureChange::FullReassignment
       {taxon_concept_id: @old_taxon_concept.id}
     )
     @old_taxon_concept.update_attributes(dependents_updated_at: update_timestamp)
+    @old_taxon_concept.reload
     @new_taxon_concept.update_attributes(dependents_updated_at: update_timestamp)
   end
 

--- a/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
+++ b/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
@@ -27,7 +27,13 @@ class NomenclatureChange::TaxonomicTreeNameResolver
       compatible_node = TaxonConcept.where(
         taxonomy_id: node.taxonomy_id,
         full_name: expected_full_name
-      ).first
+      )
+      # match on author & year as well
+      compatible_node = if node.author_year.blank?
+        compatible_node.where('SQUISH_NULL(author_year) IS NULL')
+      else
+        compatible_node.where(author_year: node.author_year)
+      end.first
       unless compatible_node
         compatible_node = TaxonConcept.create(
           taxonomy_id: node.taxonomy_id,

--- a/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
+++ b/app/models/nomenclature_change/taxonomic_tree_name_resolver.rb
@@ -10,69 +10,78 @@ class NomenclatureChange::TaxonomicTreeNameResolver
     resolve(@node)
   end
 
-
   private
   def resolve(node)
-    expected_full_name = node.expected_full_name(node.parent)
+    @expected_full_name = node.expected_full_name(node.parent)
+    return node if name_compatible_with_parent?(node)
+    Rails.logger.debug("Resolving node name: #{node.full_name} (expected: #{@expected_full_name})")
 
-    expected_scientific_name = if ['A', 'N'].include?(node.name_status)
-      expected_full_name.split.last
+    # find or create a new accepted name compatible with this parent
+    compatible_node = TaxonConcept.where(
+      taxonomy_id: node.taxonomy_id,
+      full_name: @expected_full_name
+    )
+    # match on author & year as well
+    compatible_node = if node.author_year.blank?
+      compatible_node.where('SQUISH_NULL(author_year) IS NULL')
     else
-      expected_full_name
+      compatible_node.where(author_year: node.author_year)
+    end.first
+    if !compatible_node
+      compatible_node = create_compatible_node(node)
+    elsif compatible_node && !['A', 'N'].include?(compatible_node.name_status)
+      upgrade_node(compatible_node, node.parent)
     end
 
-    Rails.logger.debug("Resolving node name: #{node.full_name} (expected: #{expected_full_name})")
-    unless name_compatible_with_parent?(node)
-      # find or create a new accepted name compatible with this parent
-      compatible_node = TaxonConcept.where(
-        taxonomy_id: node.taxonomy_id,
-        full_name: expected_full_name
-      )
-      # match on author & year as well
-      compatible_node = if node.author_year.blank?
-        compatible_node.where('SQUISH_NULL(author_year) IS NULL')
-      else
-        compatible_node.where(author_year: node.author_year)
-      end.first
-      unless compatible_node
-        compatible_node = TaxonConcept.create(
-          taxonomy_id: node.taxonomy_id,
-          scientific_name: expected_scientific_name,
-          parent_id: node.parent_id,
-          name_status: node.name_status,
-          rank_id: node.rank_id,
-          author_year: node.author_year,
-          nomenclature_note_en: node.nomenclature_note_en,
-          nomenclature_note_es: node.nomenclature_note_es,
-          nomenclature_note_fr: node.nomenclature_note_fr
-        )
-        if node.nomenclature_comment
-          compatible_node.create_nomenclature_comment(note: node.nomenclature_comment.note)
-        end
-      else
-        unless ['A', 'N'].include?(compatible_node.name_status)
-          t = NomenclatureChange::ToAcceptedNameTransformation.new(compatible_node, node.parent)
-          t.process
-        end
-      end
-      # restore old parent, even though this ends up as a synonym it should
-      # have sane ancestry
-      node.update_attribute(:parent_id, @node_old_copy.parent_id)
-      r = NomenclatureChange::FullReassignment.new(node, compatible_node)
-      r.process
-      t = NomenclatureChange::ToSynonymTransformation.new(node, compatible_node)
-      t.process
-    else
-      compatible_node = node
-    end
+    # restore old parent, even though this ends up as a synonym it should
+    # have sane ancestry
+    node.update_attribute(:parent_id, @node_old_copy.parent_id)
 
-    compatible_node.children.each do |child_node|
+    r = NomenclatureChange::FullReassignment.new(node, compatible_node)
+    r.process
+    downgrade_node(node, compatible_node)
+
+    node.children.each do |child_node|
+      child_node.parent = compatible_node
       resolve(child_node)
     end
   end
 
+  def create_compatible_node(node)
+    expected_scientific_name = if ['A', 'N'].include?(node.name_status)
+      @expected_full_name.split.last
+    else
+      @expected_full_name
+    end
+    compatible_node = TaxonConcept.create(
+      taxonomy_id: node.taxonomy_id,
+      scientific_name: expected_scientific_name,
+      parent_id: node.parent_id,
+      name_status: node.name_status,
+      rank_id: node.rank_id,
+      author_year: node.author_year,
+      nomenclature_note_en: node.nomenclature_note_en,
+      nomenclature_note_es: node.nomenclature_note_es,
+      nomenclature_note_fr: node.nomenclature_note_fr
+    )
+    if node.nomenclature_comment
+      compatible_node.create_nomenclature_comment(note: node.nomenclature_comment.note)
+    end
+    compatible_node
+  end
+
+  def upgrade_node(node, parent)
+    t = NomenclatureChange::ToAcceptedNameTransformation.new(node, parent)
+    t.process
+  end
+
+  def downgrade_node(node, compatible_node)
+    t = NomenclatureChange::ToSynonymTransformation.new(node, compatible_node)
+    t.process
+  end
+
   def name_compatible_with_parent?(node)
-    node.expected_full_name(node.parent) == node.full_name
+    @expected_full_name == node.full_name
   end
 
 end

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -286,6 +286,9 @@ describe NomenclatureChange::Split::Processor do
     specify "input genus child's child is a synonym" do
       expect(input_genus_child_child.reload.name_status).to eq('S')
     end
+    specify "input genus child's child's name did not change" do
+      expect(input_genus_child_child.reload.full_name).to eq('Crotalus durissus unicolor')
+    end
     specify "output genus should have child with resolved name" do
       output_genus_child = output_genus.children.first
       expect(output_genus_child).not_to be_nil

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -247,6 +247,7 @@ describe NomenclatureChange::Split::Processor do
         taxon_name: create(:taxon_name, scientific_name: 'unicolor')
       )
     end
+    let!(:quota){ create(:quota, taxon_concept: input_genus_child, geo_entity: create(:geo_entity)) }
     let(:output_genus) do
       create_cites_eu_genus(
         taxon_name: create(:taxon_name, scientific_name: 'Paracrotalus')
@@ -278,6 +279,10 @@ describe NomenclatureChange::Split::Processor do
     specify "input genus child is a synonym" do
       expect(input_genus_child.reload.name_status).to eq('S')
     end
+    specify "input genus child is a synonym of output genus child" do
+      output_genus_child = output_genus.children.first
+      expect(input_genus_child.accepted_names).to include(output_genus_child)
+    end
     specify "input genus child's child is a synonym" do
       expect(input_genus_child_child.reload.name_status).to eq('S')
     end
@@ -291,6 +296,13 @@ describe NomenclatureChange::Split::Processor do
       output_genus_child_child = output_genus_child.children.first
       expect(output_genus_child_child).not_to be_nil
       expect(output_genus_child_child.full_name).to eq('Paracrotalus durissus unicolor')
+    end
+    specify "input genus child has no quotas" do
+      expect(input_genus_child.quotas).to be_empty
+    end
+    specify "input genus child's accepted name has 1 quota" do
+      output_genus_child = output_genus.children.first
+      expect(output_genus_child.quotas.size).to eq(1)
     end
   end
   describe :summary do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/118741503

There was an error in the way logic was invoked recursively on descendants, which affected descendants 2 levels below split level.

Also simplified the full reassignment procedure, which helped with the other issue mentioned in that ling, which was quotas not getting reassigned.