### PR TITLE
Add migration to add fields to annual report uploads

### DIFF
--- a/db/migrate/20161103110635_add_more_fields_to_trade_uploads.rb
+++ b/db/migrate/20161103110635_add_more_fields_to_trade_uploads.rb
@@ -1,0 +1,14 @@
+class AddMoreFieldsToTradeUploads < ActiveRecord::Migration
+  def change
+    add_column :trade_annual_report_uploads, :is_from_epix, :boolean, default: false
+    add_column :trade_annual_report_uploads, :is_from_web_service, :boolean, default: false
+    add_column :trade_annual_report_uploads, :number_of_records_submitted, :integer
+    add_column :trade_annual_report_uploads, :auto_reminder_sent_at, :date
+    add_column :trade_annual_report_uploads, :sandbox_transferred_at, :date
+    add_column :trade_annual_report_uploads, :sandbox_transferred_by_id, :integer
+    add_column :trade_annual_report_uploads, :submitted_at, :date
+    add_column :trade_annual_report_uploads, :submitted_by_id, :integer
+    add_column :trade_annual_report_uploads, :deleted_at, :date
+    add_column :trade_annual_report_uploads, :deleted_by_id, :integer
+  end
+end

--- a/db/migrate/20161103110635_add_more_fields_to_trade_uploads.rb
+++ b/db/migrate/20161103110635_add_more_fields_to_trade_uploads.rb
@@ -3,12 +3,12 @@ class AddMoreFieldsToTradeUploads < ActiveRecord::Migration
     add_column :trade_annual_report_uploads, :is_from_epix, :boolean, default: false
     add_column :trade_annual_report_uploads, :is_from_web_service, :boolean, default: false
     add_column :trade_annual_report_uploads, :number_of_records_submitted, :integer
-    add_column :trade_annual_report_uploads, :auto_reminder_sent_at, :date
-    add_column :trade_annual_report_uploads, :sandbox_transferred_at, :date
+    add_column :trade_annual_report_uploads, :auto_reminder_sent_at, :datetime
+    add_column :trade_annual_report_uploads, :sandbox_transferred_at, :datetime
     add_column :trade_annual_report_uploads, :sandbox_transferred_by_id, :integer
-    add_column :trade_annual_report_uploads, :submitted_at, :date
+    add_column :trade_annual_report_uploads, :submitted_at, :datetime
     add_column :trade_annual_report_uploads, :submitted_by_id, :integer
-    add_column :trade_annual_report_uploads, :deleted_at, :date
+    add_column :trade_annual_report_uploads, :deleted_at, :datetime
     add_column :trade_annual_report_uploads, :deleted_by_id, :integer
   end
 end


### PR DESCRIPTION
This adds several new fields into the `trade_annual_report_uploads` table, according to [this PT story](https://www.pivotaltracker.com/story/show/133274153)