### PR TITLE
Copy just annotation values instead of entire object

### DIFF
--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -134,6 +134,9 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
         exclusion.comparison_attributes, :without_protection => true
       )
     end
+    # annotation
+    reassignable.annotation && copied_object.new_record? &&
+      copied_object.annotation = reassignable.annotation.dup
   end
 
   def build_trade_restriction_associations(reassignable, copied_object)


### PR DESCRIPTION
This is to fix the [listing changes annotation issue reported by Frances](https://www.pivotaltracker.com/story/show/136614369).
So basically, the problem was that after a split with many output taxa, changing the annotation  of a listing change will trigger the same amendments on the listing change of the other taxa. This was because, when copying the listing changes in the nomenclature change processor, we were also copying the entire annotation association, meaning that the annotation was exactly the same (so also same id).
I've fixed that by duplicating the values of the annotation but effectively creating a new object.