### PR TITLE
Nomenclature change documents split

### DIFF
--- a/app/controllers/admin/nomenclature_changes/split_controller.rb
+++ b/app/controllers/admin/nomenclature_changes/split_controller.rb
@@ -28,6 +28,7 @@ class Admin::NomenclatureChanges::SplitController < Admin::NomenclatureChanges::
       builder.build_legislation_reassignments
       skip_or_previous_step if @nomenclature_change.input.legislation_reassignments.empty?
     when :summary
+      builder.build_document_reassignments
       processor = NomenclatureChange::Split::Processor.new(@nomenclature_change)
       @summary = processor.summary
     end

--- a/app/models/nomenclature_change/document_citation_reassignment.rb
+++ b/app/models/nomenclature_change/document_citation_reassignment.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: nomenclature_change_reassignments
+#
+#  id                           :integer          not null, primary key
+#  nomenclature_change_input_id :integer          not null
+#  type                         :string(255)      not null
+#  reassignable_type            :string(255)
+#  reassignable_id              :integer
+#  note_en                      :text
+#  note_es                      :text
+#  note_fr                      :text
+#  internal_note                :text
+#  created_by_id                :integer          not null
+#  updated_by_id                :integer          not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+
+class NomenclatureChange::DocumentCitationReassignment < NomenclatureChange::Reassignment
+  belongs_to :input, class_name: NomenclatureChange::Input,
+    inverse_of: :document_citation_reassignments,
+    foreign_key: :nomenclature_change_input_id
+end

--- a/app/models/nomenclature_change/input.rb
+++ b/app/models/nomenclature_change/input.rb
@@ -57,6 +57,12 @@ class NomenclatureChange::Input < ActiveRecord::Base
     foreign_key: :nomenclature_change_input_id,
     dependent: :destroy,
     autosave: true
+  has_many :document_citation_reassignments,
+    inverse_of: :input,
+    class_name: 'NomenclatureChange::DocumentCitationReassignment',
+    foreign_key: :nomenclature_change_input_id,
+    dependent: :destroy,
+    autosave: true
   validates :nomenclature_change, :presence => true
   validates :taxon_concept, :presence => true
   accepts_nested_attributes_for :parent_reassignments, :allow_destroy => true
@@ -131,5 +137,9 @@ class NomenclatureChange::Input < ActiveRecord::Base
 
   def legislation_reassignment_class
     NomenclatureChange::LegislationReassignment
+  end
+
+  def document_citation_reassignment_class
+    NomenclatureChange::DocumentCitationReassignment
   end
 end

--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -23,6 +23,10 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
 
       reassignable.taxon_concept_id = new_taxon_concept.id
       reassignable
+    elsif reassignable.is_a?(DocumentCitation)
+      reassignable.document_citation_taxon_concepts <<
+        DocumentCitationTaxonConcept.new(taxon_concept_id: new_taxon_concept.id)
+      reassignable
     else
       # Each reassignable object implements find_duplicate,
       # which is called from here to make sure we're not adding a duplicate.

--- a/app/models/nomenclature_change/reassignment_summarizer.rb
+++ b/app/models/nomenclature_change/reassignment_summarizer.rb
@@ -10,6 +10,7 @@ class NomenclatureChange::ReassignmentSummarizer
       output_children_summary,
       output_names_summary,
       output_distribution_summary,
+      output_documents_summary,
       output_generic_summary(
         @input.taxon_concept.taxon_commons,
         'TaxonCommon', 'common names'
@@ -89,6 +90,21 @@ class NomenclatureChange::ReassignmentSummarizer
         ).count
       end
     "#{cnt} (of #{distributions_cnt}) distributions"
+  end
+
+  def output_documents_summary
+    document_citations_cnt = @input.taxon_concept.document_citation_taxon_concepts.count
+    return nil unless document_citations_cnt > 0
+    cnt =
+      if @input.is_a?(NomenclatureChange::Output)
+        document_citations_cnt
+      else
+        @input.document_citation_reassignments.includes(:reassignment_targets).
+          where(
+            'nomenclature_change_reassignment_targets.nomenclature_change_output_id' => @output.id
+        ).count
+      end
+    "#{cnt} (of #{document_citations_cnt}) document citations"
   end
 
   def output_legislation_summary(rel, reassignable_type, title)

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -20,6 +20,10 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
       reassignment.kind_of?(NomenclatureChange::OutputParentReassignment)
       reassignable.parent_id = new_taxon_concept.id
       reassignable
+    elsif reassignable.is_a?(DocumentCitation)
+      reassignable.document_citation_taxon_concepts <<
+        DocumentCitationTaxonConcept.new(taxon_concept_id: new_taxon_concept.id)
+      reassignable
     else
       # Each reassignable object implements find_duplicate,
       # which is called from here to make sure we're not adding a duplicate.

--- a/app/models/nomenclature_change/split/constructor.rb
+++ b/app/models/nomenclature_change/split/constructor.rb
@@ -58,6 +58,15 @@ class NomenclatureChange::Split::Constructor
     end
   end
 
+  def build_document_reassignments
+    input = @nomenclature_change.input
+    outputs = @nomenclature_change.outputs
+    _build_document_reassignments(input, outputs)
+    outputs_for_reassignments.each do |output|
+      _build_document_reassignments(output, [output])
+    end
+  end
+
   def build_common_names_reassignments
     input = @nomenclature_change.input
     _build_common_names_reassignments(@nomenclature_change.input, @nomenclature_change.outputs)

--- a/spec/models/nomenclature_change/shared/document_reassignments_constructor_examples.rb
+++ b/spec/models/nomenclature_change/shared/document_reassignments_constructor_examples.rb
@@ -1,0 +1,15 @@
+shared_context 'document_reassignments_constructor_examples' do
+  context "when previously no reassignments in place" do
+    context "when no document citations" do
+      specify { expect(input.document_citation_reassignments.size).to eq(0) }
+    end
+    context "when document citations" do
+      let(:input_species) {
+        s = create_cites_eu_species
+        2.times { create(:document_citation_taxon_concept, taxon_concept: s) }
+        s
+      }
+      specify { expect(input.document_citation_reassignments.size).to eq(2) }
+    end
+  end
+end

--- a/spec/models/nomenclature_change/split/constructor_spec.rb
+++ b/spec/models/nomenclature_change/split/constructor_spec.rb
@@ -144,6 +144,12 @@ describe NomenclatureChange::Split::Constructor do
       end
       include_context 'distribution_reassignments_constructor_examples'
     end
+    describe :build_documents_reassignments do
+      before(:each) do
+        constructor.build_document_reassignments
+      end
+      include_context 'document_reassignments_constructor_examples'
+    end
     describe :build_legislation_reassignments do
       before(:each) do
         @old_reassignments = input.legislation_reassignments


### PR DESCRIPTION
This is a first iteration on document reassignments for the split.
The reassignment happens at the `DocumentCitation` level. A new `Document Citation` is created  whenever the distribution conditions are met and gets populated with the corresponding `DocumentCitationGeoEntities` and `DocumentCitationTaxonConcept`.
The matching conditions for copying a document citation are the following:
  - If at least a country is in the distribution reassignments appears in the document citation geo_entities
  - If the document citation geo_entities list is empty
  - If none of the countries in the document citation geo_entities list matches the distribution

Simple tests has been added and more to be done soon. I thought that at this stage it would be better to finalise the implementation first, in order to work on other nomenclature changes asap. 