### PR TITLE
fixes filtering list of locations by taxon concept citations

### DIFF
--- a/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
+++ b/app/assets/javascripts/species/mixins/multiple_selection_search_button.js.coffee
@@ -10,14 +10,3 @@ Species.MultipleSelectionSearchButton = Ember.Mixin.create
   ).property('loaded').volatile()
 
   template: Ember.Handlebars.compile("{{view.summary}}"),
-
-  click: (event, controller) ->
-    if @get('controller.isSearchContextDocuments') &&
-    @get('taxonConceptQuery') != @get('taxonConceptQueryLastCheck')
-      @set('taxonConceptQueryLastCheck', @get('taxonConceptQuery'))
-      if @get('taxonConceptQuery.length') >= 3
-        query = @get('taxonConceptQuery')
-      # we're in the E-Library search, need to check if
-      # filtering by taxon is required for locations
-      @get(controller).reload(query)
-    @handlePopupClick(event)

--- a/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/events_search_button.js.coffee
@@ -21,6 +21,3 @@ Species.EventsSearchButton = Ember.View.extend Species.MultipleSelectionSearchBu
     else
       "MEETINGS"
   ).property("selectedEvents.@each")
-
-  click: (event) ->
-    @_super(event, 'controller.events')

--- a/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/geo_entities_search_button.js.coffee
@@ -20,4 +20,12 @@ Species.GeoEntitiesSearchButton = Ember.View.extend Species.MultipleSelectionSea
   ).property("selectedGeoEntities.@each")
 
   click: (event) ->
-    @_super(event, 'controller.geoEntities')
+    if @get('controller.isSearchContextDocuments') &&
+    @get('taxonConceptQuery') != @get('taxonConceptQueryLastCheck')
+      @set('taxonConceptQueryLastCheck', @get('taxonConceptQuery'))
+      if @get('taxonConceptQuery.length') >= 3
+        query = @get('taxonConceptQuery')
+      # we're in the E-Library search, need to check if
+      # filtering by taxon is required for locations
+      @get('controller.geoEntities').reload(query)
+    @handlePopupClick(event)

--- a/app/controllers/api/v1/document_geo_entities_controller.rb
+++ b/app/controllers/api/v1/document_geo_entities_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::DocumentGeoEntitiesController < ApplicationController
           document_citation: :document_citation_taxon_concepts
         }
       ).where(
-        'document_citation_taxon_concepts.taxon_concept_id': @species_search.ids
+        'document_citation_taxon_concepts.taxon_concept_id' => @species_search.ids
       )
     end
 


### PR DESCRIPTION
Restores the functionality to filter locations in the document search form by citations of a taxon concept, when a taxon concept query longer than 3 characters has been provided. Hopefully doesn't break anything to do with multiple selection of events.