### PR TITLE
Filter private documents

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -4,7 +4,8 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
 
   def index
     load_associations
-    @search = DocumentSearch.new(params.merge(show_private: true), 'admin')
+    is_secretariat = current_user && current_user.is_secretariat?
+    @search = DocumentSearch.new(params.merge(show_private: !is_secretariat), 'admin')
     index! do
       if @search.events_ids.present? && @search.events_ids.length == 1
         @event = Event.find(@search.events_ids.first)

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -87,7 +87,7 @@ class Api::V1::DocumentsController < ApplicationController
   private
 
   def access_denied?
-    !current_user || current_user.role == User::API_USER
+    !current_user || current_user.is_api_user_or_secretariat?
   end
 
   def render_404

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -47,7 +47,6 @@ class DocumentSearch
 
   def initialize_params(options)
     @options = DocumentSearchParams.sanitize(options)
-    @options[:show_private] = true if admin_interface?
     @options.keys.each { |k| instance_variable_set("@#{k}", @options[k]) }
     @offset = @per_page * (@page - 1)
   end

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -53,7 +53,7 @@ class DocumentSearch
 
   def initialize_query
     @query = Document.from("#{table_name} documents")
-    @query = @query.where(is_public: true) if !admin_interface? && !@show_private
+    @query = @query.where(is_public: true) unless @show_private
     add_conditions_for_event
     add_conditions_for_document
     add_extra_conditions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,10 @@ class User < ActiveRecord::Base
     is_manager? || is_contributor?
   end
 
+  def is_api_user_or_secretariat?
+    is_api_user? || is_secretariat?
+  end
+
   def role_for_display
     ROLES_FOR_DISPLAY[self.role] || '(empty)'
   end

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -66,6 +66,20 @@ describe Api::V1::DocumentsController, :type => :controller do
     end
   end
 
+  context "GET index returns only public documents for secretariat role" do
+    def get_public_documents
+      get :index, taxon_concept_id: @taxon_concept.id
+      response.body.should have_json_size(3).at_path('documents')
+    end
+    context "GET index api user " do
+      login_secretariat_user
+
+      it "returns only public documents" do
+        get_public_documents
+      end
+    end
+  end
+
   context "show action fails" do
     login_api_user
     it "should return 403 status when permission denied" do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -26,4 +26,11 @@ module ControllerMacros
       sign_in FactoryGirl.create(:user, role: User::API_USER)
     end
   end
+
+  def login_secretariat_user
+    before(:each) do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      sign_in FactoryGirl.create(:user, role: User::SECRETARIAT)
+    end
+  end
 end


### PR DESCRIPTION
This is about filtering out private documents if the logged in user is a Secretariat.
A secretariat can search for documents in both public and admin interface, but only the public ones will be retrieved.

It would be better to merge [this PR](https://github.com/unepwcmc/SAPI/pull/663) first.