### PR TITLE
Amend mailer notification for submission

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,18 +1,5 @@
 class NotificationMailer < ApplicationMailer
 
-  def validation_result(user, aru, validation_report, validation_report_csv_file)
-    @user = user
-    @aru = aru
-    @status = validation_report[:CITESReportResult][:Status]
-    @message = validation_report[:CITESReportResult][:Message]
-    @has_errors = @aru.validation_report.present?
-    if @has_errors
-      attachments["validation_report_#{@aru.id}.csv"] = File.read(validation_report_csv_file.path)
-u
-    end
-    mail(to: @user.email, subject: 'CITES Report validation result')
-  end
-
   def changelog(user, aru, csv_file)
     @user = user
     @aru = aru

--- a/app/views/notification_mailer/changelog.html.erb
+++ b/app/views/notification_mailer/changelog.html.erb
@@ -3,9 +3,10 @@
   The generation of your CITES Report submission <%= @aru.id %> changelog has completed.<br>
 </p>
 
-<% unless @aru.is_submitted? %>
-  To view your submission online, please follow this link: <%= link_to trade_annual_report_upload_url(@aru), trade_annual_report_upload_url(@aru) %>.
-<% end %>
+<p>
+  This report has been submitted on <%= @aru.submitted_at.strftime("%d/%m/%y") %> with <%= @aru.number_of_records_submitted %> records.
+</p>
+
 </p>
 <p>
   Best regards,


### PR DESCRIPTION
This is just about amending the wording of the changelog notification email after submission.
It doesn't provide links to aru pages anymore but it just give information about the submission, such as date of submission and number of records submitted.