### PR TITLE
Add field to paper trail for diffing

### DIFF
--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -23,6 +23,7 @@
 class Trade::SandboxTemplate < ActiveRecord::Base
 
   self.table_name = :trade_sandbox_template
+  has_paper_trail
 
   COLUMNS_IN_CSV_ORDER = [
     "appendix", "species_name", "term_code", "quantity", "unit_code",

--- a/db/migrate/20161128152531_add_object_changes_text_column_to_versions.rb
+++ b/db/migrate/20161128152531_add_object_changes_text_column_to_versions.rb
@@ -1,0 +1,5 @@
+class AddObjectChangesTextColumnToVersions < ActiveRecord::Migration
+  def change
+    add_column :versions, :object_changes, :text
+  end
+end


### PR DESCRIPTION
This contains a migration that will add the `object_changes` field to the `versions` table used by paper_trail. That is used to use the diffing functionalities offered by paper_trail.
Also adds paper_trail to `Trade::SandboxTemplate`.
All this will be used in the trade reporting tool