### PR TITLE
Add date to meeting options

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::EventsController < ApplicationController
 
   def index
     @events = Event.
-      select([:id, :name, :type, :effective_at]).
+      select([:id, :name, :type, :published_at]).
       where(type: Event.elibrary_event_types.map(&:name)).
       order('type, published_at DESC')
     render :json => @events,

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::EventsController < ApplicationController
 
   def index
     @events = Event.
-      select([:id, :name, :type]).
+      select([:id, :name, :type, :effective_at]).
       where(type: Event.elibrary_event_types.map(&:name)).
       order('type, published_at DESC')
     render :json => @events,

--- a/app/serializers/species/event_serializer.rb
+++ b/app/serializers/species/event_serializer.rb
@@ -1,3 +1,8 @@
 class Species::EventSerializer < ActiveModel::Serializer
   attributes :id, :name, :type
+
+  def name
+    name = object.name
+    "#{name} #{object.effective_at.strftime('(%B %Y)')}" if object.effective_at
+  end
 end

--- a/app/serializers/species/event_serializer.rb
+++ b/app/serializers/species/event_serializer.rb
@@ -3,6 +3,6 @@ class Species::EventSerializer < ActiveModel::Serializer
 
   def name
     name = object.name
-    "#{name} #{object.effective_at.strftime('(%B %Y)')}" if object.effective_at
+    "#{name} #{object.published_at.strftime('(%B %Y)')}" if object.published_at
   end
 end


### PR DESCRIPTION
This adds the effective_at date (in the format: "(Month Year)") to meetings selection as described by [this PT story](https://www.pivotaltracker.com/story/show/116037201).
The effective_at field has been attached to the name field in order to maintain the current behaviour without changing anything else.