### PR TITLE
inform user when deleting taxon concept blocked by existing document citations

### DIFF
--- a/app/models/taxon_concept.rb
+++ b/app/models/taxon_concept.rb
@@ -170,6 +170,7 @@ class TaxonConcept < ActiveRecord::Base
   has_many :nomenclature_change_outputs, class_name: 'NomenclatureChange::Output'
   has_many :nomenclature_change_outputs_as_new, class_name: 'NomenclatureChange::Output',
     foreign_key: :new_taxon_concept_id
+  has_many :document_citation_taxon_concepts
 
   validates :taxonomy_id, :presence => true
   validates :rank_id, :presence => true
@@ -449,7 +450,8 @@ class TaxonConcept < ActiveRecord::Base
       'shipments (reported as)' => reported_shipments,
       'nomenclature changes (as input)' => nomenclature_change_inputs,
       'nomenclature changes (as output)' => nomenclature_change_outputs,
-      'nomenclature changes (as new output)' => nomenclature_change_outputs_as_new
+      'nomenclature changes (as new output)' => nomenclature_change_outputs_as_new,
+      'document citations' => document_citation_taxon_concepts
     }
   end
 

--- a/spec/models/taxon_concept/destroy_spec.rb
+++ b/spec/models/taxon_concept/destroy_spec.rb
@@ -19,6 +19,12 @@ describe TaxonConcept do
         before(:each) { create(:taxon_concept_reference, :taxon_concept => @taxon_concept) }
         specify { @taxon_concept.destroy.should be_true }
       end
+      context "when document citations" do
+        before(:each) do
+          create(:document_citation_taxon_concept, taxon_concept: @taxon_concept)
+        end
+        specify { @taxon_concept.destroy.should be_false }
+      end
     end
     context "CMS" do
       before(:each) { @taxon_concept = create_cms_species }


### PR DESCRIPTION
To do with https://appsignal.com/wcmc/sites/56c5d74b776f725e76821201/web/exceptions/Admin::TaxonConceptsController-hash-destroy/ActiveRecord::InvalidForeignKey