### PR TITLE
Forgot this line that adds shipments versions to csv

### DIFF
--- a/lib/modules/trade/changelog_csv_generator.rb
+++ b/lib/modules/trade/changelog_csv_generator.rb
@@ -51,6 +51,7 @@ class Trade::ChangelogCsvGenerator
                 reified[dc]
               end
             values = values + [''] if duplicates
+            csv << values
           end
 
           offset += limit


### PR DESCRIPTION
This just adds a line I forgot when amending the changelog generator for the duplicates.
It now also adds the versions of a shipment to the csv.