### PR TITLE
Hotfix 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.10.1 - E-Library bug fix (deleting documents)
+
 ### 0.10.0 - E-Library
 
 ### 0.9.6.4

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -21,7 +21,7 @@
     <fieldset>
       <div class="documents-control-group">
         <div class="location-area popup-area">
-          <label>Country <i class="fa fa-info-circle" title="Including territories and historic names"></i></label>
+          <label>Countries and territories <i class="fa fa-info-circle" title="Including historic names"></i></label>
           {{view Species.GeoEntitiesSearchButton
             selectedGeoEntitiesBinding="controller.selectedGeoEntities"
             loadedBinding="geoEntities.loaded"

--- a/db/migrate/20160621093131_change_foreign_key_constraint_on_delete_in_document_details.rb
+++ b/db/migrate/20160621093131_change_foreign_key_constraint_on_delete_in_document_details.rb
@@ -1,0 +1,8 @@
+class ChangeForeignKeyConstraintOnDeleteInDocumentDetails < ActiveRecord::Migration
+  def change
+    remove_foreign_key(:proposal_details, :documents)
+    remove_foreign_key(:review_details, :documents)
+    add_foreign_key(:proposal_details, :documents, dependent: :delete)
+    add_foreign_key(:review_details, :documents, dependent: :delete)
+  end
+end


### PR DESCRIPTION
Fix for issue:
https://www.pivotaltracker.com/story/show/121857537

and small wording change requested in:
https://www.pivotaltracker.com/story/show/121226913

The issue was caused by records in `review_details` linked to a RST document, which would prevent it from being deleted. We already had `dependent: :destroy` in the AR model, but that was not enough. The relation between `documents` and `review_details` is a `has_one`,  which means it would attempt to delete only one linked record. Yet it turned out some documents have more than one details record linked, possibly due to import errors. After amending the foreign key constraint on the db level, all linked records are deleted with document. 