### PR TITLE
nullify primary_language_document_id when primary document is destroyed

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -38,7 +38,11 @@ class Document < ActiveRecord::Base
   belongs_to :designation
   belongs_to :event
   belongs_to :language
-  belongs_to :primary_language_document, class_name: 'Document', foreign_key: 'primary_language_document_id'
+  belongs_to :primary_language_document, class_name: 'Document',
+    foreign_key: 'primary_language_document_id'
+  has_many :secondary_language_documents, class_name: 'Document',
+    foreign_key: 'primary_language_document_id',
+    dependent: :nullify
   has_many :citations, class_name: 'DocumentCitation', dependent: :destroy
   has_and_belongs_to_many :tags, class_name: 'DocumentTag', join_table: 'document_tags_documents'
   validates :title, presence: true

--- a/db/migrate/20160504095537_change_primary_document_foreign_key_to_nullify.rb
+++ b/db/migrate/20160504095537_change_primary_document_foreign_key_to_nullify.rb
@@ -1,0 +1,18 @@
+class ChangePrimaryDocumentForeignKeyToNullify < ActiveRecord::Migration
+  def up
+    remove_foreign_key :documents,
+      name: 'documents_primary_language_document_id_fk'
+    add_foreign_key :documents, :documents,
+      name: 'documents_primary_language_document_id_fk',
+      column: 'primary_language_document_id',
+      dependent: :nullify
+  end
+
+  def down
+    remove_foreign_key :documents,
+      name: 'documents_primary_language_document_id_fk'
+    add_foreign_key :documents, :documents,
+      name: 'documents_primary_language_document_id_fk',
+      column: 'primary_language_document_id'
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -67,4 +67,31 @@ describe Document, sidekiq: :inline do
 
     end
   end
+
+  describe :destroy do
+    let(:primary_document){
+      create(:proposal)
+    }
+    let!(:secondary_document){
+      create(:proposal, primary_language_document_id: primary_document.id)
+    }
+    context "when secondary document destroyed" do
+      specify "document count decreases by 1" do
+        expect {
+          secondary_document.destroy
+        }.to change{ Document.count }.by(-1)
+      end
+    end
+    context "when primary document destroyed" do
+      specify "document count decreases by 1" do
+        expect{
+          primary_document.destroy
+        }.to change{ Document.count }.by(-1)
+      end
+      specify "secondary document becomes primary" do
+        primary_document.destroy
+        expect(secondary_document.primary_language_document).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is unrelated to any of the stories, but while testing I noticed if you try to delete a primary document and exception is thrown when there are secondary documents in place. In this case it is possibly better to nullify primary_language_document_id in linked documents rather than destroy them.