### PR TITLE
Deactivate users

### DIFF
--- a/app/controllers/trade_controller.rb
+++ b/app/controllers/trade_controller.rb
@@ -1,17 +1,17 @@
 class TradeController < ApplicationController
 
   before_filter :authenticate_user!
-  before_filter :verify_manager_or_secretariat, except: [:update, :create, :destroy]
+  before_filter :verify_manager_or_secretariat_or_active, except: [:update, :create, :destroy]
   before_filter :verify_manager, only: [:update, :create, :destroy]
 
   def user_can_edit
-    render json: { can_edit: current_user.is_manager? }
+    render json: { can_edit: current_user.is_manager? && current_user.is_active? }
   end
 
   private
 
-  def verify_manager_or_secretariat
-    unless current_user.is_manager_or_secretariat?
+  def verify_manager_or_secretariat_or_active
+    unless current_user.is_manager_or_secretariat? || current_user.is_active
       redirect_to signed_in_root_path(current_user)
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,7 +31,9 @@ class Ability
 
     user ||= User.new
 
-    if user.is_manager?
+    if user.is_secretariat? || !user.is_active
+      can [:autocomplete, :read, :edit, :new], :all
+    elsif user.is_manager?
       can :manage, :all
     elsif user.is_contributor?
       can [:autocomplete, :read], :all
@@ -51,8 +53,6 @@ class Ability
         Trade::Shipment, Trade::Permit, Trade::AnnualReportUpload,
         Trade::ValidationRule
       ]
-    elsif user.is_secretariat?
-      can [:autocomplete, :read, :edit, :new], :all
     elsif !user.is_manager_or_contributor?
       cannot :manage, :all
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
     :trackable, :validatable
   attr_accessible :email, :name, :password, :password_confirmation,
     :remember_me, :role, :terms_and_conditions, :is_cites_authority,
-    :organisation, :geo_entity_id
+    :organisation, :geo_entity_id, :is_active
 
   MANAGER = 'admin'
   CONTRIBUTOR = 'default' # nonsense

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -56,5 +56,11 @@
         <%= f.select :role, User::ROLES_FOR_DISPLAY.to_a.map(&:reverse) %>
       </div>
     </div>
+    <div class="control-group">
+      <label class="control-label">Active</label>
+      <div class="controls">
+        <%= f.check_box :is_active %>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/users/_list.html.erb
+++ b/app/views/admin/users/_list.html.erb
@@ -1,10 +1,11 @@
 <thead>
   <th width="20%">Name</th>
   <th width="20%">Email</th>
-  <th width="10%">CITES Auth</th>
+  <th width="5%">CITES Auth</th>
   <th width="20%">Organisation</th>
   <th width="20%">Country</th>
   <th width="10%">Role</th>
+  <th width="5%">Active</th>
   <th>Actions</th>
 </thead>
 <tbody>
@@ -36,6 +37,9 @@
       </td>
       <td>
         <%= user.role_for_display %>
+      </td>
+      <td>
+        <%= true_false_icon(user.is_active) %>
       </td>
       <td>
         <% if can?(:update, user) %>

--- a/db/migrate/20170404125230_add_is_active_column_to_users.rb
+++ b/db/migrate/20170404125230_add_is_active_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsActiveColumnToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :is_active, :boolean, default: true, null: false
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -77,7 +77,16 @@ describe User do
 
     context "when is a Secretariat" do
       let(:user) { create(:user, role: User::SECRETARIAT) }
-      it { should_not be_able_to(:manage, TaxonConcept) }
+      it { should_not be_able_to(:create, :all) }
+      it { should_not be_able_to(:update, :all) }
+      it { should_not be_able_to(:destroy, :all) }
+    end
+
+    context "when is not active" do
+      let(:user) { create(:user, role: User::MANAGER, is_active: false) }
+      it { should_not be_able_to(:create, :all) }
+      it { should_not be_able_to(:update, :all) }
+      it { should_not be_able_to(:destroy, :all) }
     end
   end
 end


### PR DESCRIPTION
This is about adding a flag to activate/deactivate users. By default, all users are active, but if a user is set to be inactive, then, regardless of the role, it has no abilities to create, update or destroy things; basically behaves like the secretariat, so the user is still able to read everything but not to alter any data.