### PR TITLE
Citation reassignment to children

### DIFF
--- a/app/models/nomenclature_change/cascading_citations_processor.rb
+++ b/app/models/nomenclature_change/cascading_citations_processor.rb
@@ -1,0 +1,63 @@
+class NomenclatureChange::CascadingCitationsProcessor
+
+  def initialize(input, outputs)
+    @input = input
+    @outputs = outputs
+  end
+
+  def run
+    @outputs.each do |output|
+      @taxon_concept = output.new_taxon_concept || output.taxon_concept
+      next unless @taxon_concept
+      descendents_for_citation_cascading(@taxon_concept).each do |d|
+        Rails.logger.debug("Processing citation for descendant #{d.full_name} of input #{@taxon_concept.full_name}")
+        cascade_document_citations(d, @input)
+      end
+    end
+  end
+
+  def summary
+    []
+  end
+
+  private
+
+  def descendents_for_citation_cascading(taxon_concept)
+    unless [Rank::GENUS, Rank::SPECIES].include? taxon_concept.rank.try(:name)
+      return []
+    end
+    # if it is a genus or a species, we want taxon-level nomenclature notes,
+    # both public and private, to cascade to descendents
+    subquery = <<-SQL
+      WITH RECURSIVE descendents AS (
+        SELECT id,
+          full_name,
+          name_status
+        FROM taxon_concepts
+        WHERE parent_id = :taxon_concept_id
+        UNION ALL
+        SELECT taxon_concepts.id,
+          taxon_concepts.full_name,
+          taxon_concepts.name_status
+        FROM taxon_concepts
+        JOIN descendents h ON h.id = taxon_concepts.parent_id
+      )
+      SELECT * FROM descendents
+    SQL
+    sanitized_subquery = ActiveRecord::Base.send(
+      :sanitize_sql_array, [subquery, taxon_concept_id: taxon_concept.id]
+    )
+    TaxonConcept.from(
+      "(#{sanitized_subquery}) taxon_concepts"
+    )
+  end
+
+  def cascade_document_citations(tc, input)
+    document_citations = input.document_citation_reassignments.map(&:reassignable)
+    document_citations.each do |dc|
+      dc.document_citation_taxon_concepts <<
+        DocumentCitationTaxonConcept.new(document_citation_id: dc.id, taxon_concept_id: tc.id)
+    end
+  end
+
+end

--- a/app/models/nomenclature_change/lump/processor.rb
+++ b/app/models/nomenclature_change/lump/processor.rb
@@ -29,6 +29,7 @@ class NomenclatureChange::Lump::Processor < NomenclatureChange::Processor
     end
     inputs_that_are_not_output.each do |input|
       chain << NomenclatureChange::ReassignmentTransferProcessor.new(input, @output)
+      chain << NomenclatureChange::CascadingCitationsProcessor.new(input, [@output])
       chain << NomenclatureChange::StatusDowngradeProcessor.new(input, [@output])
     end
     chain

--- a/app/models/nomenclature_change/split/processor.rb
+++ b/app/models/nomenclature_change/split/processor.rb
@@ -49,10 +49,12 @@ class NomenclatureChange::Split::Processor < NomenclatureChange::Processor
       end
       if @input.taxon_concept_id != output.taxon_concept_id
         chain << NomenclatureChange::CascadingNotesProcessor.new(output)
+        chain << NomenclatureChange::CascadingCitationsProcessor.new(@input, [output])
       end
     end
     unless input_is_one_of_outputs
       chain << NomenclatureChange::CascadingNotesProcessor.new(@input)
+      chain << NomenclatureChange::CascadingCitationsProcessor.new(@input, @outputs)
     end
     unless input_is_one_of_outputs
       chain << NomenclatureChange::StatusDowngradeProcessor.new(@input, @outputs)

--- a/app/models/nomenclature_change/to_synonym_transformation.rb
+++ b/app/models/nomenclature_change/to_synonym_transformation.rb
@@ -12,6 +12,9 @@ class NomenclatureChange::ToSynonymTransformation
     relink_relationships(
       @accepted_taxon_concept.trade_name_relationships, @new_accepted_name
     )
+    relink_document_citations(
+      @new_accepted_name.document_citation_taxon_concepts, @accepted_taxon_concept
+    )
     @accepted_taxon_concept.update_attribute(:name_status, 'S')
     # turn current name into synonym of new name
     rel_type = TaxonRelationshipType.find_by_name(TaxonRelationshipType::HAS_SYNONYM)
@@ -25,6 +28,14 @@ class NomenclatureChange::ToSynonymTransformation
     relationships.includes(:taxon_concept, :taxon_relationship_type).each do |rel|
       Rails.logger.debug "Relinking #{rel.taxon_relationship_type.name} relationship from #{rel.taxon_concept.full_name} to #{new_taxon_concept.full_name}"
       rel.update_attributes(taxon_concept_id: new_taxon_concept.id)
+    end
+  end
+
+  def relink_document_citations(document_citations, new_taxon_concept)
+    document_citations.each do |dc|
+      Rails.logger.debug "Relinking #{dc.id} document citation taxon concept from #{dc.taxon_concept.full_name} to #{new_taxon_concept.full_name}"
+      new_taxon_concept.document_citation_taxon_concepts <<
+        DocumentCitationTaxonConcept.new(document_citation_id: dc.document_citation_id, taxon_concept_id: new_taxon_concept.id)
     end
   end
 

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -235,6 +235,9 @@ describe NomenclatureChange::Lump::Processor do
       )
     end
     let!(:quota) { create(:quota, taxon_concept: input_genus_child, geo_entity: create(:geo_entity)) }
+    let!(:document_citation_taxon_concept_input_genus_child) {
+      create(:document_citation_taxon_concept, taxon_concept: input_genus_child)
+    }
     let(:output_genus) do
       create_cites_eu_genus(
         taxon_name: create(:taxon_name, scientific_name: 'Paracrotalus')
@@ -293,6 +296,9 @@ describe NomenclatureChange::Lump::Processor do
     specify "input genus child's accepted name has 1 quota" do
       output_genus_child = output_genus.children.first
       expect(output_genus_child.quotas.size).to eq(1)
+    end
+    specify "input genus child's document citations retained" do
+      expect(input_genus_child.document_citation_taxon_concepts.count).to eq(1)
     end
   end
   describe :summary do

--- a/spec/models/nomenclature_change/lump/processor_spec.rb
+++ b/spec/models/nomenclature_change/lump/processor_spec.rb
@@ -290,6 +290,10 @@ describe NomenclatureChange::Lump::Processor do
       expect(output_genus_child_child).not_to be_nil
       expect(output_genus_child_child.full_name).to eq('Paracrotalus durissus unicolor')
     end
+    specify "output genus child should have input genus citations" do
+      output_genus_child = output_genus.children.first
+      expect(output_genus_child.document_citation_taxon_concepts.count).to eq(1)
+    end
     specify "input genus child has no quotas" do
       expect(input_genus_child.quotas).to be_empty
     end

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -248,6 +248,9 @@ describe NomenclatureChange::Split::Processor do
       )
     end
     let!(:quota) { create(:quota, taxon_concept: input_genus_child, geo_entity: create(:geo_entity)) }
+    let!(:document_citation_taxon_concept_input_genus_child) {
+      create(:document_citation_taxon_concept, taxon_concept: input_genus_child)
+    }
     let(:output_genus) do
       create_cites_eu_genus(
         taxon_name: create(:taxon_name, scientific_name: 'Paracrotalus')
@@ -306,6 +309,9 @@ describe NomenclatureChange::Split::Processor do
     specify "input genus child's accepted name has 1 quota" do
       output_genus_child = output_genus.children.first
       expect(output_genus_child.quotas.size).to eq(1)
+    end
+    specify "input genus child's document citations retained" do
+      expect(input_genus_child.document_citation_taxon_concepts.count).to eq(1)
     end
   end
   describe :summary do

--- a/spec/models/nomenclature_change/split/processor_spec.rb
+++ b/spec/models/nomenclature_change/split/processor_spec.rb
@@ -303,6 +303,10 @@ describe NomenclatureChange::Split::Processor do
       expect(output_genus_child_child).not_to be_nil
       expect(output_genus_child_child.full_name).to eq('Paracrotalus durissus unicolor')
     end
+    specify "output genus child should have input genus citations" do
+      output_genus_child = output_genus.children.first
+      expect(output_genus_child.document_citation_taxon_concepts.count).to eq(1)
+    end
     specify "input genus child has no quotas" do
       expect(input_genus_child.quotas).to be_empty
     end


### PR DESCRIPTION
This PR is about cascading document citations to children in split and lump.
A new processor has been created to handle this and it's been added to split and lump chains.
When children of splitted/lumped species become synonym, the citations were not retained, so a relink of the lost document citations has been added in the ToSynonymTransformation class.

Also fixed a bug in which citations were not copied if the geo entity citations list was empty.

I'll do a separate PR for cascading citations in the swap because it's seems to need different amendments. 