### PR TITLE
Validation message when duplicated primary document

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -43,6 +43,7 @@ class Document < ActiveRecord::Base
   has_and_belongs_to_many :tags, class_name: 'DocumentTag', join_table: 'document_tags_documents'
   validates :title, presence: true
   validates :date, presence: true
+  validates_uniqueness_of :primary_language_document_id, scope: :language_id
   # TODO validates inclusion of type in available types
   accepts_nested_attributes_for :citations, :allow_destroy => true,
     :reject_if => proc { |attributes|

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -43,7 +43,7 @@ class Document < ActiveRecord::Base
   has_and_belongs_to_many :tags, class_name: 'DocumentTag', join_table: 'document_tags_documents'
   validates :title, presence: true
   validates :date, presence: true
-  validates_uniqueness_of :primary_language_document_id, scope: :language_id
+  validates_uniqueness_of :primary_language_document_id, scope: :language_id, allow_nil: true
   # TODO validates inclusion of type in available types
   accepts_nested_attributes_for :citations, :allow_destroy => true,
     :reject_if => proc { |attributes|

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -140,7 +140,7 @@ class DocumentSearch
   def select_and_group_query
     columns = "event_name, event_type, date, date_raw, is_public, document_type,
       proposal_number, primary_document_id,
-      geo_entity_names, taxon_names, extension,
+      geo_entity_names, taxon_names,
       proposal_outcome, review_phase"
     aggregators = <<-SQL
       ARRAY_TO_JSON(

--- a/app/serializers/species/document_serializer.rb
+++ b/app/serializers/species/document_serializer.rb
@@ -2,7 +2,7 @@ class Species::DocumentSerializer < ActiveModel::Serializer
   attributes :event_type, :event_name, {date_formatted: :date}, :is_public,
     :document_type, :proposal_number,
     :primary_document_id, :taxon_names, :geo_entity_names,
-    :taxon_names, :geo_entity_names, :extension,
+    :taxon_names, :geo_entity_names,
     :document_language_versions,
     :proposal_outcome, :review_phase
   include PgArrayParser

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -49,5 +49,22 @@ describe Document, sidekiq: :inline do
       }
       specify{ expect(document.designation).to eq(cites) }
     end
+    context "when documents with same language and same primary document" do
+      let(:language){ create(:language) }
+      let(:primary_document){ create(:document) }
+      let!(:document1){ create(:document,
+                              language_id: language.id,
+                              primary_language_document_id: primary_document.id)
+      }
+
+      let(:document2){ build(:document,
+                            language_id: language.id,
+                            primary_language_document_id: primary_document.id)
+      }
+
+      specify{ expect(document2).to be_invalid }
+      specify{ expect(document2).to have(1).error_on(:primary_language_document_id) }
+
+    end
   end
 end


### PR DESCRIPTION
Fire a validation error message rather then exception when attempting to create a duplicate pair of the form: language_id, primary_language_document_id. Ignored validation if nil values are present.
[PT story](https://www.pivotaltracker.com/story/show/114773803)