### PR TITLE
Submit shipments sql fix

### DIFF
--- a/app/controllers/trade/annual_report_uploads_controller.rb
+++ b/app/controllers/trade/annual_report_uploads_controller.rb
@@ -31,7 +31,7 @@ class Trade::AnnualReportUploadsController < TradeController
 
   def submit
     @annual_report_upload = Trade::AnnualReportUpload.find(params[:id])
-    if @annual_report_upload.submit
+    if @annual_report_upload.submit(current_user)
       render :json => @annual_report_upload, :status => :ok,
         :serializer => Trade::ShowAnnualReportUploadSerializer
     else

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -89,7 +89,10 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
     DownloadsCacheCleanupWorker.perform_async(:shipments)
 
     # flag as submitted
-    update_attribute(:submitted_at, DateTime.now)
+    update_attributes({
+      submitted_at: DateTime.now,
+      submitted_by_id: submitter.id
+    )
   end
 
   private

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -68,13 +68,13 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
     end
   end
 
-  def submit
+  def submit(submitter)
     run_primary_validations
     unless @validation_errors.count == 0
       self.errors[:base] << "Submit failed, primary validation errors present."
       return false
     end
-    return false unless sandbox.copy_from_sandbox_to_shipments
+    return false unless sandbox.copy_from_sandbox_to_shipments(submitter)
     # remove uploaded file
     store_dir = csv_source_file.store_dir
     remove_csv_source_file!

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -21,7 +21,8 @@ require 'csv_column_headers_validator'
 class Trade::AnnualReportUpload < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
   track_who_does_it
-  attr_accessible :csv_source_file, :trading_country_id, :point_of_view
+  attr_accessible :csv_source_file, :trading_country_id, :point_of_view,
+                  :submitted_at, :submitted_by_id
   mount_uploader :csv_source_file, Trade::CsvSourceFileUploader
   belongs_to :trading_country, :class_name => GeoEntity, :foreign_key => :trading_country_id
   validates :csv_source_file, :csv_column_headers => true, :on => :create

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -92,7 +92,7 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
     update_attributes({
       submitted_at: DateTime.now,
       submitted_by_id: submitter.id
-    )
+    })
   end
 
   private

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -13,13 +13,15 @@ class Trade::Sandbox
     @ar_klass.sanitize
   end
 
-  def copy_from_sandbox_to_shipments
+  def copy_from_sandbox_to_shipments(submitter)
     success = true
     Trade::Shipment.transaction do
       pg_result = Trade::SandboxTemplate.connection.execute(
         Trade::SandboxTemplate.send(:sanitize_sql_array, [
-          'SELECT * FROM copy_transactions_from_sandbox_to_shipments(?)',
-          @annual_report_upload.id
+          'SELECT * FROM copy_transactions_from_sandbox_to_shipments(?, ?, ?)',
+          @annual_report_upload.id,
+          'Sapi',
+          submitter.id
         ])
       )
       moved_rows_cnt = pg_result.first['copy_transactions_from_sandbox_to_shipments'].to_i

--- a/app/serializers/trade/annual_report_upload_serializer.rb
+++ b/app/serializers/trade/annual_report_upload_serializer.rb
@@ -19,6 +19,6 @@ class Trade::AnnualReportUploadSerializer < ActiveModel::Serializer
   end
 
   def updated_by
-    object.creator && object.updater.name
+    object.updater && object.updater.name
   end
 end

--- a/db/migrate/20161215140343_add_epix_user_fields_to_shipments.rb
+++ b/db/migrate/20161215140343_add_epix_user_fields_to_shipments.rb
@@ -1,0 +1,19 @@
+class AddEpixUserFieldsToShipments < ActiveRecord::Migration
+  def up
+    change_column_null :trade_shipments, :created_at, true
+    change_column_null :trade_shipments, :updated_at, true
+    add_column :trade_shipments, :epix_created_at, :timestamp
+    add_column :trade_shipments, :epix_updated_at, :timestamp
+    add_column :trade_shipments, :epix_created_by_id, :integer
+    add_column :trade_shipments, :epix_updated_by_id, :integer
+  end
+
+  def down
+    change_column_null :trade_shipments, :created_at, false
+    change_column_null :trade_shipments, :updated_at, false
+    remove_column :trade_shipments, :epix_created_at
+    remove_column :trade_shipments, :epix_updated_at
+    remove_column :trade_shipments, :epix_created_by_id
+    remove_column :trade_shipments, :epix_updated_by_id
+  end
+end

--- a/db/migrate/20161218150218_add_epix_fields_to_sandbox_template.rb
+++ b/db/migrate/20161218150218_add_epix_fields_to_sandbox_template.rb
@@ -1,0 +1,13 @@
+class AddEpixFieldsToSandboxTemplate < ActiveRecord::Migration
+  def change
+    add_column :trade_sandbox_template, :epix_created_at, :timestamp
+    add_column :trade_sandbox_template, :epix_updated_at, :timestamp
+    add_column :trade_sandbox_template, :epix_created_by_id, :integer
+    add_column :trade_sandbox_template, :epix_updated_by_id, :integer
+
+    change_column_null :trade_annual_report_uploads, :created_at, true
+    change_column_null :trade_annual_report_uploads, :updated_at, true
+    change_column_null :trade_sandbox_template, :created_at, true
+    change_column_null :trade_sandbox_template, :updated_at, true
+  end
+end

--- a/db/migrate/20161219204239_add_updated_by_id_and_created_by_id_to_trade_sandbox_template.rb
+++ b/db/migrate/20161219204239_add_updated_by_id_and_created_by_id_to_trade_sandbox_template.rb
@@ -1,0 +1,6 @@
+class AddUpdatedByIdAndCreatedByIdToTradeSandboxTemplate < ActiveRecord::Migration
+  def change
+    add_column :trade_sandbox_template, :updated_by_id, :integer
+    add_column :trade_sandbox_template, :created_by_id, :integer
+  end
+end

--- a/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
+++ b/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
@@ -81,6 +81,7 @@ BEGIN
 END;
 $$;
 
+DROP FUNCTION IF EXISTS copy_transactions_from_sandbox_to_shipments(INTEGER);
 CREATE OR REPLACE FUNCTION copy_transactions_from_sandbox_to_shipments(
   annual_report_upload_id INTEGER,
   submitter_type VARCHAR,

--- a/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
+++ b/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
@@ -174,20 +174,20 @@ BEGIN
         purposes.id AS purpose_id,
         terms.id AS term_id,
         sandbox_table.quantity::NUMERIC AS quantity,
-        sandbox_table.appendix,' ||
-        aru.id || 'AS trade_annual_report_upload_id,
+        sandbox_table.appendix,
+        ' || aru.id || ' AS trade_annual_report_upload_id,
         exporters.id AS exporter_id,
         importers.id AS importer_id,
-        origins.id AS country_of_origin_id,' ||
-        reported_by_exporter || ' AS reported_by_exporter,
+        origins.id AS country_of_origin_id,
+        ' || reported_by_exporter || ' AS reported_by_exporter,
         taxon_concept_id,
         reported_taxon_concept_id,
         sandbox_table.year::INTEGER AS year,
         sandbox_table.id AS sandbox_id,
         current_timestamp,
-        current_timestamp, ' ||
-        aru.created_by_id || ', ' ||
-        aru.updated_by_id || '
+        current_timestamp,
+        ' || COALESCE(aru.created_by_id, aru.epix_created_by_id) || ',
+        ' || COALESCE(aru.updated_by_id, aru.epix_updated_by_id) || '
       FROM '|| table_name || ' sandbox_table';
 
     IF reported_by_exporter THEN

--- a/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
+++ b/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
@@ -99,10 +99,6 @@ DECLARE
   total_shipments INTEGER;
   sql TEXT;
   permit_type TEXT;
-  created_at TIMESTAMP;
-  updated_at TIMESTAMP;
-  epix_created_at TIMESTAMP;
-  epix_updated_at TIMESTAMP;
   sapi_type BOOLEAN;
 BEGIN
   SELECT * INTO aru FROM trade_annual_report_uploads WHERE id = annual_report_upload_id;
@@ -153,22 +149,6 @@ BEGIN
   RAISE INFO '[%] Inserted % permits', table_name, inserted_rows;
 
   sapi_type := CASE WHEN submitter_type = 'Sapi' THEN true ELSE false END;
-  created_at := COALESCE(aru.created_at, to_timestamp(0));
-  created_at := CASE WHEN sapi_type IS TRUE THEN current_timestamp
-                     ELSE created_at
-                     END;
-  updated_at := COALESCE(aru.updated_at, to_timestamp(0));
-  updated_at := CASE WHEN sapi_type IS TRUE THEN current_timestamp
-                     ELSE updated_at
-                     END;
-  epix_created_at := COALESCE(aru.epix_created_at, to_timestamp(0));
-  epix_created_at := CASE WHEN sapi_type IS FALSE THEN current_timestamp
-                          ELSE epix_created_at
-                          END;
-  epix_updated_at := COALESCE(aru.epix_updated_at, to_timestamp(0));
-  epix_updated_at := CASE WHEN sapi_type IS FALSE THEN current_timestamp
-                          ELSE epix_updated_at
-                          END;
 
   sql := '
     CREATE TEMP TABLE ' || table_name || '_for_submit AS
@@ -214,22 +194,14 @@ BEGIN
         reported_taxon_concept_id,
         sandbox_table.year::INTEGER AS year,
         sandbox_table.id AS sandbox_id,
-        NULLIF(''' || created_at || '''::timestamp, ''' || to_timestamp(0) || '''::timestamp),
-        NULLIF(''' || updated_at || '''::timestamp, ''' ||  to_timestamp(0) || '''::timestamp),
-        NULLIF(''' || epix_created_at || '''::timestamp, ''' || to_timestamp(0) || '''::timestamp),
-        NULLIF(''' || epix_updated_at || '''::timestamp, ''' || to_timestamp(0) || '''::timestamp),
-        CASE WHEN ' || sapi_type || ' IS TRUE THEN ' || submitter_id || '
-             ELSE NULLIF(' || COALESCE(aru.created_by_id, 0) ||', 0)
-        END,
-        CASE WHEN ' || sapi_type || ' IS TRUE THEN ' || submitter_id || '
-             ELSE NULLIF(' || COALESCE(aru.updated_by_id, 0) ||', 0)
-        END,
-        CASE WHEN ' || sapi_type || ' IS FALSE THEN ' || submitter_id || '
-             ELSE NULLIF(' || COALESCE(aru.epix_created_by_id, 0) ||', 0)
-        END,
-        CASE WHEN ' || sapi_type || ' IS FALSE THEN ' || submitter_id || '
-             ELSE NULLIF(' || COALESCE(aru.epix_updated_by_id, 0) ||', 0)
-        END
+        CASE WHEN ' || sapi_type || ' IS TRUE THEN current_timestamp ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS TRUE THEN current_timestamp ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS FALSE THEN current_timestamp ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS FALSE THEN current_timestamp ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS TRUE THEN ' || submitter_id || ' ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS TRUE THEN ' || submitter_id || ' ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS FALSE THEN ' || submitter_id || ' ELSE NULL END,
+        CASE WHEN ' || sapi_type || ' IS FALSE THEN ' || submitter_id || ' ELSE NULL END
       FROM '|| table_name || ' sandbox_table';
 
     IF reported_by_exporter THEN

--- a/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
+++ b/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
@@ -187,7 +187,13 @@ BEGIN
         current_timestamp,
         current_timestamp,
         ' || COALESCE(aru.created_by_id, aru.epix_created_by_id) || ',
-        ' || COALESCE(aru.updated_by_id, aru.epix_updated_by_id) || '
+        '
+        ||
+        CASE WHEN COALESCE(aru.updated_at, aru.epix_updated_at) > COALESCE(aru.epix_updated_at, to_timestamp(0))
+             THEN COALESCE(aru.updated_by_id, aru.epix_updated_by_id)
+             ELSE COALESCE(aru.epix_updated_by_id, aru.updated_by_id)
+        END
+        || '
       FROM '|| table_name || ' sandbox_table';
 
     IF reported_by_exporter THEN

--- a/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
+++ b/db/plpgsql/011_copy_transactions_from_sandbox_to_shipments.sql
@@ -312,5 +312,5 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION copy_transactions_from_sandbox_to_shipments(annual_report_upload_id INTEGER) IS
+COMMENT ON FUNCTION copy_transactions_from_sandbox_to_shipments(annual_report_upload_id INTEGER, submitter_type VARCHAR, submitter_id INTEGER) IS
   'Procedure to copy transactions from sandbox to shipments. Returns the number of rows copied if success, 0 if failure.'

--- a/spec/controllers/trade/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/trade/annual_report_uploads_controller_spec.rb
@@ -30,7 +30,7 @@ describe Trade::AnnualReportUploadsController do
       @aru.save(:validate => false)
       @completed_aru = build(:annual_report_upload)
       @completed_aru.save(:validate => false)
-      @completed_aru.submit
+      @completed_aru.submit(@user)
     end
     it "should return all annual report uploads" do
       get :index, format: :json

--- a/spec/models/trade/annual_report_upload_spec.rb
+++ b/spec/models/trade/annual_report_upload_spec.rb
@@ -153,6 +153,7 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
                          :name => 'Portugal',
                          :iso_code2 => 'PT'
                         )
+      @submitter = FactoryGirl.create(:user, role: User::MANAGER)
     end
     context "when no primary errors" do
       subject { # aru no primary errors
@@ -174,19 +175,19 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
         aru
       }
       specify {
-        expect { subject.submit }.to change { Trade::Shipment.count }.by(1)
+        expect { subject.submit(@submitter) }.to change { Trade::Shipment.count }.by(1)
       }
       specify {
-        expect { subject.submit }.to change { Trade::Permit.count }.by(3)
+        expect { subject.submit(@submitter) }.to change { Trade::Permit.count }.by(3)
       }
       specify "leading space is stripped" do
-        subject.submit
+        subject.submit(@submitter)
         Trade::Permit.find_by_number('BBB').should_not be_nil
       end
       context "when permit previously reported" do
         before(:each) { create(:permit, :number => 'xxx') }
         specify {
-          expect { subject.submit }.to change { Trade::Permit.count }.by(2)
+          expect { subject.submit(@submitter) }.to change { Trade::Permit.count }.by(2)
         }
       end
     end
@@ -206,7 +207,7 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
         aru
       }
       specify {
-        expect { subject.submit }.not_to change { Trade::Shipment.count }
+        expect { subject.submit(@submitter) }.not_to change { Trade::Shipment.count }
       }
     end
     context "when reported under a synonym" do
@@ -240,14 +241,14 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
         aru
       }
       specify {
-        expect { subject.submit }.to change { Trade::Shipment.count }.by(1)
+        expect { subject.submit(@submitter) }.to change { Trade::Shipment.count }.by(1)
       }
       specify {
-        subject.submit
+        subject.submit(@submitter)
         Trade::Shipment.first.taxon_concept_id.should == @species.id
       }
       specify {
-        subject.submit
+        subject.submit(@submitter)
         Trade::Shipment.first.reported_taxon_concept_id.should == @synonym.id
       }
     end


### PR DESCRIPTION
This is related to [Submission into Trade DB](https://www.pivotaltracker.com/story/show/132315085).
Due to the amendments made to the ARU model, this sql scripts needs to be updated in order to handle nullable fields such as `updated_at`, `epix_updated_at`, `updated_by_id`, `epix_updated_by_id`.
The `updated_by` field gets populated based on the fact that is not null and also depending on which of the `updated_at` fields is the latest.