### PR TITLE
Duplicate detection when submitting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ addons:
   code_climate:
     repo_token: dd9c26c5738d807099d3f35926ddb76902d4e2a7b899a8fe3b866152ffe8bbf1
 # uncomment this line if your project needs to run something other than `rake`:
+
+env:
+  - MAILER_HOST=http://localhost:3000 MAILER_FROM=no-reply@unep-wcmc.org
+
 before_script:
   - psql -c 'create database sapi_test' -U postgres
   - cp config/database.yml.sample config/database.yml

--- a/app/assets/javascripts/trade/controllers/annual_report_upload_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/annual_report_upload_controller.js.coffee
@@ -15,10 +15,13 @@ Trade.AnnualReportUploadController = Ember.ObjectController.extend Trade.Flash,
   actions:
 
     submitShipments: ->
-      onSuccess = => 
+      onSuccess = =>
         @set('sandboxShipmentsSubmitting', false)
         @transitionToRoute('search')
-        @flashSuccess(message: "#{@get('numberOfRows')} shipments submitted.", persists: true)
+        @flashSuccess(
+          message: "Submission scheduled. Email notification will be sent when it is processed.",
+          persists: true
+        )
       onError = (xhr, msg, error) =>
         @set('sandboxShipmentsSubmitting', false)
         @flashError(message: xhr.responseText)

--- a/app/assets/javascripts/trade/templates/search.handlebars
+++ b/app/assets/javascripts/trade/templates/search.handlebars
@@ -2,9 +2,9 @@
   Welcome to the Shipments Database
 </h2>
 
+{{ partial 'trade/flash' }}
+
 {{ partial 'trade/search/filters' }}
 {{ partial 'trade/search/loading_modal' }}
-
-{{ partial 'trade/flash' }}
 
 {{outlet}}

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -13,5 +13,12 @@ class NotificationMailer < ApplicationMailer
     mail(to: @user.email, subject: 'Changes history log - generation failed')
   end
 
+  def duplicates(user, aru, csv_file)
+    @user = user
+    @aru = aru
+    attachments["changelog_with_dulpicates_#{@aru.id}.csv"] = File.read(csv_file)
+    mail(to: @user.email, subject: 'Duplicates detected on submission')
+  end
+
 end
 

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -39,8 +39,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
 
   # object that represents the particular sandbox table linked to this annual
   # report upload
-  def sandbox(tmp=false)
-    return nil if submitted_at.present? && !tmp
+  def sandbox
+    return nil if submitted_at.present?
     @sandbox ||= Trade::Sandbox.new(self)
   end
 
@@ -80,27 +80,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
       self.errors[:base] << "Submit failed, primary validation errors present."
       return false
     end
-    return false unless sandbox.copy_from_sandbox_to_shipments(submitter)
 
-    ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
-
-    records_submitted = sandbox.moved_rows_cnt
-    # remove uploaded file
-    store_dir = csv_source_file.store_dir
-    remove_csv_source_file!
-    puts '### removing uploads dir ###'
-    puts Rails.root.join('public', store_dir)
-    FileUtils.remove_dir(Rails.root.join('public', store_dir), :force => true)
-
-    # clear downloads cache
-    DownloadsCacheCleanupWorker.perform_async(:shipments)
-
-    # flag as submitted
-    update_attributes({
-      submitted_at: DateTime.now,
-      submitted_by_id: submitter.id,
-      number_of_records_submitted: records_submitted
-    })
+    SubmissionWorker.perform_async(self.id, submitter.id)
   end
 
   def reported_by_exporter?

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -28,7 +28,7 @@ class Trade::Sandbox
       @moved_rows_cnt = pg_result.first['copy_transactions_from_sandbox_to_shipments'].to_i
       if @moved_rows_cnt < 0
         # if -1 returned, not all rows have been moved
-        self.errors[:base] << "Submit failed, could not save all rows."
+        @annual_report_upload.errors[:base] << "Submit failed, could not save all rows."
         success = false
         raise ActiveRecord::Rollback
       end

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -36,6 +36,19 @@ class Trade::Sandbox
     success
   end
 
+  def check_for_duplicates_in_shipments
+    Trade::Shipment.transaction do
+      pg_result = Trade::SandboxTemplate.connection.execute(
+        Trade::SandboxTemplate.send(:sanitize_sql_array, [
+          'SELECT * FROM check_for_duplicates_in_shipments(?)',
+          @annual_report_upload.id,
+        ])
+      )
+      duplicates = pg_result.values.first.first.delete('{}')
+      return duplicates
+    end
+  end
+
   def destroy
     Trade::SandboxTemplate.connection.execute(
       Trade::SandboxTemplate.drop_stmt(@table_name)

--- a/app/views/notification_mailer/duplicates.html.erb
+++ b/app/views/notification_mailer/duplicates.html.erb
@@ -1,0 +1,10 @@
+<p>Dear <%= @user.name %>,</p>
+<p>
+  Your CITES Report submission <%= @aru.id %> has failed due to the presence of duplicate records.<br>
+</p>
+
+<p>
+  Best regards,
+  the Trade Reporting Tool team
+<p>
+

--- a/app/workers/submission_worker.rb
+++ b/app/workers/submission_worker.rb
@@ -24,18 +24,7 @@ class SubmissionWorker
 
     tempfile = Trade::ChangelogCsvGenerator.call(aru, submitter)
 
-    begin
-      s3 = Aws::S3::Resource.new
-      filename = "#{Rails.env}/trade/annual_report_upload/#{aru.id}/changelog.csv"
-      bucket_name = Rails.application.secrets.aws['bucket_name']
-      obj = s3.bucket(bucket_name).object(filename)
-      obj.upload_file(tempfile.path)
-
-      aru.update_attributes(aws_storage_path: obj.public_url)
-    rescue Aws::S3::Errors::ServiceError => e
-      Rails.logger.warn "Something went wrong while uploading #{aru.id} to S3"
-      Appsignal.add_exception(e) if defined? Appsignal
-    end
+    upload_on_S3(aru, tempfile)
 
     records_submitted = aru.sandbox.moved_rows_cnt
     # remove uploaded file
@@ -60,6 +49,23 @@ class SubmissionWorker
       submitted_by_id: submitter.id,
       number_of_records_submitted: records_submitted
     })
+  end
+
+  private
+
+  def upload_on_S3(aru, tempfile)
+    begin
+      s3 = Aws::S3::Resource.new
+      filename = "#{Rails.env}/trade/annual_report_upload/#{aru.id}/changelog.csv"
+      bucket_name = Rails.application.secrets.aws['bucket_name']
+      obj = s3.bucket(bucket_name).object(filename)
+      obj.upload_file(tempfile.path)
+
+      aru.update_attributes(aws_storage_path: obj.public_url)
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn "Something went wrong while uploading #{aru.id} to S3"
+      Appsignal.add_exception(e) if defined? Appsignal
+    end
   end
 
 end

--- a/app/workers/submission_worker.rb
+++ b/app/workers/submission_worker.rb
@@ -1,0 +1,65 @@
+class SubmissionWorker
+  include Sidekiq::Worker
+  sidekiq_options :queue => :admin
+
+  def perform(aru_id, submitter_id)
+    begin
+      aru = Trade::AnnualReportUpload.find(aru_id)
+    rescue ActiveRecord::RecordNotFound => e
+      # catch this exception so that retry is not scheduled
+      Rails.logger.warn "CITES Report #{aru_id} not found"
+      Appsignal.add_exception(e) if defined? Appsignal
+      NotificationMailer.changelog_failed(user, aru).deliver
+    end
+    submitter = User.find(submitter_id)
+
+    duplicates = aru.sandbox.check_for_duplicates_in_shipments
+    if duplicates.present?
+      tempfile = Trade::ChangelogCsvGenerator.call(aru, submitter, duplicates)
+      NotificationMailer.duplicates(submitter, aru, tempfile).deliver
+      return false
+    end
+
+    return false unless aru.sandbox.copy_from_sandbox_to_shipments(submitter)
+
+    tempfile = Trade::ChangelogCsvGenerator.call(aru, submitter)
+
+    begin
+      s3 = Aws::S3::Resource.new
+      filename = "#{Rails.env}/trade/annual_report_upload/#{aru.id}/changelog.csv"
+      bucket_name = Rails.application.secrets.aws['bucket_name']
+      obj = s3.bucket(bucket_name).object(filename)
+      obj.upload_file(tempfile.path)
+
+      aru.update_attributes(aws_storage_path: obj.public_url)
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn "Something went wrong while uploading #{aru.id} to S3"
+      Appsignal.add_exception(e) if defined? Appsignal
+    end
+
+    records_submitted = aru.sandbox.moved_rows_cnt
+    # remove uploaded file
+    store_dir = aru.csv_source_file.store_dir
+    aru.remove_csv_source_file!
+    puts '### removing uploads dir ###'
+    puts Rails.root.join('public', store_dir)
+    FileUtils.remove_dir(Rails.root.join('public', store_dir), :force => true)
+
+    # clear downloads cache
+    DownloadsCache.send(:clear_shipments)
+
+    NotificationMailer.changelog(submitter, aru, tempfile).deliver
+
+    tempfile.delete
+
+    aru.sandbox.destroy
+
+    # flag as submitted
+    aru.update_attributes({
+      submitted_at: DateTime.now,
+      submitted_by_id: submitter.id,
+      number_of_records_submitted: records_submitted
+    })
+  end
+
+end

--- a/app/workers/submission_worker.rb
+++ b/app/workers/submission_worker.rb
@@ -37,10 +37,6 @@ class SubmissionWorker
     # clear downloads cache
     DownloadsCache.send(:clear_shipments)
 
-    NotificationMailer.changelog(submitter, aru, tempfile).deliver
-
-    tempfile.delete
-
     aru.sandbox.destroy
 
     # flag as submitted
@@ -49,6 +45,10 @@ class SubmissionWorker
       submitted_by_id: submitter.id,
       number_of_records_submitted: records_submitted
     })
+
+    NotificationMailer.changelog(submitter, aru, tempfile).deliver
+
+    tempfile.delete
   end
 
   private

--- a/db/plpgsql/012_check_for_duplicates_in_shipments.sql
+++ b/db/plpgsql/012_check_for_duplicates_in_shipments.sql
@@ -1,0 +1,37 @@
+DROP FUNCTION IF EXISTS check_for_duplicates_in_shipments(INTEGER);
+CREATE OR REPLACE FUNCTION check_for_duplicates_in_shipments(
+  annual_report_upload_id INTEGER
+  ) RETURNS INTEGER[]
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+    table_name TEXT;
+    duplicates_ids INTEGER[];
+  BEGIN
+    table_name = 'trade_sandbox_' || annual_report_upload_id;
+
+    EXECUTE '
+      WITH duplicates AS (
+        SELECT DISTINCT sb.id
+        FROM ' || table_name || ' AS sb
+        JOIN geo_entities AS ge ON ge.iso_code2 = sb.trading_partner
+        JOIN trade_shipments AS s ON sb.reported_taxon_concept_id = s.reported_taxon_concept_id
+        AND sb.appendix = s.appendix AND sb.year::integer = s.year
+        WHERE (
+          ge.id = s.importer_id AND NOT s.reported_by_exporter AND
+          sb.import_permit = s.import_permit_number
+        )
+        OR
+        (
+          ge.id = s.exporter_id AND s.reported_by_exporter AND
+          sb.export_permit = s.export_permit_number
+        )
+      )
+
+      SELECT ARRAY(SELECT id FROM duplicates);
+    ' INTO duplicates_ids;
+
+    RETURN duplicates_ids;
+
+  END;
+  $$;

--- a/db/plpgsql/012_check_for_duplicates_in_shipments.sql
+++ b/db/plpgsql/012_check_for_duplicates_in_shipments.sql
@@ -20,22 +20,22 @@ CREATE OR REPLACE FUNCTION check_for_duplicates_in_shipments(
         AND sb.appendix = s.appendix AND sb.year::integer = s.year
         WHERE (
           (aru.point_of_view = ''I'' AND NOT s.reported_by_exporter AND aru.trading_country_id = s.importer_id) AND
-          (COALESCE(sb.import_permit,'') = COALESCE(s.import_permit_number,''))
+          (COALESCE(sb.import_permit,'''') = COALESCE(s.import_permit_number,''''))
         )
         OR
         (
           (aru.point_of_view = ''I'' AND s.reported_by_exporter AND ge.id = s.importer_id) AND
-          (COALESCE(sb.import_permit,'') = COALESCE(s.import_permit_number,''))
+          (COALESCE(sb.import_permit,'''') = COALESCE(s.import_permit_number,''''))
         )
         OR
         (
           (aru.point_of_view = ''E'' AND s.reported_by_exporter AND aru.trading_country_id = s.exporter_id) AND
-          (COALESCE(sb.export_permit,'') = COALESCE(s.export_permit_number,''))
+          (COALESCE(sb.export_permit,'''') = COALESCE(s.export_permit_number,''''))
         )
         OR
         (
           (aru.point_of_view = ''E'' AND NOT s.reported_by_exporter AND ge.id = s.exporter_id) AND
-          (COALESCE(sb.export_permit,'') = COALESCE(s.export_permit_number,''))
+          (COALESCE(sb.export_permit,'''') = COALESCE(s.export_permit_number,''''))
         )
       )
 

--- a/db/plpgsql/012_check_for_duplicates_in_shipments.sql
+++ b/db/plpgsql/012_check_for_duplicates_in_shipments.sql
@@ -20,22 +20,22 @@ CREATE OR REPLACE FUNCTION check_for_duplicates_in_shipments(
         AND sb.appendix = s.appendix AND sb.year::integer = s.year
         WHERE (
           (aru.point_of_view = ''I'' AND NOT s.reported_by_exporter AND aru.trading_country_id = s.importer_id) AND
-          (sb.import_permit = s.import_permit_number OR (sb.import_permit IS NULL AND s.import_permit_number IS NULL))
+          (COALESCE(sb.import_permit,'') = COALESCE(s.import_permit_number,''))
         )
         OR
         (
           (aru.point_of_view = ''I'' AND s.reported_by_exporter AND ge.id = s.importer_id) AND
-          (sb.import_permit = s.import_permit_number OR (sb.import_permit IS NULL AND s.import_permit_number IS NULL))
+          (COALESCE(sb.import_permit,'') = COALESCE(s.import_permit_number,''))
         )
         OR
         (
           (aru.point_of_view = ''E'' AND s.reported_by_exporter AND aru.trading_country_id = s.exporter_id) AND
-          (sb.export_permit = s.export_permit_number OR (sb.export_permit IS NULL AND s.export_permit_number IS NULL))
+          (COALESCE(sb.export_permit,'') = COALESCE(s.export_permit_number,''))
         )
         OR
         (
           (aru.point_of_view = ''E'' AND NOT s.reported_by_exporter AND ge.id = s.exporter_id) AND
-          (sb.export_permit = s.export_permit_number OR (sb.export_permit IS NULL AND s.export_permit_number IS NULL))
+          (COALESCE(sb.export_permit,'') = COALESCE(s.export_permit_number,''))
         )
       )
 

--- a/db/plpgsql/012_check_for_duplicates_in_shipments.sql
+++ b/db/plpgsql/012_check_for_duplicates_in_shipments.sql
@@ -16,8 +16,8 @@ CREATE OR REPLACE FUNCTION check_for_duplicates_in_shipments(
         FROM ' || table_name || ' AS sb
         JOIN geo_entities AS ge ON ge.iso_code2 = sb.trading_partner
         JOIN trade_shipments AS s ON sb.reported_taxon_concept_id = s.reported_taxon_concept_id
-        JOIN trade_annual_report_uploads AS aru ON aru.id = ' || annual_report_upload_id || '
         AND sb.appendix = s.appendix AND sb.year::integer = s.year
+        JOIN trade_annual_report_uploads AS aru ON aru.id = ' || annual_report_upload_id || '
         WHERE (
           (aru.point_of_view = ''I'' AND NOT s.reported_by_exporter AND aru.trading_country_id = s.importer_id) AND
           (COALESCE(sb.import_permit,'''') = COALESCE(s.import_permit_number,''''))

--- a/db/plpgsql/012_check_for_duplicates_in_shipments.sql
+++ b/db/plpgsql/012_check_for_duplicates_in_shipments.sql
@@ -16,15 +16,26 @@ CREATE OR REPLACE FUNCTION check_for_duplicates_in_shipments(
         FROM ' || table_name || ' AS sb
         JOIN geo_entities AS ge ON ge.iso_code2 = sb.trading_partner
         JOIN trade_shipments AS s ON sb.reported_taxon_concept_id = s.reported_taxon_concept_id
+        JOIN trade_annual_report_uploads AS aru ON aru.id = ' || annual_report_upload_id || '
         AND sb.appendix = s.appendix AND sb.year::integer = s.year
         WHERE (
-          ge.id = s.importer_id AND NOT s.reported_by_exporter AND
-          sb.import_permit = s.import_permit_number
+          (aru.point_of_view = ''I'' AND NOT s.reported_by_exporter AND aru.trading_country_id = s.importer_id) AND
+          (sb.import_permit = s.import_permit_number OR (sb.import_permit IS NULL AND s.import_permit_number IS NULL))
         )
         OR
         (
-          ge.id = s.exporter_id AND s.reported_by_exporter AND
-          sb.export_permit = s.export_permit_number
+          (aru.point_of_view = ''I'' AND s.reported_by_exporter AND ge.id = s.importer_id) AND
+          (sb.import_permit = s.import_permit_number OR (sb.import_permit IS NULL AND s.import_permit_number IS NULL))
+        )
+        OR
+        (
+          (aru.point_of_view = ''E'' AND s.reported_by_exporter AND aru.trading_country_id = s.exporter_id) AND
+          (sb.export_permit = s.export_permit_number OR (sb.export_permit IS NULL AND s.export_permit_number IS NULL))
+        )
+        OR
+        (
+          (aru.point_of_view = ''E'' AND NOT s.reported_by_exporter AND ge.id = s.exporter_id) AND
+          (sb.export_permit = s.export_permit_number OR (sb.export_permit IS NULL AND s.export_permit_number IS NULL))
         )
       )
 

--- a/lib/modules/trade/changelog_csv_generator.rb
+++ b/lib/modules/trade/changelog_csv_generator.rb
@@ -1,7 +1,8 @@
 require 'csv'
 class Trade::ChangelogCsvGenerator
+  DEFAULT_COLUMNS = ['ID', 'Version', 'OP', 'ChangedAt', 'ChangedBy']
 
-  def self.call(aru, requester)
+  def self.call(aru, requester, duplicates=nil)
     data_columns = if aru.reported_by_exporter?
       Trade::SandboxTemplate::EXPORTER_COLUMNS
     else
@@ -14,20 +15,25 @@ class Trade::ChangelogCsvGenerator
 
     tempfile = Tempfile.new(["changelog_sapi_#{aru.id}-", ".csv"], Rails.root.join('tmp'))
 
-    ar_klass = aru.sandbox(true).ar_klass
+    ar_klass = aru.sandbox.ar_klass
+
+    all_columns = DEFAULT_COLUMNS + data_columns.map(&:camelize)
+    all_columns = all_columns + ['Duplicate'] if duplicates
 
     CSV.open(tempfile, 'w', headers: true) do |csv|
-      csv << ['ID', 'Version', 'OP', 'ChangedAt', 'ChangedBy'] +
-        data_columns.map(&:camelize)
+      csv << all_columns
       limit = 100
       offset = 0
       query = ar_klass.includes(:versions).limit(limit).offset(offset)
       while query.any?
         query.all.each do |shipment|
-          csv << [shipment.id, nil, nil, shipment.created_at, nil] +
+          duplicate = (duplicates && duplicates.split(',').include?(shipment.id.to_s)) ? 'D' : ''
+          values = [shipment.id, nil, nil, shipment.created_at, nil] +
             data_columns.map do |dc|
               shipment[dc]
             end
+          values = values + [duplicate] if duplicates
+          csv << values
 
           shipment.versions.each do |version|
             reified = version.reify(dup: true)
@@ -38,12 +44,13 @@ class Trade::ChangelogCsvGenerator
             elsif id_as_number
               sapi_users && sapi_users[id_as_number] || 'WCMC'
             end
-            csv << [
+            values = [
                 version.item_id, version.id, version.event, version.created_at, whodunnit
               ] +
               data_columns.map do |dc|
                 reified[dc]
               end
+            values = values + [''] if duplicates
           end
 
           offset += limit

--- a/spec/controllers/trade/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/trade/annual_report_uploads_controller_spec.rb
@@ -30,7 +30,7 @@ describe Trade::AnnualReportUploadsController do
       @aru.save(:validate => false)
       @completed_aru = build(:annual_report_upload)
       @completed_aru.save(:validate => false)
-      @completed_aru.submit(@user)
+      @completed_aru.update_attributes(submitted_at: Time.now)
     end
     it "should return all annual report uploads" do
       get :index, format: :json

--- a/spec/workers/submission_worker_spec.rb
+++ b/spec/workers/submission_worker_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+
+describe SubmissionWorker do
+  before(:each) do
+    genus = create_cites_eu_genus(
+      :taxon_name => create(:taxon_name, :scientific_name => 'Acipenser')
+    )
+    @species = create_cites_eu_species(
+      :taxon_name => create(:taxon_name, :scientific_name => 'baerii'),
+      :parent_id => genus.id
+    )
+    create(:term, :code => 'CAV')
+    create(:unit, :code => 'KIL')
+    country = create(:geo_entity_type, :name => 'COUNTRY')
+    @argentina = create(:geo_entity,
+                        :geo_entity_type => country,
+                        :name => 'Argentina',
+                        :iso_code2 => 'AR'
+                       )
+
+    @portugal = create(:geo_entity,
+                       :geo_entity_type => country,
+                       :name => 'Portugal',
+                       :iso_code2 => 'PT'
+                      )
+    @submitter = FactoryGirl.create(:user, role: User::MANAGER)
+    Trade::ChangelogCsvGenerator.stub(:call).and_return(Tempfile.new('changelog.csv'))
+  end
+  context "when no primary errors" do
+    before(:each) do
+      @aru = build(:annual_report_upload, :trading_country_id => @argentina.id, :point_of_view => 'I')
+      @aru.save(:validate => false)
+      sandbox_klass = Trade::SandboxTemplate.ar_klass(@aru.sandbox.table_name)
+      sandbox_klass.create(
+        :taxon_name => 'Acipenser baerii',
+        :appendix => 'II',
+        :trading_partner => @portugal.iso_code2,
+        :term_code => 'CAV',
+        :unit_code => 'KIL',
+        :year => '2010',
+        :quantity => 1,
+        :import_permit => 'XXX',
+        :export_permit => 'AAA; BBB'
+      )
+      create_year_format_validation
+    end
+    specify {
+      expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.to change { Trade::Shipment.count }.by(1)
+    }
+    specify {
+      expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.to change { Trade::Permit.count }.by(3)
+    }
+    specify "leading space is stripped" do
+      SubmissionWorker.new.perform(@aru.id, @submitter.id)
+      Trade::Permit.find_by_number('BBB').should_not be_nil
+    end
+    context "when permit previously reported" do
+      before(:each) { create(:permit, :number => 'xxx') }
+      specify {
+        expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.to change { Trade::Permit.count }.by(2)
+      }
+    end
+  end
+  context "when primary errors present" do
+    before(:each) do
+      @aru = build(:annual_report_upload)
+      @aru.save(:validate => false)
+      sandbox_klass = Trade::SandboxTemplate.ar_klass(@aru.sandbox.table_name)
+      sandbox_klass.create(
+        :taxon_name => 'Acipenser baerii',
+        :appendix => 'II',
+        :term_code => 'CAV',
+        :unit_code => 'KIL',
+        :year => '10'
+      )
+      create_year_format_validation
+    end
+    specify {
+      expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.not_to change { Trade::Shipment.count }
+    }
+  end
+  context "when reported under a synonym" do
+    before(:each) do
+      @synonym = create_cites_eu_species(
+        :name_status => 'S',
+        scientific_name: 'Acipenser stenorrhynchus'
+      )
+      create(:taxon_relationship,
+        :taxon_relationship_type_id => synonym_relationship_type.id,
+        :taxon_concept => @species,
+        :other_taxon_concept => @synonym
+      )
+      @aru = build(:annual_report_upload, :trading_country_id => @argentina.id, :point_of_view => 'I')
+      @aru.save(:validate => false)
+      sandbox_klass = Trade::SandboxTemplate.ar_klass(@aru.sandbox.table_name)
+      sandbox_klass.create(
+        :taxon_name => 'Acipenser stenorrhynchus',
+        :appendix => 'II',
+        :trading_partner => @portugal.iso_code2,
+        :term_code => 'CAV',
+        :unit_code => 'KIL',
+        :year => '2010',
+        :quantity => 1,
+        :import_permit => 'XXX',
+        :export_permit => 'AAA;BBB'
+      )
+      create_year_format_validation
+    end
+    specify {
+      expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.to change { Trade::Shipment.count }.by(1)
+    }
+    specify {
+      SubmissionWorker.new.perform(@aru.id, @submitter.id)
+      Trade::Shipment.first.taxon_concept_id.should == @species.id
+    }
+    specify {
+      SubmissionWorker.new.perform(@aru.id, @submitter.id)
+      Trade::Shipment.first.reported_taxon_concept_id.should == @synonym.id
+    }
+  end
+
+end

--- a/spec/workers/submission_worker_spec.rb
+++ b/spec/workers/submission_worker_spec.rb
@@ -25,6 +25,7 @@ describe SubmissionWorker do
                       )
     @submitter = FactoryGirl.create(:user, role: User::MANAGER)
     Trade::ChangelogCsvGenerator.stub(:call).and_return(Tempfile.new('changelog.csv'))
+    SubmissionWorker.any_instance.stub(:upload_on_S3)
   end
   context "when no primary errors" do
     before(:each) do


### PR DESCRIPTION
This is about [Duplicate detection when submitting into the Trade DB](https://www.pivotaltracker.com/story/show/136017501).
First of all I had to add a new plpgsql function that detects the duplicates, comparing the shipments in the annual report with the shipments in the database. I used the `copy_transactions_from_sandbox_to_shipments` function as a reference to correctly link the countries, since apparently we are handling those differently depending on the `point of view` of the aru (exporter/importer). 
After that, I made the submission to work as a sidekiq job so that we can avoid worrying about time consumption of the sql queries.

If this looks consistent, than I move to apply the same to the TRT.