### PR TITLE
Delete rst phases

### DIFF
--- a/app/assets/javascripts/species/controllers/document_tags_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/document_tags_controller.js.coffee
@@ -1,7 +1,6 @@
 Species.DocumentTagsController = Ember.ArrayController.extend Species.ArrayLoadObserver,
   needs: 'elibrarySearch'
   proposalOutcomes: null
-  reviewPhases: null
 
   load: ->
     unless @get('loaded')
@@ -9,5 +8,4 @@ Species.DocumentTagsController = Ember.ArrayController.extend Species.ArrayLoadO
 
   handleLoadFinished: () ->
     @set('proposalOutcomes', @get('content').filterProperty('type', 'DocumentTag::ProposalOutcome'))
-    @set('reviewPhases', @get('content').filterProperty('type', 'DocumentTag::ReviewPhase'))
     @get('controllers.elibrarySearch').initDocumentTagsSelectors()

--- a/app/assets/javascripts/species/mixins/document_tag_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/document_tag_lookup.js.coffee
@@ -10,8 +10,8 @@ Species.DocumentTagLookup = Ember.Mixin.create
       @set('selectedProposalOutcome', po)
 
   proposalOutcomeDropdownVisible: ( ->
-    @get('selectedDocumentType.id') == 'Document::Proposal'
-  ).property('selectedDocumentType')
+    @get('selectedEventType.id') == 'CitesCop'
+  ).property('selectedEventType')
 
   actions:
     handleProposalOutcomeSelection: (proposalOutcome) ->

--- a/app/assets/javascripts/species/mixins/document_tag_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/document_tag_lookup.js.coffee
@@ -8,17 +8,9 @@ Species.DocumentTagLookup = Ember.Mixin.create
     if @get('selectedProposalOutcomeId')
       po = @get('controllers.documentTags.proposalOutcomes').findBy('id', @get('selectedProposalOutcomeId'))
       @set('selectedProposalOutcome', po)
-    else if @get('selectedReviewPhaseId')
-      rp = @get('controllers.documentTags.reviewPhases').findBy('id', @get('selectedReviewPhaseId'))
-      @set('selectedReviewPhase', rp)
-      @resetDocumentType
 
   proposalOutcomeDropdownVisible: ( ->
     @get('selectedDocumentType.id') == 'Document::Proposal'
-  ).property('selectedDocumentType')
-
-  reviewPhaseDropdownVisible: ( ->
-    @get('selectedDocumentType.id') == 'Document::ReviewOfSignificantTrade'
   ).property('selectedDocumentType')
 
   actions:
@@ -27,9 +19,3 @@ Species.DocumentTagLookup = Ember.Mixin.create
 
     handleProposalOutcomeDeselection: (proposalOutcome) ->
       @set('selectedProposalOutcome', null)
-
-    handleReviewPhaseSelection: (reviewPhase) ->
-      @set('selectedReviewPhase', reviewPhase)
-
-    handleReviewPhaseDeselection: (reviewPhase) ->
-      @set('selectedReviewPhase', null)

--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -24,9 +24,6 @@
 {{#if proposalOutcome}}
   <td class='outcome-col'>{{unbound doc.proposal_outcome}}</td>
 {{/if}}
-{{#if reviewPhase}}
-  <td class='review-phase-col'>{{unbound doc.review_phase}}</td>
-{{/if}}
 <td class='download-col'>
   <input type="checkbox">
 </td>

--- a/app/assets/javascripts/species/templates/components/documents-results.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-results.handlebars
@@ -14,9 +14,6 @@
             {{#if proposalOutcome}}
               <th class="outcome-col">OUTCOME</th>
             {{/if}}
-            {{#if reviewPhase}}
-              <th class="review-phase-col">PHASE</th>
-            {{/if}}
             <th class="download-col">
               {{batch-download}}
               {{download-checkbox}}
@@ -37,15 +34,12 @@
             {{#if proposalOutcome}}
               <th></th>
             {{/if}}
-            {{#if reviewPhase}}
-              <th></th>
-            {{/if}}
             <th class="download-col"></th>
           </tr>
         </thead>
         <tbody>
           {{#each doc in documents}}
-            {{document-result doc=doc proposalOutcome=proposalOutcome reviewPhase=reviewPhase}}
+            {{document-result doc=doc proposalOutcome=proposalOutcome}}
           {{/each}}
         </tbody>
       </table>

--- a/app/assets/javascripts/species/templates/components/documents-row.handlebars
+++ b/app/assets/javascripts/species/templates/components/documents-row.handlebars
@@ -16,7 +16,6 @@
   documents=documents.docs
   dataController=dataController
   proposalOutcome=proposalOutcome
-  reviewPhase=reviewPhase
   loadMore=loadMore
   block=true
   }}

--- a/app/assets/javascripts/species/templates/documents.handlebars
+++ b/app/assets/javascripts/species/templates/documents.handlebars
@@ -25,14 +25,12 @@
           dataController=controller
           loadMore=controller.citesAcDocsLoadMore
           documents=controller.citesAcDocuments
-          reviewPhase=true
           isLoading=controller.citesAcDocsIsLoading}}
         {{documents-row meeting_type="CITES Review of Significant Trade (plants)"
           eventType="CitesPc"
           dataController=controller
           loadMore=controller.citesPcDocsLoadMore
           documents=controller.citesPcDocuments
-          reviewPhase=true
           isLoading=controller.citesPcDocsIsLoading}}
         {{documents-row meeting_type="EU Scientific Review Group"
           eventType="EcSrg"

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -84,17 +84,6 @@
         }}
       </div>
       <div class="documents-control-group">
-        {{single-dropdown
-          isVisible=controller.reviewPhaseDropdownVisible
-          action="handleReviewPhaseSelection"
-          clearAction="handleReviewPhaseDeselection"
-          title="Review phase"
-          placeholder="All phases"
-          values=controllers.documentTags.reviewPhases
-          selection=controller.selectedReviewPhase
-        }}
-      </div>
-      <div class="documents-control-group">
         <label>Search by title keyword(s)
           <i class="fa fa-info-circle"
             title="This search will only return results if there is an exact match with the word or phrase in the title of the document.">

--- a/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/documents.handlebars
@@ -24,7 +24,6 @@
           dataController=controller
           loadMore=controller.citesAcDocsLoadMore
           documents=controller.citesAcDocuments.docs
-          reviewPhase=true
           isLoading=controller.citesAcDocsIsLoading}}
       </tbody>
     </table>
@@ -38,7 +37,6 @@
           dataController=controller
           loadMore=controller.citesPcDocsLoadMore
           documents=controller.citesPcDocuments.docs
-          reviewPhase=true
           isLoading=controller.citesPcDocsIsLoading}}
       </tbody>
     </table>

--- a/app/serializers/species/document_serializer.rb
+++ b/app/serializers/species/document_serializer.rb
@@ -4,7 +4,7 @@ class Species::DocumentSerializer < ActiveModel::Serializer
     :primary_document_id, :taxon_names, :geo_entity_names,
     :taxon_names, :geo_entity_names,
     :document_language_versions,
-    :proposal_outcome, :review_phase
+    :proposal_outcome
   include PgArrayParser
 
   def document_type


### PR DESCRIPTION
Deleted the review phase selection interface and logic form the documents search, according to [this PT story](https://www.pivotaltracker.com/story/show/118558027)
Also, a bug affecting the proposal outcome selection dropdown not showing up has been fixed.