### PR TITLE
Fix order of documents

### DIFF
--- a/app/assets/javascripts/species/mixins/document_loader.js.coffee
+++ b/app/assets/javascripts/species/mixins/document_loader.js.coffee
@@ -73,8 +73,6 @@ Species.DocumentLoader = Ember.Mixin.create
         taxon_concepts_ids: [@get('controllers.taxonConcept.id')],
       }
     params['event_type'] = eventType
-    params['sort_col'] = @get('sortCol') || 'date'
-    params['sort_dir'] = @get('sortDir') || 'desc'
     params
 
   getEventTypeKey: (eventType) ->

--- a/app/models/document_observer.rb
+++ b/app/models/document_observer.rb
@@ -1,6 +1,7 @@
 class DocumentObserver < ActiveRecord::Observer
 
   def after_save(document)
+    sync_sort_index(document)
     clear_cache
   end
 
@@ -14,6 +15,25 @@ class DocumentObserver < ActiveRecord::Observer
     DocumentSearch.increment_cache_iterator
     RefreshDocumentsWorker.perform_async
     DownloadsCacheCleanupWorker.perform_async(:documents)
+  end
+
+  def sync_sort_index(document)
+    if document.sort_index_changed?
+      if document.primary_language_document &&
+        document.primary_language_document_id != document.id
+        document.primary_language_document.update_attribute(
+          :sort_index,
+          document.sort_index
+        )
+      else
+        document.secondary_language_documents(true).each do |d|
+          d.update_attribute(
+            :sort_index,
+            document.sort_index
+          )
+        end
+      end
+    end
   end
 
 end

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -133,8 +133,7 @@ class DocumentSearch
   end
 
   def add_ordering_for_public
-    # sort_col and sort_dir are sanitized
-    @query = @query.order("#{@sort_col} #{@sort_dir}")
+    @query = @query.order("date_raw DESC")
   end
 
   def select_and_group_query
@@ -153,15 +152,10 @@ class DocumentSearch
         )
       ) AS document_language_versions
     SQL
-    # sort_col and sort_dir are sanitized
     @query = Document.from(
       '(' + @query.to_sql + ') documents'
     ).select(columns + "," + aggregators).group(columns)
-    if @sort_col != 'title'
-      @query = @query.order("#{@sort_col} #{@sort_dir}")
-    else
-      @query = @query.order("MAX(title) #{@sort_dir}")
-    end
+    @query = @query.order('date_raw DESC')
   end
 
   def self.refresh

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -155,7 +155,7 @@ class DocumentSearch
     @query = Document.from(
       '(' + @query.to_sql + ') documents'
     ).select(columns + "," + aggregators).group(columns)
-    @query = @query.order('date_raw DESC')
+    @query = @query.order('date_raw DESC, MAX(sort_index), MAX(title)')
   end
 
   def self.refresh

--- a/app/models/document_search_params.rb
+++ b/app/models/document_search_params.rb
@@ -20,17 +20,7 @@ class DocumentSearchParams < Hash
       ].compact,
       show_private: sanitise_boolean(params[:show_private], false),
       page: sanitise_positive_integer(params[:page], 1),
-      per_page: sanitise_positive_integer(params[:per_page], 25),
-      sort_col: whitelist_param(
-        sanitise_string(params[:sort_col]),
-        ['date_raw', 'event_name', 'title'],
-        'date_raw'
-      ),
-      sort_dir: whitelist_param(
-        sanitise_string(params[:sort_dir]),
-        ['asc', 'desc'],
-        'desc'
-      )
+      per_page: sanitise_positive_integer(params[:per_page], 25)
     }
 
     super(sanitized_params)

--- a/db/migrate/20160505105252_add_indexes_to_api_documents_mview.rb
+++ b/db/migrate/20160505105252_add_indexes_to_api_documents_mview.rb
@@ -1,0 +1,32 @@
+class AddIndexesToApiDocumentsMview < ActiveRecord::Migration
+  def up
+    add_index :api_documents_mview, [:event_id],
+      name: 'index_documents_mview_on_event_id'
+    add_index :api_documents_mview, [:date_raw],
+      name: 'index_documents_mview_on_date_raw'
+    execute <<-SQL
+      CREATE INDEX index_documents_mview_on_taxon_concepts_ids
+      ON api_documents_mview
+      USING GIN (taxon_concept_ids)
+    SQL
+    execute <<-SQL
+      CREATE INDEX index_documents_mview_on_geo_entity_ids
+      ON api_documents_mview
+      USING GIN (geo_entity_ids)
+    SQL
+    execute <<-SQL
+      CREATE INDEX index_documents_mview_on_title_to_ts_vector
+      ON api_documents_mview
+      USING gin
+      (to_tsvector('simple'::regconfig, COALESCE(title, ''::text)));
+    SQL
+  end
+
+  def down
+    remove_index :api_documents_mview, name: 'index_documents_mview_on_event_id'
+    remove_index :api_documents_mview, name: 'index_documents_mview_on_date_raw'
+    remove_index :api_documents_mview, name: 'index_documents_mview_on_taxon_concepts_ids'
+    remove_index :api_documents_mview, name: 'index_documents_mview_on_geo_entity_ids'
+    remove_index :api_documents_mview, name: 'index_documents_mview_on_title_to_ts_vector'
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -68,6 +68,30 @@ describe Document, sidekiq: :inline do
     end
   end
 
+  describe :update do
+    let(:primary_document){
+      create(:proposal, sort_index: 1)
+    }
+    let!(:secondary_document){
+      create(:proposal,
+        sort_index: 2,
+        primary_language_document_id: primary_document.id
+      )
+    }
+    context "when primary document sort_index_updated" do
+      specify "secondary document sort_index is in sync" do
+        primary_document.update_attributes(sort_index: 3)
+        expect(secondary_document.reload.sort_index).to eq(3)
+      end
+    end
+    context "when secondary document sort_index_updated" do
+      specify "primary document sort_index is in sync" do
+        secondary_document.update_attributes(sort_index: 3)
+        expect(primary_document.reload.sort_index).to eq(3)
+      end
+    end
+  end
+
   describe :destroy do
     let(:primary_document){
       create(:proposal)


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/115769339

The solution is to apply ordering by `sort_index`, which is a numeric attribute of a document that can be updated via the admin tool and determines the order of a document relative to other documents linked to the same event.

Also removed remainders of the "sorting columns" logic and restored indexes on `api_documents_mview` which went missing along the way.