### PR TITLE
Select multiple meetings

### DIFF
--- a/app/assets/javascripts/admin/documents.js.coffee
+++ b/app/assets/javascripts/admin/documents.js.coffee
@@ -99,9 +99,16 @@ $(document).ready ->
     allowClear: true
   }
 
+  eventsSelect2Options = {
+    placeholder: 'Start typing an event'
+    width: '300px'
+    allowClear: true
+  }
+
   $('.primary-language-document').select2(primaryDocumentSelect2Options)
   $('.citation-taxon-concept').select2(citationTaxonSelect2Options)
   $('.citation-geo-entity').select2(citationGeoEntitySelect2Options)
+  $('.events-search').select2(eventsSelect2Options)
   $('.document-tag').select2(documentTagSelect2Options)
 
   $(document).on('nested:fieldAdded', (event) ->

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -19,7 +19,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       filtersHash.title_query = null
     @set('titleQuery', filtersHash.title_query)
     @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', filtersHash.event_type))
-    @set('selectedEventsIds', filtersHash.events_ids)
+    @set('selectedEventsIds', filtersHash.events_ids || [])
     allDocumentTypes = @get('controllers.events.documentTypes').concat @get('controllers.events.interSessionalDocumentTypes')
     @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
     @set('selectedProposalOutcomeId', filtersHash.proposal_outcome_id)

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -88,6 +88,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       @set('taxonConceptQueryForDisplay', '')
       @set('taxonConceptQuery', '')
       @set('selectedGeoEntities', [])
+      @set('selectedGeoEntitiesIds', [])
       @set('titleQuery', '')
       @set('selectedEventType', null)
       @set('selectedEvents', [])

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -19,7 +19,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       filtersHash.title_query = null
     @set('titleQuery', filtersHash.title_query)
     @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', filtersHash.event_type))
-    @set('selectedEventId', filtersHash.event_id)
+    @set('selectedEventsIds', filtersHash.events_ids)
     allDocumentTypes = @get('controllers.events.documentTypes').concat @get('controllers.events.interSessionalDocumentTypes')
     @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
     @set('selectedProposalOutcomeId', filtersHash.proposal_outcome_id)
@@ -35,7 +35,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),
       title_query: titleQuery,
       event_type: @get('selectedEventType.id'),
-      event_id: @get('selectedEvent.id'),
+      events_ids: @get('selectedEvents').mapProperty('id'),
       document_type: @get('selectedDocumentType.id'),
       proposal_outcome_id: @get('selectedProposalOutcome.id'),
     }
@@ -90,8 +90,8 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner, Spec
       @set('selectedGeoEntities', [])
       @set('titleQuery', '')
       @set('selectedEventType', null)
-      @set('selectedEvent', null)
-      @set('selectedEventId', null)
+      @set('selectedEvents', [])
+      @set('selectedEventsIds', [])
       @set('selectedDocumentType', null)
       @set('selectedInterSessionalDocType', null)
       @set('selectedProposalOutcome', null)

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -84,6 +84,3 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
   load: ->
     unless @get('loaded')
       @set('content', Species.Event.find())
-
-  handleLoadFinished: ->
-    @get('controllers.elibrarySearch').initEventSelector()

--- a/app/assets/javascripts/species/mixins/event_loader.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_loader.js.coffee
@@ -1,6 +1,4 @@
 Species.EventLoader = Ember.Mixin.create
   ensureEventsLoaded: (searchController) ->
-    if @controllerFor('events').get('loaded')
-      searchController.initEventSelector()
-    else
+    unless @controllerFor('events').get('loaded')
       @controllerFor('events').load()

--- a/app/assets/javascripts/species/mixins/event_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_lookup.js.coffee
@@ -1,11 +1,11 @@
 Species.EventLookup = Ember.Mixin.create
-  selectedEvent: null
-  selectedEventId: null
+  selectedEvents: []
+  selectedEventsIds: []
 
   initEventSelector: ->
-    @set('selectedEvent', @get('controllers.events.content').findBy('id', @get('selectedEventId')))
-    if @get('selectedEventType') == null && @get('selectedEvent')
-      @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', @get('selectedEvent.type')))
+    @set('selectedEvents', @get('controllers.events.content').findBy('id', @get('selectedEventsIds')))
+    if @get('selectedEventType') == null && @get('selectedEvents')
+      @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', @get('selectedEvents.type')))
 
   filteredEvents: ( ->
     if @get('selectedEventType')
@@ -26,21 +26,16 @@ Species.EventLookup = Ember.Mixin.create
     handleEventTypeSelection: (eventType) ->
       @set('selectedEventType', eventType)
       if @get('selectedEventType.id') != @get('selectedEvent.type')
-        @set('selectedEvent', null)
-        @set('selectedEventId', null)
+        @set('selectedEvents', [])
+        @set('selectedEventsIds', [])
       if (@get('selectedDocumentType.eventTypes') && @get('selectedDocumentType.eventTypes').indexOf(@get('selectedEvent.type')) < 0) || eventType.id == 'EcSrg'
         @set('selectedDocumentType', null)
 
     handleEventTypeDeselection: (eventType) ->
       @set('selectedEventType', null)
-      @set('selectedEvent', null)
-      @set('selectedEventId', null)
+      @set('selectedEvents', [])
+      @set('selectedEventsIds', [])
       @set('selectedDocumentType', null)
 
-    handleEventSelection: (event) ->
-      @set('selectedEvent', event)
-      @set('selectedEventId', event.id)
-
-    handleEventDeselection: (event) ->
-      @set('selectedEvent', null)
-      @set('selectedEventId', null)
+    deleteEventSelection: (context) ->
+      @get('selectedEvents').removeObject(context)

--- a/app/assets/javascripts/species/mixins/event_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_lookup.js.coffee
@@ -2,11 +2,6 @@ Species.EventLookup = Ember.Mixin.create
   selectedEvents: []
   selectedEventsIds: []
 
-  initEventSelector: ->
-    @set('selectedEvents', @get('controllers.events.content').findBy('id', @get('selectedEventsIds')))
-    if @get('selectedEventType') == null && @get('selectedEvents')
-      @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', @get('selectedEvents.type')))
-
   filteredEvents: ( ->
     if @get('selectedEventType')
       event_ids = @get('selectedEventType.id').split(',')

--- a/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
+++ b/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
@@ -1,0 +1,17 @@
+Species.MultipleSelectionSearchButton = Ember.Mixin.create
+  loading: ( ->
+    "loading" unless @get('loaded')
+  ).property('loaded').volatile()
+
+  template: Ember.Handlebars.compile("{{view.summary}}"),
+
+  click: (event, controller) ->
+    if @get('controller.isSearchContextDocuments') &&
+    @get('taxonConceptQuery') != @get('taxonConceptQueryLastCheck')
+      @set('taxonConceptQueryLastCheck', @get('taxonConceptQuery'))
+      if @get('taxonConceptQuery.length') >= 3
+        query = @get('taxonConceptQuery')
+      # we're in the E-Library search, need to check if
+      # filtering by taxon is required for locations
+      @get(controller).reload(query)
+    @handlePopupClick(event)

--- a/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
+++ b/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
@@ -1,4 +1,10 @@
 Species.MultipleSelectionSearchButton = Ember.Mixin.create
+  tagName: 'a'
+  href: '#'
+  classNames: ['link']
+  classNameBindings: ['loading']
+  shortPlaceholder: true
+
   loading: ( ->
     "loading" unless @get('loaded')
   ).property('loaded').volatile()

--- a/app/assets/javascripts/species/router.js.coffee
+++ b/app/assets/javascripts/species/router.js.coffee
@@ -13,7 +13,7 @@ Species.Router.map (match) ->
   @resource 'documents', {
     queryParams: [
       'taxon_concept_query', 'geo_entities_ids', 'title_query',
-      'event_type', 'event_id', 'document_type',
+      'event_type', 'events_ids', 'document_type',
       'proposal_outcome_id', 'review_phase_id'
     ]
   }

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -9,6 +9,10 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
     #dirty hack to check if we have an array or comma separated string here
     if queryParams.geo_entities_ids && queryParams.geo_entities_ids.substring
       queryParams.geo_entities_ids = queryParams.geo_entities_ids.split(',')
+    if queryParams.events_ids && queryParams.events_ids.substring
+      queryParams.events_ids = queryParams.events_ids.split(',')
+    queryParams.geo_entities_ids = [] if queryParams.geo_entities_ids == true
+    queryParams.events_ids = [] if queryParams.events_ids == true
     @controllerFor('elibrarySearch').setFilters(queryParams)
     $(@spinnerSelector).css("visibility", "visible")
     $('tr.group i.fa-minus-circle').click()

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -40,7 +40,7 @@
       </div>
 
       <div class="documents-control-group">
-        <div class="location-area popup-area">
+        <div {{bind-attr class=":popup-area :events-area selectedEventType:events-visible"}}>
           <label>Meeting</label>
           {{view Species.EventsSearchButton
             selectedEventsBinding="controller.selectedEvents"

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -40,16 +40,18 @@
       </div>
 
       <div class="documents-control-group">
-        {{single-dropdown
-          isVisible=controller.eventsDropdownVisible
-          action="handleEventSelection"
-          clearAction="handleEventDeselection"
-          title="Meeting"
-          placeholder="All meetings"
-          values=controller.filteredEvents
-          selection=controller.selectedEvent
-        }}
+        <div class="location-area popup-area">
+          <label>Meeting</label>
+          {{view Species.EventsSearchButton
+            selectedEventsBinding="controller.selectedEvents"
+            loadedBinding="events.loaded"
+            shortPlaceholder=false
+            taxonConceptQueryBinding="controller.taxonConceptQueryForDisplay"
+          }}
+          {{view Species.EventsSearchDropdown controllerBinding="controller"}}
+        </div>
       </div>
+
       <div class="documents-control-group">
         {{single-dropdown
           isVisible=controller.documentTypeDropdownVisible
@@ -61,6 +63,7 @@
           selection=controller.selectedDocumentType
         }}
       </div>
+
       <div class="documents-control-group">
         {{single-dropdown
           isVisible=controller.interSessionalDocTypeDropdownVisible
@@ -72,6 +75,7 @@
           selection=controller.selectedDocumentType
         }}
       </div>
+
       <div class="documents-control-group">
         {{single-dropdown
           isVisible=controller.proposalOutcomeDropdownVisible
@@ -83,6 +87,7 @@
           selection=controller.selectedProposalOutcome
         }}
       </div>
+
       <div class="documents-control-group">
         <label>Search by title keyword(s)
           <i class="fa fa-info-circle"

--- a/app/assets/javascripts/species/templates/events_search_dropdown.handlebars
+++ b/app/assets/javascripts/species/templates/events_search_dropdown.handlebars
@@ -1,0 +1,15 @@
+<div class="popup">
+  <div class="search-block01">
+    <strong class="title01">SELECTED MEETINGS</strong>
+    {{collection Species.SelectedEventsCollectionView
+      contentBinding="controller.selectedEvents"}}
+  </div>
+  <div class="list-holder">
+    <ul>
+      <li>
+        {{collection Species.EventsCollectionView
+          contentBinding="controller.filteredEvents"}}
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
@@ -1,9 +1,4 @@
 Species.EventsSearchButton = Ember.View.extend Species.MultipleSelectionSearchButton, Species.SearchFormDropdowns,
-  tagName: 'a'
-  href: '#'
-  classNames: ['link']
-  classNameBindings: ['loading']
-  shortPlaceholder: true
 
   summary: ( ->
     short = (@get('shortPlaceholder') == true)

--- a/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
@@ -1,0 +1,31 @@
+Species.EventsSearchButton = Ember.View.extend Species.MultipleSelectionSearchButton, Species.SearchFormDropdowns,
+  tagName: 'a'
+  href: '#'
+  classNames: ['link']
+  classNameBindings: ['loading']
+  shortPlaceholder: true
+
+  summary: ( ->
+    short = (@get('shortPlaceholder') == true)
+    if (@get('selectedEvents'))
+      if (@get('selectedEvents').length == 0)
+        if short
+          "MEETINGS"
+        else
+          "All meetings"
+      else if (@get('selectedEvents').length == 1)
+        if short
+          "1 MEET"
+        else
+         "1 meeting"
+      else
+        if short
+          @get('selectedEvents').length + " MEETS"
+        else
+          @get('selectedEvents').length + " meetings"
+    else
+      "MEETINGS"
+  ).property("selectedEvents.@each")
+
+  click: (event) ->
+    @_super(event, 'controller.events')

--- a/app/assets/javascripts/species/views/elibrary_search_form/events_search_dropdown.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/events_search_dropdown.js.coffee
@@ -1,0 +1,6 @@
+Species.EventsSearchDropdown = Ember.View.extend
+  templateName: 'species/events_search_dropdown'
+  classNames: ['popup-clickable', 'popup-holder01']
+  placeholder: ( ->
+      'Type to filter meetings'
+  ).property()

--- a/app/assets/javascripts/species/views/search_form/events_collection_view.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/events_collection_view.js.coffee
@@ -1,0 +1,16 @@
+Species.EventsCollectionView = Ember.CollectionView.extend
+  tagName: 'ul'
+  content: null
+
+  geoEntityType: null
+
+  emptyView: Ember.View.extend
+    template: Ember.Handlebars.compile("No matches")
+
+  itemViewClass: Ember.View.extend
+    contextBinding: 'content'
+    template: Ember.Handlebars.compile("{{unbound name}}")
+
+    click: (event) ->
+      @get('controller.selectedEvents').addObject(@get('context'))
+

--- a/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
@@ -1,9 +1,4 @@
 Species.GeoEntitiesSearchButton = Ember.View.extend Species.MultipleSelectionSearchButton, Species.SearchFormDropdowns,
-  tagName: 'a'
-  href: '#'
-  classNames: ['link']
-  classNameBindings: ['loading']
-  shortPlaceholder: true
 
   summary: ( ->
     short = (@get('shortPlaceholder') == true)

--- a/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
@@ -1,15 +1,9 @@
-Species.GeoEntitiesSearchButton = Ember.View.extend Species.SearchFormDropdowns,
+Species.GeoEntitiesSearchButton = Ember.View.extend Species.MultipleSelectionSearchButton, Species.SearchFormDropdowns,
   tagName: 'a'
   href: '#'
   classNames: ['link']
   classNameBindings: ['loading']
   shortPlaceholder: true
-
-  loading: ( ->
-    "loading" unless @get('loaded')
-  ).property('loaded').volatile()
-
-  template: Ember.Handlebars.compile("{{view.summary}}"),
 
   summary: ( ->
     short = (@get('shortPlaceholder') == true)
@@ -31,12 +25,4 @@ Species.GeoEntitiesSearchButton = Ember.View.extend Species.SearchFormDropdowns,
   ).property("selectedGeoEntities.@each")
 
   click: (event) ->
-    if @get('controller.isSearchContextDocuments') &&
-    @get('taxonConceptQuery') != @get('taxonConceptQueryLastCheck')
-      @set('taxonConceptQueryLastCheck', @get('taxonConceptQuery'))
-      if @get('taxonConceptQuery.length') >= 3
-        query = @get('taxonConceptQuery')
-      # we're in the E-Library search, need to check if
-      # filtering by taxon is required for locations
-      @get('controller.geoEntities').reload(query)
-    @handlePopupClick(event)
+    @_super(event, 'controller.geoEntities')

--- a/app/assets/javascripts/species/views/search_form/selected_events_collection_view.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/selected_events_collection_view.js.coffee
@@ -1,0 +1,11 @@
+Species.SelectedEventsCollectionView = Ember.CollectionView.extend
+  tagName: 'ul',
+  content: null,
+
+  geoEntityType: null,
+
+  itemViewClass: Ember.View.extend
+    contextBinding: 'content',
+    template: Ember.Handlebars.compile(
+      '{{name}} <span {{action "deleteEventSelection" this}} class="delete">x</span>'
+    )

--- a/app/assets/stylesheets/admin/documents.scss
+++ b/app/assets/stylesheets/admin/documents.scss
@@ -1,0 +1,1 @@
+.events-search { padding-bottom: 10px; }

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -410,3 +410,6 @@ html.lt-ie9 .search-block .search-form {
   line-height: 30px;
   color: #2d3237;
 }
+
+.events-area { display: none; }
+.events-visible { display: block; }

--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -6,7 +6,8 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
     load_associations
     @search = DocumentSearch.new(params.merge(show_private: true), 'admin')
     index! do
-      if @event.present?
+      if @search.events_ids.present? && @search.events_ids.length == 1
+        @event = Event.find(@search.events_ids.first)
         render 'admin/event_documents/index'
       else
         render 'index'

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -126,7 +126,7 @@ class DocumentSearch
     return if @title_query.present?
 
     @query = if @events_ids.present?
-      @query.order([:date_raw, :title])
+      @query.order(['date_raw DESC', :title])
     else
       @query.order('created_at DESC')
     end

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -1,7 +1,7 @@
 class DocumentSearch
   include CacheIterator
   include SearchCache # this provides #cached_results and #cached_total_cnt
-  attr_reader :page, :per_page, :offset, :event_type, :event_id,
+  attr_reader :page, :per_page, :offset, :event_type, :event_ids,
     :document_type, :title_query
 
   def initialize(options, interface)
@@ -67,8 +67,8 @@ class DocumentSearch
   end
 
   def add_conditions_for_event
-    if @event_id.present?
-      @query = @query.where(event_id: @event_id)
+    if @event_ids.present?
+      @query = @query.where(event_id: @event_ids)
       return
     end
     return unless @event_type.present?
@@ -125,7 +125,7 @@ class DocumentSearch
   def add_ordering_for_admin
     return if @title_query.present?
 
-    @query = if @event_id.present?
+    @query = if @event_ids.present?
       @query.order([:date_raw, :title])
     else
       @query.order('created_at DESC')

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -1,7 +1,7 @@
 class DocumentSearch
   include CacheIterator
   include SearchCache # this provides #cached_results and #cached_total_cnt
-  attr_reader :page, :per_page, :offset, :event_type, :event_ids,
+  attr_reader :page, :per_page, :offset, :event_type, :events_ids,
     :document_type, :title_query
 
   def initialize(options, interface)
@@ -67,8 +67,8 @@ class DocumentSearch
   end
 
   def add_conditions_for_event
-    if @event_ids.present?
-      @query = @query.where(event_id: @event_ids)
+    if @events_ids.present?
+      @query = @query.where(event_id: @events_ids)
       return
     end
     return unless @event_type.present?
@@ -125,7 +125,7 @@ class DocumentSearch
   def add_ordering_for_admin
     return if @title_query.present?
 
-    @query = if @event_ids.present?
+    @query = if @events_ids.present?
       @query.order([:date_raw, :title])
     else
       @query.order('created_at DESC')

--- a/app/models/document_search_params.rb
+++ b/app/models/document_search_params.rb
@@ -6,7 +6,7 @@ class DocumentSearchParams < Hash
 
   def initialize(params)
     sanitized_params = {
-      event_ids: sanitise_integer_array(params['events_ids']),
+      events_ids: sanitise_integer_array(params['events_ids']),
       event_type: sanitise_string(params['event_type']),
       document_type: sanitise_string(params['document_type']),
       title_query: sanitise_string(params['title_query']),

--- a/app/models/document_search_params.rb
+++ b/app/models/document_search_params.rb
@@ -6,7 +6,7 @@ class DocumentSearchParams < Hash
 
   def initialize(params)
     sanitized_params = {
-      event_id: sanitise_string(params['event_id']),
+      event_ids: sanitise_integer_array(params['events_ids']),
       event_type: sanitise_string(params['event_type']),
       document_type: sanitise_string(params['document_type']),
       title_query: sanitise_string(params['title_query']),

--- a/app/views/admin/documents/index.html.erb
+++ b/app/views/admin/documents/index.html.erb
@@ -40,9 +40,9 @@
         <%= select_tag 'event_id_search',
           options_for_select(
             @events.map { |e| [e.name, e.id, {:class => e.type}] },
-            @search.event_id
+            @search.events_ids
           ), {
-            :prompt => 'Select an event...', class: 'input-large', name: 'event_id'
+            class: 'events-search', name: 'events_ids[]', multiple: true
           }
         %>
         <%= select_tag 'document_type', options_for_select(

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Admin::DocumentsController, sidekiq: :inline do
   login_admin
   let(:event){ create(:event, published_at: DateTime.new(2014,12,25)) }
+  let(:event2){ create(:event, published_at: DateTime.new(2015,12,12)) }
   let(:taxon_concept){ create(:taxon_concept) }
   let(:geo_entity){ create(:geo_entity) }
   let(:proposal_outcome){ create(:proposal_outcome) }
@@ -98,12 +99,14 @@ describe Admin::DocumentsController, sidekiq: :inline do
 
       context "when event" do
         it "renders the event/documents/index template" do
-          get :index, event_id: event.id
+          get :index, events_ids: [event.id]
           response.should render_template('admin/event_documents/index')
         end
         it "assigns @documents for event, sorted by title" do
-          get :index, event_id: event.id
-          assigns(:documents).should eq([@document2, @document1])
+          @document3 = create(:document, title: 'CC hello world', event: event2)
+          DocumentSearch.refresh
+          get :index, events_ids: [event.id, event2.id]
+          assigns(:documents).should eq([@document2, @document1, @document3])
         end
       end
     end

--- a/spec/controllers/admin/documents_controller_spec.rb
+++ b/spec/controllers/admin/documents_controller_spec.rb
@@ -106,7 +106,7 @@ describe Admin::DocumentsController, sidekiq: :inline do
           @document3 = create(:document, title: 'CC hello world', event: event2)
           DocumentSearch.refresh
           get :index, events_ids: [event.id, event2.id]
-          assigns(:documents).should eq([@document2, @document1, @document3])
+          assigns(:documents).should eq([@document3, @document2, @document1])
         end
       end
     end


### PR DESCRIPTION
[Select multiple meetings in documents search](https://www.pivotaltracker.com/story/show/109874910)

The selection of meetings should now work more or less like the country selection, except that no search/autocompletion is provided. Common functionalities between the two have been extracted in a mixin. Also, the meetings dropdown should appear just if the event type has been provided.

The backend logic has been adjusted accordingly, in order to accept multiple events. Also, the admin documents search has been provided with the same functionality, keeping the same behaviour if just an event has been selected(event list show page rather than index page).