### PR TITLE
More reliable logic for nomenclature notification

### DIFF
--- a/app/serializers/species/show_taxon_concept_serializer.rb
+++ b/app/serializers/species/show_taxon_concept_serializer.rb
@@ -121,8 +121,11 @@ class Species::ShowTaxonConceptSerializer < ActiveModel::Serializer
   end
 
   def nomenclature_notification
-    outputs = NomenclatureChange::Output.where(
-      "(taxon_concept_id = ? OR new_taxon_concept_id = ?) AND created_at > ?",
+    outputs = NomenclatureChange::Output.includes("nomenclature_change").where(
+      "
+        (taxon_concept_id = ? OR new_taxon_concept_id = ?) AND
+        nomenclature_changes.created_at > ? AND nomenclature_changes.status = 'submitted'
+      ",
       object.id, object.id, 6.months.ago
     )
 

--- a/spec/serializers/show_taxon_concept_serializer_spec.rb
+++ b/spec/serializers/show_taxon_concept_serializer_spec.rb
@@ -3,10 +3,17 @@ require 'spec_helper'
 describe Species::ShowTaxonConceptSerializer do
   context "when species is output of recent nomenclature changes" do
     let(:species) { create_cites_eu_species }
+    let(:nomenclature_change) {
+      create(:nomenclature_change,
+        status: 'submitted',
+        created_at: 5.months.ago
+      )
+    }
     let!(:output) {
       create(:nomenclature_change_output,
-        taxon_concept_id: species.id,
-        created_at: 5.months.ago)
+        nomenclature_change_id: nomenclature_change.id,
+        taxon_concept_id: species.id
+      )
     }
     specify {
       expect(described_class.new(species).nomenclature_notification).to eq(true)
@@ -14,10 +21,17 @@ describe Species::ShowTaxonConceptSerializer do
   end
   context "when new species is output of recent nomenclature changes" do
     let(:species) { create_cites_eu_species }
+    let(:nomenclature_change) {
+      create(:nomenclature_change,
+        status: 'submitted',
+        created_at: 5.months.ago
+      )
+    }
     let!(:output) {
       create(:nomenclature_change_output,
-        new_taxon_concept_id: species.id,
-        created_at: 5.months.ago)
+        nomenclature_change_id: nomenclature_change.id,
+        new_taxon_concept_id: species.id
+      )
     }
     specify {
       expect(described_class.new(species).nomenclature_notification).to eq(true)
@@ -25,10 +39,17 @@ describe Species::ShowTaxonConceptSerializer do
   end
   context "when species is output of old nomenclature changes" do
     let(:species) { create_cites_eu_species }
+    let(:nomenclature_change) {
+      create(:nomenclature_change,
+        status: 'submitted',
+        created_at: 7.months.ago
+      )
+    }
     let!(:output) {
       create(:nomenclature_change_output,
-        taxon_concept_id: species.id,
-        created_at: 7.months.ago)
+        nomenclature_change_id: nomenclature_change.id,
+        taxon_concept_id: species.id
+      )
     }
     specify {
       expect(described_class.new(species).nomenclature_notification).to eq(false)
@@ -36,6 +57,23 @@ describe Species::ShowTaxonConceptSerializer do
   end
   context "when species is not output of nomenclature changes" do
     let(:species) { create_cites_eu_species }
+    specify {
+      expect(described_class.new(species).nomenclature_notification).to eq(false)
+    }
+  end
+  context "when nomenclature changes is not yet submitted" do
+    let(:species) { create_cites_eu_species }
+    let(:nomenclature_change) {
+      create(:nomenclature_change,
+        created_at: 5.months.ago
+      )
+    }
+    let!(:output) {
+      create(:nomenclature_change_output,
+        nomenclature_change_id: nomenclature_change.id,
+        taxon_concept_id: species.id
+      )
+    }
     specify {
       expect(described_class.new(species).nomenclature_notification).to eq(false)
     }


### PR DESCRIPTION
I thought this could be a more reliable logic for displaying the nomenclature notification.
Since a nomenclature change can be left uncompleted, we need to make sure that its status is `submitted`; at this point, we can even rely on the `created_at` field of the nomenclature change itself rather then the one of the output model.
