### PR TITLE
calculate higher taxa for N taxon concepts

### DIFF
--- a/db/plpgsql/002_rebuild_taxonomy.sql
+++ b/db/plpgsql/002_rebuild_taxonomy.sql
@@ -261,7 +261,7 @@ CREATE OR REPLACE FUNCTION rebuild_taxonomy_for_node(node_id integer) RETURNS vo
       FROM taxon_concepts h
       INNER JOIN taxon_names ON h.taxon_name_id = taxon_names.id
       INNER JOIN ranks ON h.rank_id = ranks.id
-      WHERE name_status = 'A' AND
+      WHERE name_status IN ('A', 'N') AND
         CASE
         WHEN node_id IS NOT NULL THEN h.id = node_id
         ELSE h.parent_id IS NULL
@@ -275,7 +275,7 @@ CREATE OR REPLACE FUNCTION rebuild_taxonomy_for_node(node_id integer) RETURNS vo
       hstore(LOWER(ranks.name) || '_id', (hi.id)::VARCHAR)
       FROM q
       JOIN taxon_concepts hi
-      ON hi.parent_id = q.id AND hi.name_status = 'A'
+      ON hi.parent_id = q.id AND hi.name_status IN ('A', 'N')
       INNER JOIN taxon_names ON hi.taxon_name_id = taxon_names.id
       INNER JOIN ranks ON hi.rank_id = ranks.id
     )


### PR DESCRIPTION
This change to to ensure higher taxa are being calculated for `N` taxon concepts overnight. This is consistent with the logic that happens in the `TaxonConceptObserver` (populating the `data` hstore field with names and ids of higher taxa).

This has probably no direct impact on Species+; however, it is necessary to ensure correct automated mapping of taxon concepts and taxon groups in CITES Dashbards. That mapping relies on higher taxa being available for both `A` and `N` taxon concepts. 

https://github.com/unepwcmc/cites_dashboards