### PR TITLE
Fix floating new-tag when searching documents

### DIFF
--- a/app/assets/stylesheets/species/tabset-top-level.scss
+++ b/app/assets/stylesheets/species/tabset-top-level.scss
@@ -1,5 +1,6 @@
 #main .tabset.top-level, .inner .tabset.top-level {
   margin: 0 0 -1px 0;
+  position: relative;
 
   li {
     float: left;


### PR DESCRIPTION
Set the position of the tabset to relative so to adjust the position of the new-tag.
