### PR TITLE
Add epix user fields for annual_report_uploads

### DIFF
--- a/db/migrate/20161104135655_add_epix_user_fields_to_annual_report_upload.rb
+++ b/db/migrate/20161104135655_add_epix_user_fields_to_annual_report_upload.rb
@@ -1,9 +1,9 @@
 class AddEpixUserFieldsToAnnualReportUpload < ActiveRecord::Migration
   def change
     add_column :trade_annual_report_uploads, :epix_created_by_id, :integer
-    add_column :trade_annual_report_uploads, :epix_created_at, :integer
+    add_column :trade_annual_report_uploads, :epix_created_at, :datetime
     add_column :trade_annual_report_uploads, :epix_updated_by_id, :integer
-    add_column :trade_annual_report_uploads, :epix_updated_at, :integer
+    add_column :trade_annual_report_uploads, :epix_updated_at, :datetime
     remove_column :trade_annual_report_uploads, :is_from_epix
   end
 end

--- a/db/migrate/20161104135655_add_epix_user_fields_to_annual_report_upload.rb
+++ b/db/migrate/20161104135655_add_epix_user_fields_to_annual_report_upload.rb
@@ -1,0 +1,9 @@
+class AddEpixUserFieldsToAnnualReportUpload < ActiveRecord::Migration
+  def change
+    add_column :trade_annual_report_uploads, :epix_created_by_id, :integer
+    add_column :trade_annual_report_uploads, :epix_created_at, :integer
+    add_column :trade_annual_report_uploads, :epix_updated_by_id, :integer
+    add_column :trade_annual_report_uploads, :epix_updated_at, :integer
+    remove_column :trade_annual_report_uploads, :is_from_epix
+  end
+end


### PR DESCRIPTION
This adds `created_by`, `created_at`, `updated_by`, `updated_at` fields for epix users to annual_report_uploads to avoid conflict with sapi users in the trade reporting tool.
It also removes the `is_from_epix` boolean, since we can now use the `epix_created_by` field to distinguish between epix and sapi users