### PR TITLE
Export trade db

### DIFF
--- a/app/models/trade/shipment_report_queries.rb
+++ b/app/models/trade/shipment_report_queries.rb
@@ -73,6 +73,64 @@ module Trade::ShipmentReportQueries
       ON shipments.updated_by_id = uu.id"
   end
 
+  def self.full_db_query(limit, offset)
+    "SELECT
+      shipments.id AS id,
+      year AS year,
+      appendix AS appendix,
+      full_name_with_spp(ranks.name, taxon_concept_full_name) AS taxon,
+      taxon_concept_id AS taxon_id,
+      taxon_concept_class_name AS class,
+      taxon_concept_order_name AS order,
+      taxon_concept_family_name AS family,
+      taxon_concept_genus_name AS genus,
+      full_name_with_spp(reported_taxon_ranks.name, reported_taxon_concept_full_name) AS reported_taxon,
+      reported_taxon_concept_id AS reported_taxon_id,
+      terms.name_en AS term,
+      CASE WHEN quantity = 0 THEN NULL ELSE quantity END,
+      units.name_en AS unit,
+      importers.iso_code2 AS importer,
+      exporters.iso_code2 AS exporter,
+      countries_of_origin.iso_code2 AS origin,
+      purposes.code AS purpose,
+      sources.code AS source,
+      CASE
+        WHEN reported_by_exporter THEN 'E'
+        ELSE 'I'
+      END AS reporter_type,
+      import_permit_number AS import_permit,
+      export_permit_number AS export_permit,
+      origin_permit_number AS origin_permit,
+      legacy_shipment_number AS legacy_shipment_no,
+      uc.name AS created_by,
+      uu.name AS updated_by
+    FROM trade_shipments_with_taxa_view AS shipments
+    JOIN ranks
+      ON ranks.id = taxon_concept_rank_id
+    LEFT JOIN ranks AS reported_taxon_ranks
+      ON reported_taxon_ranks.id = reported_taxon_concept_rank_id
+    JOIN geo_entities importers
+      ON importers.id = importer_id
+    JOIN geo_entities exporters
+      ON exporters.id = exporter_id
+    LEFT JOIN geo_entities countries_of_origin
+      ON countries_of_origin.id = country_of_origin_id
+    LEFT JOIN trade_codes units
+      ON units.id = unit_id
+    JOIN trade_codes terms
+      ON terms.id = term_id
+    LEFT JOIN trade_codes purposes
+      ON purposes.id = purpose_id
+    LEFT JOIN trade_codes sources
+      ON sources.id = source_id
+    LEFT JOIN users as uc
+      ON shipments.created_by_id = uc.id
+    LEFT JOIN users as uu
+      ON shipments.updated_by_id = uu.id
+    ORDER BY shipments.id
+    LIMIT #{limit} OFFSET #{offset}"
+  end
+
   def comptab_query(options)
     "SELECT
       year,

--- a/lib/tasks/export_trade_db.rake
+++ b/lib/tasks/export_trade_db.rake
@@ -1,0 +1,49 @@
+require 'zip'
+require 'fileutils'
+namespace :export do
+  task :trade_db => :environment do
+    RECORDS_PER_FILE = 500000
+    ntuples = RECORDS_PER_FILE
+    offset = 0
+    i = 0
+    dir = 'tmp/trade_db_files/'
+    FileUtils.mkdir_p dir
+    begin
+      while(ntuples == RECORDS_PER_FILE) do
+        i = i + 1
+        query = Trade::ShipmentReportQueries.full_db_query(RECORDS_PER_FILE, offset)
+        results = ActiveRecord::Base.connection.execute query
+        ntuples = results.ntuples
+        columns = results.fields
+        columns.map do |column|
+          column.capitalize!
+          column.gsub! '_', ' '
+        end
+        values = results.values
+        Rails.logger.info("Query executed returning #{ntuples} records!")
+        filename = "trade_db_#{i}.csv"
+        Rails.logger.info("Processing batch number #{i} in #{filename}.")
+        File.open("#{dir}#{filename}", 'w') do |file|
+          file.write columns.join(',')
+          values.each do |record|
+            file.write "\n"
+            file.write record.join(',')
+          end
+        end
+        offset = offset + RECORDS_PER_FILE
+      end
+      Rails.logger.info("Trade database completely exported!")
+      zipfile = 'tmp/trade_db_files/trade_db.zip'
+      Zip::File.open(zipfile, Zip::File::CREATE) do |zipfile|
+        (1..i).each do |index|
+          filename = "trade_db_#{index}.csv"
+          zipfile.add(filename, dir + filename)
+        end
+      end
+    rescue => e
+      Rails.logger.info("Export aborted!")
+      Rails.logger.info("Caught exception #{e}")
+      Rails.logger.info(e.message)
+    end
+  end
+end


### PR DESCRIPTION
This adds a query and a rake task to fetch the entire trade database and export it into multiple csv files, which are then zipped into a single file.