### PR TITLE
Add trade cleanup endpoint

### DIFF
--- a/app/controllers/api/trade_downloads_cache_cleanup_controller.rb
+++ b/app/controllers/api/trade_downloads_cache_cleanup_controller.rb
@@ -7,9 +7,8 @@ class Api::TradeDownloadsCacheCleanupController < ApplicationController
       DownloadsCacheCleanupWorker.perform_async(:shipments)
     rescue
       message = 'Something went wrong'
-      return
     end
-    message = 'Shipments downloads successfully cleared'
+    message = 'Shipments downloads successfully cleared' unless message.present?
     render json: {
       message: message
     }

--- a/app/controllers/api/trade_downloads_cache_cleanup_controller.rb
+++ b/app/controllers/api/trade_downloads_cache_cleanup_controller.rb
@@ -1,0 +1,17 @@
+class Api::TradeDownloadsCacheCleanupController < ApplicationController
+  respond_to :json
+
+  def index
+    message = ''
+    begin
+      DownloadsCacheCleanupWorker.perform_async(:shipments)
+    rescue
+      message = 'Something went wrong'
+      return
+    end
+    message = 'Shipments downloads successfully cleared'
+    render json: {
+      message: message
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ SAPI::Application.routes.draw do
     resources :ranks, :only => [:index]
     resources :geo_entities, :only => [:index]
     resources :geo_relationship_types, :only => [:index]
+    resources :trade_downloads_cache_cleanup, only: [:index]
   end
   namespace :admin do
     resources :taxonomies, :only => [:index, :create, :update, :destroy]


### PR DESCRIPTION
This PR adds and endpoint to be called specifically by the trade reporting to in order to clean trade cache after submit.