### PR TITLE
Fix propagation of english notes in other language versions

### DIFF
--- a/app/models/m_listing_change.rb
+++ b/app/models/m_listing_change.rb
@@ -11,6 +11,7 @@ module MListingChange
       translates :full_note, fallback: false
       translates :hash_full_note, :inherited_short_note, :inherited_full_note,
         :auto_note, :party_full_name
+      translates :nomenclature_note, fallback: false
     end
   end
 

--- a/app/models/m_listing_change.rb
+++ b/app/models/m_listing_change.rb
@@ -41,10 +41,6 @@ module MListingChange
     CountryDictionary.instance.get_names_by_ids(countries_ids).compact
   end
 
-  def nomenclature_note
-    self.nomenclature_note_en
-  end
-
   def to_timeline_event
     Checklist::TimelineEvent.new(
       self.as_json(

--- a/app/models/nomenclature_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/constructor_helpers.rb
@@ -184,7 +184,7 @@ module NomenclatureChange::ConstructorHelpers
       I18n.translate(
         'in_year',
         year: event && event.effective_at.try(:year) || Date.today.year,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end
@@ -197,7 +197,7 @@ module NomenclatureChange::ConstructorHelpers
           I18n.translate(
             note_type,
             input_taxon: input_html, output_taxon: output_html,
-            default: 'Translation missing'
+            default: ''
           )
         end
       end

--- a/app/models/nomenclature_change/lump/constructor.rb
+++ b/app/models/nomenclature_change/lump/constructor.rb
@@ -59,7 +59,7 @@ class NomenclatureChange::Lump::Constructor
         'lump.input_lumped_into',
         input_taxon: input_html,
         output_taxon: output_html,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end
@@ -74,7 +74,7 @@ class NomenclatureChange::Lump::Constructor
         'lump.output_lumped_from',
         output_taxon: output_html,
         input_taxa: inputs_html,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end
@@ -124,13 +124,13 @@ class NomenclatureChange::Lump::Constructor
     output = @nomenclature_change.output
     input_html = taxon_concept_html('[[input]]', output.display_rank_name)
     output_html = taxon_concept_html(output.display_full_name, output.display_rank_name)
-    note = '<p>'
+    note = ''
     note << yield(input_html, output_html)
     note << in_year(@nomenclature_change.event, lng)
     if @nomenclature_change.event
       note << following_taxonomic_changes(@nomenclature_change.event, lng)
     end
-    note + '.</p>'
+    note = "<p>#{note}.</p>" if note.present?
   end
 
   def multi_lingual_listing_change_note

--- a/app/models/nomenclature_change/split/constructor.rb
+++ b/app/models/nomenclature_change/split/constructor.rb
@@ -89,7 +89,7 @@ class NomenclatureChange::Split::Constructor
         'split.input_split_into',
         output_taxa: outputs_html,
         input_taxon: input_html,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end
@@ -115,7 +115,7 @@ class NomenclatureChange::Split::Constructor
         'split.output_split_from',
         output_taxon: output_html,
         input_taxon: input_html,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end

--- a/app/models/nomenclature_change/split/constructor.rb
+++ b/app/models/nomenclature_change/split/constructor.rb
@@ -165,13 +165,13 @@ class NomenclatureChange::Split::Constructor
     input = @nomenclature_change.input
     input_html = taxon_concept_html(input.taxon_concept.full_name, input.taxon_concept.rank.name)
     output_html = taxon_concept_html('[[output]]', input.taxon_concept.rank.name)
-    note = '<p>'
+    note = ''
     note << yield(input_html, output_html)
     note << in_year(@nomenclature_change.event, lng)
     if @nomenclature_change.event
       note << following_taxonomic_changes(@nomenclature_change.event, lng)
     end
-    note + '.</p>'
+    note = "<p>#{note}.</p>" if note.present?
   end
 
   def multi_lingual_listing_change_note

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -82,7 +82,7 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
         "status_change.status_elevated_to_accepted_name",
         output_new_taxon: output_new_html,
         output_old_taxon: output_old_html,
-        default: 'Translation missing'
+        default: ''
       )
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ SAPI::Application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = false
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -59,7 +59,7 @@ SAPI::Application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = false
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify


### PR DESCRIPTION
This PR fixes [English notes in other language versions of the CITES checklist](https://www.pivotaltracker.com/story/show/120944363).
The issue was about the configuration, in staging and production, of the I18n library falling back to english when no translation was found, preventing to using the default message instead.
The default message has also been replaced with an empty string rather than "Translation Missing"