### PR TITLE
Add submitted timestamps for epix users

### DIFF
--- a/db/migrate/20161111114955_add_submitted_timestamps_for_epix_users_to_annual_report_uploads.rb
+++ b/db/migrate/20161111114955_add_submitted_timestamps_for_epix_users_to_annual_report_uploads.rb
@@ -1,0 +1,6 @@
+class AddSubmittedTimestampsForEpixUsersToAnnualReportUploads < ActiveRecord::Migration
+  def change
+    add_column :trade_annual_report_uploads, :epix_submitted_by, :integer
+    add_column :trade_annual_report_uploads, :epix_submitted_at, :datetime
+  end
+end

--- a/db/migrate/20161111114955_add_submitted_timestamps_for_epix_users_to_annual_report_uploads.rb
+++ b/db/migrate/20161111114955_add_submitted_timestamps_for_epix_users_to_annual_report_uploads.rb
@@ -1,6 +1,6 @@
 class AddSubmittedTimestampsForEpixUsersToAnnualReportUploads < ActiveRecord::Migration
   def change
-    add_column :trade_annual_report_uploads, :epix_submitted_by, :integer
+    add_column :trade_annual_report_uploads, :epix_submitted_by_id, :integer
     add_column :trade_annual_report_uploads, :epix_submitted_at, :datetime
   end
 end


### PR DESCRIPTION
Adds `epix_submitted_by_id` and `epix_submitted_at` to `trade_annual_report_uploads`