### PR TITLE
Nomenclature change documents swap

### DIFF
--- a/app/models/document_citation_geo_entity.rb
+++ b/app/models/document_citation_geo_entity.rb
@@ -16,6 +16,10 @@ class DocumentCitationGeoEntity < ActiveRecord::Base
   attr_accessible :created_by_id, :document_citation_id, :geo_entity_id, :updated_by_id
   belongs_to :geo_entity
   belongs_to :document_citation, touch: true
+  validates :geo_entity_id, uniqueness: {
+    scope: :document_citation_id,
+    message: 'geo entity citation already present'
+  }
 
   after_destroy do |dc_ge|
     dc_ge.document_citation.touch

--- a/app/models/document_citation_taxon_concept.rb
+++ b/app/models/document_citation_taxon_concept.rb
@@ -16,6 +16,10 @@ class DocumentCitationTaxonConcept < ActiveRecord::Base
   attr_accessible :created_by_id, :document_citation_id, :taxon_concept_id, :updated_by_id
   belongs_to :taxon_concept
   belongs_to :document_citation, touch: true
+  validates :taxon_concept_id, uniqueness: {
+    scope: :document_citation_id,
+    message: 'taxon_concept citation already present'
+  }
 
   after_destroy do |dc_tc|
     dc_tc.document_citation.touch

--- a/app/models/nomenclature_change/full_reassignment.rb
+++ b/app/models/nomenclature_change/full_reassignment.rb
@@ -37,6 +37,9 @@ class NomenclatureChange::FullReassignment
     # common names
     Rails.logger.debug "FULL REASSIGNMENT Common names (#{@old_taxon_concept.taxon_commons.count})"
     @old_taxon_concept.taxon_commons.update_all(update_attrs)
+    # document citations
+    Rails.logger.debug "FULL REASSIGNMENT Document Citations (#{@old_taxon_concept.document_citation_taxon_concepts.count})"
+    @old_taxon_concept.document_citation_taxon_concepts.update_all(update_attrs)
     # shipments
     Rails.logger.debug "FULL REASSIGNMENT Shipments"
     Trade::Shipment.update_all(

--- a/app/models/nomenclature_change/processor.rb
+++ b/app/models/nomenclature_change/processor.rb
@@ -11,6 +11,7 @@ class NomenclatureChange::Processor
     Rails.logger.warn("[#{@nc.type}] BEGIN")
     @subprocessors.each { |processor| processor.run }
     Rails.logger.warn("[#{@nc.type}] END")
+    DocumentSearch.refresh_citations_and_documents
     DownloadsCache.clear
   end
 

--- a/app/models/nomenclature_change/reassignment_transfer_processor.rb
+++ b/app/models/nomenclature_change/reassignment_transfer_processor.rb
@@ -21,6 +21,11 @@ class NomenclatureChange::ReassignmentTransferProcessor < NomenclatureChange::Re
       reassignable.parent_id = new_taxon_concept.id
       reassignable
     elsif reassignable.is_a?(DocumentCitation)
+      old_taxon_concept = @input.taxon_concept
+      reassignable.
+        document_citation_taxon_concepts.
+        find_by_taxon_concept_id(old_taxon_concept.id).
+        try(:destroy)
       reassignable.document_citation_taxon_concepts <<
         DocumentCitationTaxonConcept.new(taxon_concept_id: new_taxon_concept.id)
       reassignable

--- a/app/models/nomenclature_change/status_change/constructor_helpers.rb
+++ b/app/models/nomenclature_change/status_change/constructor_helpers.rb
@@ -68,6 +68,12 @@ module NomenclatureChange::StatusChange::ConstructorHelpers
     end
   end
 
+  def build_documents_reassignments
+    input_output_for_reassignment do |input, output|
+      _build_document_reassignments(input, [output])
+    end
+  end
+
   def status_elevated_to_accepted_name(output_new, output_old, lng)
     output_new_html = taxon_concept_html(
       output_new.display_full_name,

--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -28,7 +28,9 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
   }
   validate :required_secondary_output, if: :secondary_output_or_submitting?
   validate :required_primary_output_name_status, if: :primary_output_or_submitting?
+  before_validation :set_primary_output_name_status, if: :primary_output_or_submitting?
   validate :required_secondary_output_name_status, if: :secondary_output_or_submitting?
+  before_validation :set_secondary_output_name_status, if: :secondary_output_or_submitting?
   before_save :build_input_for_auto_reassignments, if: :secondary_output?
   before_save :build_auto_reassignments, if: :notes?
 
@@ -54,6 +56,14 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
       return false
     end
     true
+  end
+
+  def set_primary_output_name_status
+    primary_output && primary_output.new_name_status = 'S'
+  end
+
+  def set_secondary_output_name_status
+    secondary_output && secondary_output.new_name_status = 'A'
   end
 
   def needs_to_receive_associations?

--- a/app/models/nomenclature_change/status_swap.rb
+++ b/app/models/nomenclature_change/status_swap.rb
@@ -79,6 +79,7 @@ class NomenclatureChange::StatusSwap < NomenclatureChange
       builder.build_legislation_reassignments
       builder.build_common_names_reassignments
       builder.build_references_reassignments
+      builder.build_documents_reassignments
     end
     true
   end

--- a/spec/factories/nomenclature_changes.rb
+++ b/spec/factories/nomenclature_changes.rb
@@ -54,6 +54,9 @@ FactoryGirl.define do
     factory :nomenclature_change_legislation_reassignment do
       type 'NomenclatureChange::LegislationReassignment'
     end
+    factory :nomenclature_change_document_citation_reassignment do
+      type 'NomenclatureChange::DocumentCitationReassignment'
+    end
   end
 
   factory :nomenclature_change_output_reassignment, class: NomenclatureChange::OutputReassignment,

--- a/spec/models/nomenclature_change/full_reassignment_spec.rb
+++ b/spec/models/nomenclature_change/full_reassignment_spec.rb
@@ -73,6 +73,21 @@ describe NomenclatureChange::FullReassignment do
       specify { expect(new_tc.taxon_commons.count).to eq(1) }
     end
 
+    context 'when document citations present' do
+      before(:each) do
+        create(
+          :document_citation_taxon_concept,
+          taxon_concept: old_tc,
+          document_citation: create(
+            :document_citation,
+            document: create(:document)
+          )
+        )
+        subject.process
+      end
+      specify { expect(new_tc.document_citation_taxon_concepts.count).to eq(1) }
+    end
+
   end
 
 end

--- a/spec/models/nomenclature_change/reassignment_copy_processor_spec.rb
+++ b/spec/models/nomenclature_change/reassignment_copy_processor_spec.rb
@@ -35,6 +35,10 @@ describe NomenclatureChange::ReassignmentCopyProcessor do
       include_context 'reference_reassignments_processor_examples'
       specify { expect(input_species.taxon_concept_references.count).to eq(2) }
     end
+    context "when document citations" do
+      include_context 'document_reassignments_processor_examples'
+      specify { expect(input_species.document_citation_taxon_concepts.count).to eq(1) }
+    end
     context "when shipments" do
       include_context 'shipment_reassignments_processor_examples'
     end

--- a/spec/models/nomenclature_change/reassignment_transfer_processor_spec.rb
+++ b/spec/models/nomenclature_change/reassignment_transfer_processor_spec.rb
@@ -35,6 +35,10 @@ describe NomenclatureChange::ReassignmentTransferProcessor do
         include_context 'reference_reassignments_processor_examples'
         specify { expect(input_species.taxon_concept_references).to be_empty }
       end
+      context "when document citations" do
+        include_context 'document_reassignments_processor_examples'
+        specify { expect(input_species.document_citation_taxon_concepts).to be_empty }
+      end
       context "when shipments" do
         include_context 'shipment_reassignments_processor_examples'
       end
@@ -65,6 +69,9 @@ describe NomenclatureChange::ReassignmentTransferProcessor do
       end
       context "when references" do
         include_context 'output_reference_reassignments_processor_examples'
+      end
+      context "when document citations" do
+        include_context 'output_document_reassignments_processor_examples'
       end
       context "when shipments" do
         include_context 'output_shipment_reassignments_processor_examples'

--- a/spec/models/nomenclature_change/shared/document_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/document_reassignments_processor_examples.rb
@@ -1,0 +1,32 @@
+shared_context 'document_reassignments_processor_examples' do
+  let(:citation){
+    citation = create(
+      :document_citation
+    )
+    create(
+      :document_citation_taxon_concept,
+      document_citation: citation,
+      taxon_concept: input_species
+    )
+    citation
+  }
+  let(:reassignment) {
+    create(:nomenclature_change_document_citation_reassignment,
+      input: input,
+      reassignable_type: 'DocumentCitation',
+      reassignable: citation
+    )
+  }
+  let!(:reassignment_target) {
+    create(:nomenclature_change_reassignment_target,
+      reassignment: reassignment,
+      output: output
+    )
+  }
+  before(:each) do
+    processor.run
+  end
+  specify { 
+    expect(output_species1.document_citation_taxon_concepts.count).to eq(1)
+  }
+end

--- a/spec/models/nomenclature_change/shared/output_document_reassignments_processor_examples.rb
+++ b/spec/models/nomenclature_change/shared/output_document_reassignments_processor_examples.rb
@@ -1,0 +1,24 @@
+shared_context 'output_document_reassignments_processor_examples' do
+  let(:citation){
+    citation = create(
+      :document_citation
+    )
+    create(
+      :document_citation_taxon_concept,
+      document_citation: citation,
+      taxon_concept: old_output_subspecies
+    )
+    citation
+  }
+  before(:each) do
+    create(:nomenclature_change_output_reassignment,
+      output: output,
+      reassignable_type: 'DocumentCitation',
+      reassignable: citation
+    )
+    output_processor.run
+    processor.run
+  end
+  specify { expect(new_output_species.document_citation_taxon_concepts.count).to eq(1) }
+  specify { expect(old_output_subspecies.document_citation_taxon_concepts).to be_empty }
+end


### PR DESCRIPTION
Adds:
- building citation reassignments during a swap
- refreshing documents search results following a nomenclature change
- specs for reassignments
- support to cascade citation reassignments (full reassignment feature for descendants)
- fixes the transfer reassignment by deleting old tc citation before adding new one