### PR TITLE
Fix show search option in documents search

### DIFF
--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -1,9 +1,9 @@
 <strong class="documents-search-results-header">Search Results</strong>
 <p class="search-options-toggle">
-  <i class="fa fa-plus-circle"></i>
   <span {{action toggleSearchOptions target=view}}>
-    Show search options
+    <i class="fa fa-plus-circle"></i>
   </span>
+  <span class="search-text">Show search options</span>
 </p>
 <div class="search-form documents">
 

--- a/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
@@ -9,5 +9,11 @@ Species.ElibrarySearchFormView = Ember.View.extend
   actions:
     toggleSearchOptions: () ->
       @.$('.search-form').toggle()
-      icon = @.$('.search-options-toggle > i')
+      tag = @.$('.search-options-toggle')
+      icon = tag.find('i')
+      search_text = tag.find('.search-text')
+      if icon.hasClass('fa-plus-circle')
+        search_text.text('Hide search options')
+      else if icon.hasClass('fa-minus-circle')
+        search_text.text('Show search options')
       icon.toggleClass("fa-plus-circle fa-minus-circle")

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -41,7 +41,7 @@
   .search-options-toggle {
     display: none;
     color: #2d3237;
-    cursor: pointer;
+    i{ cursor: pointer };
   }
   .documents-search-results-header { display: none; }
 


### PR DESCRIPTION
["Show search option" should work on clicking '+' and revert the text to "hide"](https://www.pivotaltracker.com/story/show/112523975)