### PR TITLE
Secretariat read only

### DIFF
--- a/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
@@ -139,7 +139,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
         .then(
           # resolve
           (() =>
-            if confirm("This will delete " + @get('total') + " shipments. Are you sure?")
+            if confirm("This will delete #{@get('total')} shipments. Are you sure?")
               $.ajax(
                 url: '/trade/shipments/destroy_batch'
                 type: 'POST'
@@ -147,7 +147,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
                   filters: @get('controllers.search.searchParams')
               )
               .done( (data) =>
-                @flashSuccess(message: 'Successfully deleted ' + data.rows + ' shipments.')
+                @flashSuccess(message: "Successfully deleted #{data.rows} shipments.")
                 @send("dataChanged")
               )
               .fail( (xhr) =>

--- a/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
@@ -71,6 +71,16 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
 
     # saves the new shipment (bound to currentShipment) to the db
     saveShipment: (shipment, ignoreWarnings) ->
+      $.ajax({
+        type: 'GET'
+        url: "/trade/user_can_edit"
+        data: {}
+        dataType: 'json'
+        success: (response) ->
+          console.log(response)
+        error: (error) ->
+          console.log(error)
+      })
       shipment.set('ignoreWarnings', ignoreWarnings)
       # Before trying to save a shipment
       # we need to reset the model to a valid state.
@@ -140,7 +150,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
               @set('currentShipment', null)
               $('.batch-form-modal').modal('hide')
             )
-        )  
+        )
       )
 
     editShipment: (shipment) ->
@@ -156,8 +166,8 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
         (() =>
           @get('batchUpdateParams').reset()
           @set('currentShipment', @get('batchUpdateParams'))
-          $('.batch-form-modal').modal('show')     
-        )  
+          $('.batch-form-modal').modal('show')
+        )
       )
 
     updateBatch: ->

--- a/app/assets/javascripts/trade/views/confirm_button_component.js.coffee
+++ b/app/assets/javascripts/trade/views/confirm_button_component.js.coffee
@@ -19,7 +19,7 @@ Trade.ConfirmButtonComponent = Ember.Component.extend
   actions:
 
     showConfirmation: () ->
-     @userCanEdit( =>
+      @userCanEdit( =>
         if confirm("Secondary errors detected. Save anyway?")
           @sendAction('action', @get('shipment'), true)
       )

--- a/app/assets/javascripts/trade/views/confirm_button_component.js.coffee
+++ b/app/assets/javascripts/trade/views/confirm_button_component.js.coffee
@@ -1,9 +1,30 @@
 Trade.ConfirmButtonComponent = Ember.Component.extend
   layoutName: 'trade/components/confirm-button'
+
+  userCanEdit: (callback) ->
+    $.ajax({
+      type: 'GET'
+      url: "/trade/user_can_edit"
+      data: {}
+      dataType: 'json'
+      success: (response) =>
+        if response.can_edit
+          callback()
+        else
+          alert('It is not possible to perform this action. If you require further assistance please contact the Species team on species@unep-wcmc.org')
+      error: (error) ->
+        console.log(error)
+    })
+
   actions:
+
     showConfirmation: () ->
-      if confirm("Secondary errors detected. Save anyway?")
-        @sendAction('action', @get('shipment'), true)
+     @userCanEdit( =>
+        if confirm("Secondary errors detected. Save anyway?")
+          @sendAction('action', @get('shipment'), true)
+      )
 
     confirm: () ->
-      @sendAction('action', @get('shipment'), false)
+      @userCanEdit( =>
+        @sendAction('action', @get('shipment'), false)
+      )

--- a/app/controllers/admin/taxon_concept_associated_types_controller.rb
+++ b/app/controllers/admin/taxon_concept_associated_types_controller.rb
@@ -1,4 +1,5 @@
 class Admin::TaxonConceptAssociatedTypesController < Admin::SimpleCrudController
+  authorize_resource class: false
   layout 'taxon_concepts'
   belongs_to :taxon_concept
 

--- a/app/controllers/admin/taxon_concept_references_controller.rb
+++ b/app/controllers/admin/taxon_concept_references_controller.rb
@@ -1,4 +1,4 @@
-class Admin::TaxonConceptReferencesController < Admin::SimpleCrudController
+class Admin::TaxonConceptReferencesController < Admin::StandardAuthorizationController
   defaults :resource_class => TaxonConceptReference, :collection_name => 'taxon_concept_references', :instance_name => 'taxon_concept_reference'
   belongs_to :taxon_concept
   before_filter :load_search, :only => [:index]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,23 +7,30 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     rescue_path = if request.referrer && request.referrer != request.url
                     request.referer
-                  elsif current_user.is_manager_or_contributor?
+                  elsif current_user.is_manager_or_contributor_or_secretariat?
                     admin_root_path
                   else
                     root_path
                   end
 
-    redirect_to rescue_path,
-      alert:  if current_user.is_manager_or_contributor?
+    message = if current_user.is_manager_or_contributor?
                 case exception.action
                 when :destroy
                   "You are not authorised to destroy that record"
                 else
                   exception.message
                 end
+              elsif current_user.is_secretariat?
+                t('secretariat_alert')
               else
                 "You are not authorised to access this page"
               end
+
+    flash[:error] = message
+    respond_to do |format|
+      format.html { redirect_to rescue_path }
+      format.js { render inline: "location.reload();" }
+    end
   end
 
   protected

--- a/app/controllers/trade_controller.rb
+++ b/app/controllers/trade_controller.rb
@@ -1,14 +1,23 @@
 class TradeController < ApplicationController
 
   before_filter :authenticate_user!
-  before_filter :verify_manager
+  before_filter :verify_manager_or_secretariat, except: [:update, :create, :destroy]
+  before_filter :verify_manager, only: [:update, :create, :destroy]
+
+  def user_can_edit
+    render json: { can_edit: current_user.is_manager? }
+  end
 
   private
 
-  def verify_manager
-    unless current_user.is_manager?
+  def verify_manager_or_secretariat
+    unless current_user.is_manager_or_secretariat?
       redirect_to signed_in_root_path(current_user)
     end
+  end
+
+  def verify_manager
+    raise CanCan::AccessDenied unless current_user.is_manager?
   end
 
   def search_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -52,7 +52,7 @@ class Ability
         Trade::ValidationRule
       ]
     elsif user.is_secretariat?
-      can [:autocomplete, :read], :all
+      can [:autocomplete, :read, :edit, :new], :all
     elsif !user.is_manager_or_contributor?
       cannot :manage, :all
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -51,6 +51,8 @@ class Ability
         Trade::Shipment, Trade::Permit, Trade::AnnualReportUpload,
         Trade::ValidationRule
       ]
+    elsif user.is_secretariat?
+      can [:autocomplete, :read], :all
     elsif !user.is_manager_or_contributor?
       cannot :manage, :all
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ActiveRecord::Base
     self.role == MANAGER
   end
 
+  def is_manager_or_secretariat?
+    is_manager? || is_secretariat?
+  end
+
   def is_contributor?
     self.role == CONTRIBUTOR
   end
@@ -79,6 +83,10 @@ class User < ActiveRecord::Base
 
   def is_manager_or_contributor?
     is_manager? || is_contributor?
+  end
+
+  def is_manager_or_contributor_or_secretariat?
+    is_manager_or_contributor? || is_secretariat?
   end
 
   def role_for_display

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |name, msg| %>
-  <%= content_tag :div, :class => "alert #{name == :alert ? "alert-error" : "alert-success" }" do %>
+  <%= content_tag :div, :class => "alert #{name == :error ? "alert-error" : "alert-success" }" do %>
     <a class="close" data-dismiss="alert" href="#">×</a>
     <%= msg %>
   <% end %>

--- a/app/views/shared/_topbar.html.erb
+++ b/app/views/shared/_topbar.html.erb
@@ -13,8 +13,8 @@
         <% if current_user %>
           <li class="<%= if controller_name == 'taxon_concepts' then 'active' end%>"><a href="/admin">Home</a></li>
         <% end %>
-        
-        <% if current_user && current_user.is_manager? %>
+
+        <% if current_user && current_user.is_manager_or_secretariat? %>
           <% controller_matches = ["taxonomies", "ranks", "designations", "change_types",
               "species_listings", "geo_entities", "languages", "tags", "purposes", "sources",
               "terms", "units"] %>
@@ -131,7 +131,7 @@
           <li class="<%= if controller_name == 'references' then 'active' end%>"><%= link_to 'References', admin_references_path %></li>
         <% end %>
 
-        <% if current_user && current_user.is_manager? %>
+        <% if current_user && current_user.is_manager_or_secretariat? %>
           <% controller_matches = ["cites_suspensions"] %>
           <li class="dropdown <%= if controller_matches.include?(controller_name) then 'active' end %>">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -157,8 +157,8 @@
             </ul>
           </li>
         <% end %>
-        
-        <% if current_user && current_user.is_manager_or_contributor? %>
+
+        <% if current_user && current_user.is_manager_or_contributor_or_secretariat? %>
           <% controller_matches = ["exports"] %>
           <li class="dropdown <%= if controller_matches.include?(controller_name) then 'active' end %>">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -175,7 +175,7 @@
               <li><%= link_to 'Species+ Visits Tracking', admin_ahoy_visits_path %></li>
               <li><%= link_to 'Species+ Activity Page', activities_path %></li>
 
-              <% if current_user && current_user.is_manager? %>
+              <% if current_user && current_user.is_manager_or_secretariat? %>
                 <li><%= link_to 'API Usage', api_usage_overview_path %></li>
               <% end %>
             </ul>

--- a/app/views/shared/_topbar.html.erb
+++ b/app/views/shared/_topbar.html.erb
@@ -166,9 +166,11 @@
               <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
-              <li><%= link_to 'Data Downloads', admin_exports_path %></li>
-              <li><%= link_to 'Species DB Statistics', admin_stats_path %></li>
-              <li><%= link_to 'Trade DB Statistics', trade_stats_path %></li>
+              <% if current_user && current_user.is_manager_or_contributor? %>
+                <li><%= link_to 'Data Downloads', admin_exports_path %></li>
+                <li><%= link_to 'Species DB Statistics', admin_stats_path %></li>
+                <li><%= link_to 'Trade DB Statistics', trade_stats_path %></li>
+              <% end %>
               <li><%= link_to 'IUCN Taxon Mapping', admin_iucn_mappings_path %></li>
               <li><%= link_to 'CMS Taxon Mapping', admin_cms_mappings_path %></li>
               <li><%= link_to 'Species+ Events Tracking', admin_ahoy_events_path %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
   export_text: "Exporting countries"
   export_tip: "Type the country or countries you wish to include in your final output. To include data for all countries, leave 'All Countries' selected"
   import_text: "Importing countries"
-  import_tip: "Type the country or countries you wish to include in your final output. To include data for all countries, leave 'All Countries' selected" 
+  import_tip: "Type the country or countries you wish to include in your final output. To include data for all countries, leave 'All Countries' selected"
   source_text: "Source"
   source_tip: "Type the source or sources (e.g. 'W - Wild') you wish to include in your final output. To include data for all sources, leave 'All Sources' selected"
   purpose_text: "Purpose"
@@ -77,3 +77,5 @@ en:
     net_imports: "Net Imports Report"
     net_exports: "Net Exports Report"
     comptab: "Comparative Tabulation Report"
+
+  secretariat_alert: "It is not possible to perform this action. If you require further assistance please contact the Species team on species@unep-wcmc.org."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ SAPI::Application.routes.draw do
     root :to => 'taxon_concepts#index'
   end
 
+  get 'trade/user_can_edit' => 'trade#user_can_edit'
   namespace :trade do
     resources :annual_report_uploads do
       resources :sandbox_shipments do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,5 +74,10 @@ describe User do
       let(:user) { create(:user, role: User::API_USER) }
       it { should_not be_able_to(:manage, TaxonConcept) }
     end
+
+    context "when is a Secretariat" do
+      let(:user) { create(:user, role: User::SECRETARIAT) }
+      it { should_not be_able_to(:manage, TaxonConcept) }
+    end
   end
 end


### PR DESCRIPTION
This is about having the Secretariat role as a read only role.
Basically, he should be able to read everything and see everything and admin can do, both into the `/admin` and `/trade` interface, but he cannot update, delete or create anything whatsoever.

I put in place same CanCan authorisations and some ajax calls in order to have an alert showing up for the javascript bits (especially for /trade and the editing functionalities of the taxa and related).

Plus, the first three options of the Stats&Downloads dropdown in `/admin` are hidden for this new role. 