### PR TITLE
Higher taxa trade download and import scripts

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -18,15 +18,15 @@ $(document).ready(function(){
   function growlMe(text){
   	$.jGrowl(text);
   };
-  
+
   function growlMeSticky(text){
   	$.jGrowl(text, {sticky: true});
   };
-  
+
   function notyNormal(message){
   	noty({layout: 'topRight', text: message, timeout: 4000});
   };
-  
+
   function notySticky(message){
   	noty({ layout: 'top',
    			   type: 'information',
@@ -41,24 +41,24 @@ $(document).ready(function(){
 		{
 			event : 'mouseover',
 			autoHeight: false
-		}								  
+		}
 	);
-   
+
   //setting the tabs for the search
   $("#tabs").tabs().addClass('ui-tabs-vertical ui-helper-clearfix');
   //enabling the tabs to be visible again
   $("#tabs").css("display", "block");
 	$("#tabs li").removeClass('ui-corner-top').addClass('ui-corner-left');
- 
+
   $(".someClass").tipTip({maxWidth: "300px"});
   //using the qtip2 plugin
   $(".qtipify").qtip(
-	{				
+	{
 		style: {
       classes: 'ui-tooltip-green ui-tooltip-cluetip'
-   	}				
+   	}
 	});
- 
+
   $("#genus_all_id").val('').trigger("liszt:updated");
   $("#genus_all_id").chosen({
   	allow_single_deselect:true,
@@ -69,14 +69,14 @@ $(document).ready(function(){
   });
 
   $('#taxon_search').width(300);
- 
+
   function initialiseControls() {
 	  $('#selection_taxon_taxon').attr('checked', true);
-	  $('#div_genus').find('button').addClass('ui-state-disabled')
+	  $('#div_taxonomic_cascade').find('button').addClass('ui-state-disabled')
       .removeClass('ui-state-enabled');
 	  $('#genus_all_id_chzn').removeClass('chzn-container-active')
       .addClass('chzn-disabled');
-	  $('#div_genus :input').attr('disabled', true);
+	  $('#div_taxonomic_cascade :input').attr('disabled', true);
 	  //prevent form support on input and select enter
 	  $('input,select').keypress(function(event) { return event.keyCode != 13; });
   };
@@ -90,7 +90,7 @@ $(document).ready(function(){
       }
     });
   }
-  
+
 
   function parseInputs ($inputs) {
     var values = {};
@@ -175,13 +175,13 @@ $(document).ready(function(){
  	  $('#qryTo').find('option:first').attr('selected', 'selected')
       .trigger('change');
  	  $('#taxon_search').val('');
- 	  $('#genus_search').val('');
+ 	  $('#taxonomic_cascade_search').val('');
  	  $('#species_out').text('');
  	  $('#sources').select2("val","all_sou");
  	  $('#purposes').select2("val","all_pur");
  	  $('#terms').select2("val","all_ter");
  	  $('#expcty').select2("val","all_exp");
- 	  $('#impcty').select2("val","all_imp");	
+ 	  $('#impcty').select2("val","all_imp");
     notySticky('Values are being reset...');
     $('#search-error-message').hide();
     $("#cites-trade-loading").hide();
@@ -197,27 +197,27 @@ $(document).ready(function(){
     selected_taxa = '';
   	return false;
   });
- 
+
   //Radio selector for genus or taxon search
   $("input[name='selection_taxon']").on('change',function(){
 	  var myValue = $(this).attr('id');
-	  if (myValue == 'selection_taxon_genus') {
+	  if (myValue == 'selection_taxon_cascade') {
 	  	$('#div_taxon').find('input').addClass('ui-state-disabled')
         .removeClass('ui-state-enabled');
-	  	$('#div_genus').find('button').removeClass('ui-state-disabled')
+	  	$('#div_taxonomic_cascade').find('button').removeClass('ui-state-disabled')
         .addClass('ui-state-enabled');
 	  	$('#div_taxon :input').attr('disabled', true);
-	  	$('#div_genus :input').removeAttr('disabled');
+	  	$('#div_taxonomic_cascade :input').removeAttr('disabled');
 	  	$('#taxon_search').val('');
 	  	$('#species_out').text('');
 	  } else {
-	  	$('#div_genus').find('button').addClass('ui-state-disabled')
+	  	$('#div_taxonomic_cascade').find('button').addClass('ui-state-disabled')
         .removeClass('ui-state-enabled');
 	  	$('#div_taxon').find('input').removeClass('ui-state-disabled')
         .addClass('ui-state-enabled');
 	  	$('#div_taxon :input').removeAttr('disabled');
-	  	$('#div_genus :input').attr('disabled', true);
-      $('#genus_search').val('');
+	  	$('#div_taxonomic_cascade :input').attr('disabled', true);
+      $('#taxonomic_cascade_search').val('');
 	  	$('#species_out').text('');
 	  }
   });
@@ -227,17 +227,17 @@ $(document).ready(function(){
   		bgColor: '#E6EDD7',
   		hoverColor: '#D2EF9A'
   });
-   
-  
+
+
   function getSelectionTextNew(source) {
   	var values = [];
-  
+
   	$('#ms-' + source).find('div.ms-selection ul.ms-list  li').each(function() {
       values.push($(this).text());
     });
-  
+
   	return values.join(',')
-  } 
+  }
 
   function getSelectionText(source) {
   	myValues = new Array();
@@ -246,28 +246,28 @@ $(document).ready(function(){
     });
   	return myValues.toString();
   }
-  
+
   initUnitsObj = function (data) {
     _.each(data.units, function (unit) {
       units[unit.id] = unit;
     });
     unLock('initUnitsObj');
   }
-  
+
   initCountriesObj = function (data) {
     _.each(data.geo_entities, function (country) {
       countries[country.id] = country;
     });
     unLock('initCountriesObj');
   }
-  
+
   initTermsObj = function (data) {
     _.each(data.terms, function (term) {
       terms[term.id] = term;
     });
     unLock('initTermsObj');
   }
-  
+
   initPurposesObj = function (data) {
     _.each(data.purposes, function (purpose) {
       purposes[purpose.id] = purpose;
@@ -288,7 +288,7 @@ $(document).ready(function(){
   	  	condition: function (item) {return item.iso_code2},
   	  	text: function (item) {return item.name}
   	  };
-  
+
     initCountriesObj(data);
   	populateSelect(_.extend(args, {
   		selection: $('#expcty'),
@@ -315,7 +315,7 @@ $(document).ready(function(){
     	}
     	$('#expcty_out').text(selection);
     });
-  
+
     populateSelect(_.extend(args, {
   		selection: $('#impcty'),
   		value: function (item) {return item.id}
@@ -343,7 +343,7 @@ $(document).ready(function(){
     	$('#impcty_out').text(selection);
     });
   };
-  
+
   initTerms = function (data) {
   	var selection = $('#terms'),
   	  args = {
@@ -418,7 +418,7 @@ $(document).ready(function(){
     	$('#sources_out').text(selection);
     });
   };
-  
+
   initPurposes = function (data) {
   	var selection = $('#purposes'),
   	  args = {
@@ -431,7 +431,7 @@ $(document).ready(function(){
       alloption = 'all_pur';
   	allOptionsDictionary[alloption] = true;
     initPurposesObj(data);
-  	populateSelect(args); 
+  	populateSelect(args);
     selection.select2({
     	width: '75%',
     	allowClear: false,
@@ -483,24 +483,24 @@ $(document).ready(function(){
   	}
   	return myValues.toString();
   }
-  
+
   function show_values_selection() {
   	var year_from = $('#qryFrom').val();
   	var year_to = $('#qryTo').val();
   	var exp_cty = $('#expctyms2side__dx').text();
   	var imp_cty = $('#impctyms2side__dx').text();
-  	var sources = $('#sourcesms2side__dx').text(); 
+  	var sources = $('#sourcesms2side__dx').text();
   	var purposes = $('#purposesms2side__dx').text();
   	var terms = $('#termsms2side__dx').text();
-  	
+
   	$('#year_from > span').text(year_from);
     $('#year_to > span').text(year_to);
   	$('#expcty_out').text(getSelectionText('expcty'));
   	$('#impcty_out').text(getSelectionText('impcty'));
   	$('#sources_out').text(getSelectionText('sources'));
   	$('#purposes_out').text(getSelectionText('purposes'));
-  	$('#terms_out').text(getSelectionText('terms'));		
-  	$('#genus_all_id').val();				  
+  	$('#terms_out').text(getSelectionText('terms'));
+  	$('#genus_all_id').val();
   };
 
   $('#side .ui-button, #form .ui-button').hover(function() {
@@ -523,6 +523,9 @@ $(document).ready(function(){
     )){
       displayName += ' spp. ';
     }
+    else {
+      displayName = '[' + taxon.rank_name + '] ' + displayName;
+    }
     return displayName + getFormattedSynonyms(taxon);
   }
 
@@ -535,7 +538,7 @@ $(document).ready(function(){
     // 'red collared' should highlight 'red-collared'
     return taxonDisplayName.replace(new RegExp("(" + term + '|' + termWithHyphens+ ")", "gi"), transform);
   }
-  
+
   function parseTaxonData (data, term, showSpp) {
     var d = data.auto_complete_taxon_concepts;
   	return _.map(d, function (element, index) {
@@ -547,7 +550,7 @@ $(document).ready(function(){
       };
   	});
   }
-   
+
   //Autocomplete for cites_names
   if (is_search_page) {
     $("#taxon_search").autocomplete({
@@ -600,7 +603,7 @@ $(document).ready(function(){
 
   //Autocomplete for cites_genus
   if (is_search_page) {
-    $("#genus_search").autocomplete({
+    $("#taxonomic_cascade_search").autocomplete({
     	source: function(request, response) {
         var term = request.term;
         $.ajax({
@@ -609,7 +612,6 @@ $(document).ready(function(){
           data: {
             taxonomy: 'CITES',
             taxon_concept_query: request.term,
-            'ranks[]': 'GENUS',
             visibility: 'trade'
           },
           success: function(data) {
@@ -660,7 +662,7 @@ $(document).ready(function(){
 
   //Put functions to be executed here
   initialiseControls();
-  
+
   function populateSelect(args) {
   	var data = args.data,
   	  selection = args.selection,
@@ -671,7 +673,7 @@ $(document).ready(function(){
 	  	if (condition(item)) {
 	      selection.append('<option title="' + text(item)
 	      	+ '" value="' + value(item) + '">' + text(item) + '</option>');
-	    } 
+	    }
     });
   }
 
@@ -689,7 +691,7 @@ $(document).ready(function(){
   }
 
   function buildHeader (data) {
-    var header = 
+    var header =
       "<thead><tr><% _.each(d, function(h) { %> <td><%=h%></td> <% }); %></tr></thead>";
     return _.template(header, {d: data});
   }
@@ -722,8 +724,8 @@ $(document).ready(function(){
 
   function displayResults (q) {
     var table_view_title, formURL = '/cites_trade/shipments',
-      data_headers, data_rows, table_tmpl, 
-      comptab_regex = /comptab/, 
+      data_headers, data_rows, table_tmpl,
+      comptab_regex = /comptab/,
       gross_net_regex = /(gross_exports|gross_imports|net_exports|net_imports)/;
     $.ajax(
       {
@@ -776,7 +778,7 @@ $(document).ready(function(){
       report_type = $( "select[name='reportType']" ).val();
     }
     query += "&filters[report_type]=" + report_type;
-    if (!ignoreWarning &&
+    if (!ignoreWarning &
       (report_type == 'net_imports' || report_type == 'net_exports')
     ) {
       $('#this_should_not_be_a_table').hide();
@@ -807,13 +809,13 @@ $(document).ready(function(){
   // View results page specific:
 
   // This locks-unLock rubbish is used to guarantee that, when populating the
-  // results tables, all the ajax calls for the drop-down menus (that also 
+  // results tables, all the ajax calls for the drop-down menus (that also
   // populate our data objects) are terminated!
   var locks = {
-    'initUnitsObj': true, 
-    'initCountriesObj': true, 
-    'initTermsObj': true, 
-    'initPurposesObj': true, 
+    'initUnitsObj': true,
+    'initCountriesObj': true,
+    'initTermsObj': true,
+    'initPurposesObj': true,
     'initSourcesObj': true
   };
   function unLock (function_name) {
@@ -827,7 +829,7 @@ $(document).ready(function(){
     if (!l && is_view_results_page) {
       // It is time to show these tables!
       displayResults(getParamsFromURI());
-    }
+   }
   }
 
 });

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -98,7 +98,7 @@ $(document).ready(function(){
         }
       }
     });
-    values['selection_taxon'] = $('#selection_taxon_cascade').val();
+    values['selection_taxon'] = 'taxonomic_cascade';
     return values;
   }
 

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -68,15 +68,9 @@ $(document).ready(function(){
   	$('#species_out').text(my_value);
   });
 
-  $('#taxon_search').width(300);
-
   function initialiseControls() {
-	  $('#selection_taxon_taxon').attr('checked', true);
-	  $('#div_taxonomic_cascade').find('button').addClass('ui-state-disabled')
-      .removeClass('ui-state-enabled');
 	  $('#genus_all_id_chzn').removeClass('chzn-container-active')
       .addClass('chzn-disabled');
-	  $('#div_taxonomic_cascade :input').attr('disabled', true);
 	  //prevent form support on input and select enter
 	  $('input,select').keypress(function(event) { return event.keyCode != 13; });
   };
@@ -104,7 +98,7 @@ $(document).ready(function(){
         }
       }
     });
-    values['selection_taxon'] = $('input[name="selection_taxon"]:checked').val();
+    values['selection_taxon'] = $('#selection_taxon_cascade').val();
     return values;
   }
 
@@ -174,7 +168,6 @@ $(document).ready(function(){
       .trigger('change');
  	  $('#qryTo').find('option:first').attr('selected', 'selected')
       .trigger('change');
- 	  $('#taxon_search').val('');
  	  $('#taxonomic_cascade_search').val('');
  	  $('#species_out').text('');
  	  $('#sources').select2("val","all_sou");
@@ -198,29 +191,10 @@ $(document).ready(function(){
   	return false;
   });
 
-  //Radio selector for genus or taxon search
-  $("input[name='selection_taxon']").on('change',function(){
-	  var myValue = $(this).attr('id');
-	  if (myValue == 'selection_taxon_cascade') {
-	  	$('#div_taxon').find('input').addClass('ui-state-disabled')
-        .removeClass('ui-state-enabled');
-	  	$('#div_taxonomic_cascade').find('button').removeClass('ui-state-disabled')
-        .addClass('ui-state-enabled');
-	  	$('#div_taxon :input').attr('disabled', true);
-	  	$('#div_taxonomic_cascade :input').removeAttr('disabled');
-	  	$('#taxon_search').val('');
-	  	$('#species_out').text('');
-	  } else {
-	  	$('#div_taxonomic_cascade').find('button').addClass('ui-state-disabled')
-        .removeClass('ui-state-enabled');
-	  	$('#div_taxon').find('input').removeClass('ui-state-disabled')
-        .addClass('ui-state-enabled');
-	  	$('#div_taxon :input').removeAttr('disabled');
-	  	$('#div_taxonomic_cascade :input').attr('disabled', true);
-      $('#taxonomic_cascade_search').val('');
-	  	$('#species_out').text('');
-	  }
-  });
+  $('#div_taxonomic_cascade').find('button').removeClass('ui-state-disabled')
+    .addClass('ui-state-enabled');
+  $('#div_taxonomic_cascade :input').removeAttr('disabled');
+  $('#species_out').text('');
 
   $('#table_selection').colorize({
   		altColor: '#E6EDD7',
@@ -546,56 +520,6 @@ $(document).ready(function(){
         'drop_label': getTaxonLabel(displayName, term)
       };
   	});
-  }
-
-  //Autocomplete for cites_names
-  if (is_search_page) {
-    $("#taxon_search").autocomplete({
-    	source: function(request, response) {
-        var term = request.term;
-        $.ajax({
-          url: "/api/v1/auto_complete_taxon_concepts",
-          dataType: "json",
-          data: {
-            taxonomy: 'CITES',
-            taxon_concept_query: term,
-            visibility: 'trade'
-          },
-          success: function(data) {
-            response(parseTaxonData(data, term, true));
-          },
-    			error : function(xhr, ajaxOptions, thrownError){
-    				growlMe(xhr.status + " ====== " + thrownError);
-    			}
-        });
-      },
-    	select: function( event, ui ) {
-    		$(this).attr('value', ui.item.label);
-        selected_taxa = ui.item.value;
-    		$('#species_out').text(ui.item.label);
-    		return false;
-    	},
-      response: function(event, ui) {
-        if (!ui.content.length) {
-          var noResult = { value:"" };
-          ui.content.push(noResult);
-        }
-      },
-      change: function(event, ui){
-        if (ui.item === null || ui.item.label !== $(this).val() ){
-          $(this).val('');
-          $('#species_out').text('');
-          selected_taxa = '';
-        }
-      }
-    }).data( "ui-autocomplete" )._renderItem = function( ul, item ) {
-      if (item.value === ''){
-        return $( "<li>" ).append("No results").appendTo( ul );
-      }
-      return $( "<li>" )
-        .append( "<a>" + item.drop_label + "</a>" )
-        .appendTo( ul );
-      }
   }
 
   function parseTaxonCascadeData(data, term, showSpp) {

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -561,6 +561,7 @@ $(document).ready(function(){
           url: "/api/v1/auto_complete_taxon_concepts",
           dataType: "json",
           data: {
+            locale: locale,
             taxonomy: 'CITES',
             taxon_concept_query: request.term,
             visibility: 'cites_trade'

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -570,6 +570,7 @@ $(document).ready(function(){
               return element.rank_name;
             });
             response(parseTaxonCascadeData(data, term, false));
+            $('input#taxonomic_cascade_search').removeClass('ui-autocomplete-loading');
           },
     			error : function(xhr, ajaxOptions, thrownError){
     				growlMe(xhr.status + " ====== " + thrownError);

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -612,7 +612,7 @@ $(document).ready(function(){
           data: {
             taxonomy: 'CITES',
             taxon_concept_query: request.term,
-            visibility: 'trade'
+            visibility: 'cites_trade'
           },
           success: function(data) {
             response(parseTaxonData(data, term, false));

--- a/app/assets/stylesheets/cites_trade/cites.scss
+++ b/app/assets/stylesheets/cites_trade/cites.scss
@@ -73,3 +73,8 @@ div#loading {
 li.rank-name {
   font-weight: bold;
 }
+
+div.taxon-search-container {
+  display: flex;
+  justify-content: center;
+}

--- a/app/assets/stylesheets/cites_trade/cites.scss
+++ b/app/assets/stylesheets/cites_trade/cites.scss
@@ -3,8 +3,8 @@ body {
 	/*background: white;*/
 	font-face: Verdana, Arial, Helvetica, sans-serif;
 	/*bgcolor: #FFFFFF;*/
-	
-	
+
+
 }
 #tot {
 	margin-left:50px;
@@ -40,16 +40,16 @@ body {
 .heading_label{
 	/*width: 400px;*/
 	font-size: 20px;
-	font-weight:400; 
-	font-face: Verdana, Arial, Helvetica, sans-serif; 
+	font-weight:400;
+	font-face: Verdana, Arial, Helvetica, sans-serif;
 	color: green;
 	/*align: center;*/
 	padding-top:10px;
 }
 .text_label{
-	border: 1px; 
-	font-size: 1em; 
-	font-face: Verdana, Arial, Helvetica, sans-serif; 
+	border: 1px;
+	font-size: 1em;
+	font-face: Verdana, Arial, Helvetica, sans-serif;
 	color: #000;
 }
 
@@ -70,4 +70,6 @@ div#loading {
     cursor: wait;
     }
 
-
+li.rank-name {
+  font-weight: bold;
+}

--- a/app/controllers/cites_trade_controller.rb
+++ b/app/controllers/cites_trade_controller.rb
@@ -22,7 +22,7 @@ class CitesTradeController < ApplicationController
     ).merge({
       # if taxon search comes from the genus selector, search descendants
       :taxon_with_descendants =>
-        (params[:filters] && params[:filters][:selection_taxon] == 'genus'),
+        (params[:filters] && params[:filters][:selection_taxon] == 'taxonomic_cascade'),
       :report_type =>
         if params[:filters] && params[:filters][:report_type] &&
           Trade::ShipmentsExportFactory.public_report_types.include?(

--- a/app/models/trade/filter.rb
+++ b/app/models/trade/filter.rb
@@ -30,14 +30,12 @@ class Trade::Filter
 
     unless @taxon_concepts_ids.empty?
       cascading_ranks =
-        if @internal
-          # always cascade if query is coming from the internal interface
-          Rank.in_range(Rank::SPECIES, Rank::KINGDOM)
-        elsif @taxon_with_descendants && !@internal
+        if @internal || @taxon_with_descendants
+          # always cascade if query is coming from the internal and now also public interface
           # the magnificent hack to make sure that queries coming from the public
-          # interface cascade to taxon descendants when searching by genus,
-          # but only through the 'genus' selector, not 'taxon'
-          Rank.in_range(Rank::SPECIES, Rank::GENUS)
+          # interface cascade to taxon descendants when searching across all taxonomic levels,
+          # but only through the 'all_taxa' selector, not 'taxon'
+          Rank.in_range(Rank::SPECIES, Rank::KINGDOM)
         else
           # this has to be public interface + search by taxon
           # only cascade for species

--- a/app/serializers/species/autocomplete_taxon_concept_serializer.rb
+++ b/app/serializers/species/autocomplete_taxon_concept_serializer.rb
@@ -1,3 +1,8 @@
 class Species::AutocompleteTaxonConceptSerializer < ActiveModel::Serializer
   attributes :id, :full_name, :rank_name, :name_status, :matching_names
+
+  def rank_name
+    rank_with_locale = "rank_display_name_#{I18n.locale.to_s}"
+    object.send(rank_with_locale.to_sym)
+  end
 end

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -129,21 +129,15 @@
           </div>
           <hr />
           <hr class="space" />
-          <div class="grid_2">
-            <input id="selection_taxon_taxon" type="radio" name="selection_taxon" value="taxon">&nbsp;
-          </div>
-          <div  id="div_taxon" class="grid_8">
-            <span style="padding:10px 0px"><%= t('taxon_title') %></span><br />
-            <input type="text" size="30" name="taxon_concepts_ids[]" id="taxon_search" value=""><br>
-          </div>
-          <hr class="space">
 
-          <div class="grid_2">
-            <input id="selection_taxon_cascade" type="radio" name="selection_taxon" value="taxonomic_cascade">&nbsp;
-          </div>
-          <div id="div_taxonomic_cascade" class="grid_8">
-            <span style="padding:10px 0px">Select across all taxonomic levels</span><br />
-            <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>
+          <div class="taxon-search-container">
+            <div class="grid_2">
+              <input id="selection_taxon_cascade" type="hidden" name="selection_taxon" value="taxonomic_cascade">&nbsp;
+            </div>
+            <div id="div_taxonomic_cascade" class="grid_8">
+              <span style="padding:10px 0px">Select across all taxonomic levels</span><br />
+              <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>
+            </div>
           </div>
 
         </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -20,7 +20,7 @@
         <div style="text-align: left; color:#FF0000; font-weight:bold; display:none;"
           id="csv-limit-exceeded-error-message">
           <%= t('errors.csv_limit_exceeded_1') %>.<br>
-          <%= t('errors.csv_limit_exceeded_2') %>.
+          <%#= t('errors.csv_limit_exceeded_2') %>.
         </div>
 
       </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -20,7 +20,7 @@
         <div style="text-align: left; color:#FF0000; font-weight:bold; display:none;"
           id="csv-limit-exceeded-error-message">
           <%= t('errors.csv_limit_exceeded_1') %>.<br>
-          <%#= t('errors.csv_limit_exceeded_2') %>.
+          <%#= t('errors.csv_limit_exceeded_2') %>
         </div>
 
       </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -1,6 +1,6 @@
 
   <form id='form_expert'>
- 
+
     <br>
 
     <div class="grid_16 main_content">
@@ -139,11 +139,11 @@
           <hr class="space">
 
           <div class="grid_2">
-            <input id="selection_taxon_genus" type="radio" name="selection_taxon" value="genus">&nbsp;
+            <input id="selection_taxon_cascade" type="radio" name="selection_taxon" value="taxonomic_cascade">&nbsp;
           </div>
-          <div id="div_genus" class="grid_8">
-            <span style="padding:10px 0px"><%= t('genus_title') %></span><br />
-            <input type="text" size="30" name="taxon_concepts_ids[]" id="genus_search" value=""><br>
+          <div id="div_taxonomic_cascade" class="grid_8">
+            <span style="padding:10px 0px">Select across all taxonomic levels</span><br />
+            <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>
           </div>
 
         </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -58,9 +58,12 @@
         </ul>
 
         <div id="tabs-year">
-          <div id="year" class="label_style"><%= t('year_text') %> :
-            <img src="/assets/cites_trade/information3.gif" class="qtipify" title="<%= t('year_tip') %> " />
+          <div id="year" class="label_style">
+            <%= t('year_text') %> :
           </div>
+          <p>
+            <%= t('year_tip') %>
+          </p>
           <%= t('from') %>
           <%= select_tag 'time_range_start', options_for_select(@years, @years.first), id: "qryFrom" %> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
           <%= t('to') %>
@@ -132,7 +135,7 @@
 
           <div class="taxon-search-container">
             <div id="div_taxonomic_cascade" class="grid_8">
-              <span style="padding:10px 0px">Select across all taxonomic levels</span><br />
+              <span style="padding:10px 0px">Search for species or higher taxon</span><br />
               <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>
             </div>
           </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -131,9 +131,6 @@
           <hr class="space" />
 
           <div class="taxon-search-container">
-            <div class="grid_2">
-              <input id="selection_taxon_cascade" type="hidden" name="selection_taxon" value="taxonomic_cascade">&nbsp;
-            </div>
             <div id="div_taxonomic_cascade" class="grid_8">
               <span style="padding:10px 0px">Select across all taxonomic levels</span><br />
               <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -135,7 +135,7 @@
 
           <div class="taxon-search-container">
             <div id="div_taxonomic_cascade" class="grid_8">
-              <span style="padding:10px 0px">Search for species or higher taxon</span><br />
+              <span style="padding:10px 0px"><%= t('taxon_search') %></span><br />
               <input type="text" size="30" name="taxon_concepts_ids[]" id="taxonomic_cascade_search" value=""><br>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
   errors:
     no_data_1: "Your query has returned no data"
     no_data_2: "Please select other variables"
-    csv_limit_exceeded_1: "Your query has returned too large a subset"
+    csv_limit_exceeded_1: "Your query has returned too large a subset (greater than 1 million records). You must limit the year range and select at least one import/export country or one taxon."
     csv_limit_exceeded_2: "You must limit the year range and select at least one import/export country or one taxon"
     web_limit_exceeded_1: "Web output is not available for large subsets"
     web_limit_exceeded_2: "Please download the results in CSV format"
@@ -30,7 +30,7 @@ en:
   trade_text: "Trade Terms"
   trade_tip: "Type the term or terms (e.g. 'live' or 'skins') you wish to include in your final output. To include data for all terms, leave 'All Terms' selected"
   taxon_text: "Search by taxon"
-  taxon_tip: "To retrieve data for a specific taxon, type in the taxon name. Data on specimens recorded in trade at the higher taxon level (e.g. Scleractinia spp.) can also be retrieved through this search. To retrieve data for all species within a particular genus, select a genus from the drop-down below. To select all taxa, leave these sections blank."
+  taxon_tip: "To retrieve data for a specific taxon, type in the taxon name. To retrieve data for all species within a particular higher taxon (e.g. genus, family, order, class etc.), select a higher taxon from the drop-down below. To select all taxa, leave the selection blank."
   taxon_title: "Search for taxon reported trade:"
   genus_title: "Search for genus:"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
   taxon_text: "Search by taxon"
   taxon_tip: "To retrieve data for a specific taxon, type in the taxon name. To retrieve data for all species within a particular higher taxon (e.g. genus, family, order, class etc.), select a higher taxon from the drop-down below. To select all taxa, leave the selection blank."
   taxon_title: "Search for taxon reported trade:"
+  taxon_search: "Search for species or higher taxon"
   genus_title: "Search for genus:"
 
   all_countries: "All Countries"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
   errors:
     no_data_1: "Your query has returned no data"
     no_data_2: "Please select other variables"
-    csv_limit_exceeded_1: "Your query has returned too large a subset (greater than 1 million records). You must limit the year range and select at least one import/export country or one taxon."
+    csv_limit_exceeded_1: "Your query has returned too large a subset (greater than 1 million records). You must limit the year range and select at least one import/export country or one taxon"
     csv_limit_exceeded_2: "You must limit the year range and select at least one import/export country or one taxon"
     web_limit_exceeded_1: "Web output is not available for large subsets"
     web_limit_exceeded_2: "Please download the results in CSV format"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -27,8 +27,9 @@ es:
   trade_text: "Términos del Comercio"
   trade_tip: "Introduzca el término/los términos (ej. 'vivo' o 'piel') que desea incluir en el producto final.  Para incluir datos de todos los los términos, mantenga seleccionado 'Todos los Términos'"
   taxon_text: "Buscar por taxón"
-  taxon_tip: "Para buscar datos de un taxón específico, escriba el nombre del taxon. Para buscar datos de todas las especies dentro de un grupo taxonómico en particular (por ejemplo género, familia, orden, clase, etc.), seleccione un grupo taxonómico en el menú desplegable de abajo. Para seleccionar todos los taxones, deje esta sección en blanco."
+  taxon_tip: "Para buscar datos de un especie específica, escriba el nombre del taxón. Para buscar datos de todas las especies dentro de un grupo taxonómico en particular (por ejemplo género, familia, orden, clase, etc.), escriba el nombre y seleccione el grupo taxonómico en el menú desplegable de abajo. Para seleccionar todos los taxones, deje esta sección en blanco. Es aconsejable limitar la búsqueda de datos a un taxónn específico debido al volumen de datos (hay un límite de un millón de filas para la descarga de datos)."
   taxon_title: "Buscar por taxón:"
+  taxon_search: "Buscar por especie o grupo taxonómico"
   genus_title: "Seleccione un género:"
 
   all_countries: "Todos los Países"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -26,7 +26,7 @@ es:
   purpose_tip: "Introduzca el objetivo/los objetivos (ej. 'T- Comercial' o 'S- Científico') que desea incluir en el producto final.  Para incluir datos de todos los objetivos, mantenga seleccionado 'Todos los Objetivos'"
   trade_text: "Términos del Comercio"
   trade_tip: "Introduzca el término/los términos (ej. 'vivo' o 'piel') que desea incluir en el producto final.  Para incluir datos de todos los los términos, mantenga seleccionado 'Todos los Términos'"
-  taxon_text: "Buscar por taxón :"
+  taxon_text: "Buscar por taxón"
   taxon_tip: "Para buscar datos de un taxón específico, escriba el nombre del taxon. Para buscar datos de todas las especies dentro de un grupo taxonómico en particular (por ejemplo género, familia, orden, clase, etc.), seleccione un grupo taxonómico en el menú desplegable de abajo. Para seleccionar todos los taxones, deje esta sección en blanco."
   taxon_title: "Buscar por taxón:"
   genus_title: "Seleccione un género:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,7 +5,7 @@ es:
   errors:
     no_data_1: "Su consulta ha devuelto ningún dato"
     no_data_2: "Por favor selecciona otras variables"
-    csv_limit_exceeded_1: "Su búsqueda ha encontrado un subconjunto demasiado grande"
+    csv_limit_exceeded_1: "Su búsqueda ha resultado en un subconjunto de datos demasiado grande (más de 1 millón de registros). Debe limitar el rango de años y seleccionar al menos un país de importación/exportación o un taxón."
     csv_limit_exceeded_2: "Debe limitar el rango de años y seleccionar al menos un país de importación/exportación o un taxón"
     web_limit_exceeded_1: "Vista en línea no está disponible para grandes subconjuntos"
     web_limit_exceeded_2: "Puede descargar los resultados en formato CSV"
@@ -19,7 +19,7 @@ es:
   export_text: "Países de exportación"
   export_tip: "Introduzca el país/los países que desea incluir en el producto final. Para incluir datos de todos los países, mantenga seleccionado 'Todos los Países'"
   import_text: "Países importadores"
-  import_tip: "Introduzca el país/los países que desea incluir en el producto final. Para incluir datos de todos los países, mantenga seleccionado 'Todos los Países'" 
+  import_tip: "Introduzca el país/los países que desea incluir en el producto final. Para incluir datos de todos los países, mantenga seleccionado 'Todos los Países'"
   source_text: "Origen"
   source_tip: "Introduzca el origen/los origenes (ej. 'W- Recolectados en el medio silvestre') que desea incluir en el producto final.  Para incluir datos de todos los orígenes, mantenga seleccionado  'Todos los Orígenes'"
   purpose_text: "Objetivo"
@@ -27,7 +27,7 @@ es:
   trade_text: "Términos del Comercio"
   trade_tip: "Introduzca el término/los términos (ej. 'vivo' o 'piel') que desea incluir en el producto final.  Para incluir datos de todos los los términos, mantenga seleccionado 'Todos los Términos'"
   taxon_text: "Buscar por taxón :"
-  taxon_tip: "Para recuperar datos de un taxón específico, escriba el nombre del taxón. Los datos sobre especímenes registrados en el comercio a un nivel de taxón superior (por ejemplo, Scleractinia spp.) también pueden ser recuperados a través de esta búsqueda. Para recuperar los datos de todas las especies dentro de un género en particular, seleccione un género desde el menú desplegable debajo. Para seleccionar todos los taxones, dejar estos secciones en blanco."
+  taxon_tip: "Para buscar datos de un taxón específico, escriba el nombre del taxon. Para buscar datos de todas las especies dentro de un grupo taxonómico en particular (por ejemplo género, familia, orden, clase, etc.), seleccione un grupo taxonómico en el menú desplegable de abajo. Para seleccionar todos los taxones, deje esta sección en blanco."
   taxon_title: "Buscar por taxón:"
   genus_title: "Seleccione un género:"
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,7 +5,7 @@ es:
   errors:
     no_data_1: "Su consulta ha devuelto ningún dato"
     no_data_2: "Por favor selecciona otras variables"
-    csv_limit_exceeded_1: "Su búsqueda ha resultado en un subconjunto de datos demasiado grande (más de 1 millón de registros). Debe limitar el rango de años y seleccionar al menos un país de importación/exportación o un taxón."
+    csv_limit_exceeded_1: "Su búsqueda ha resultado en un subconjunto de datos demasiado grande (más de 1 millón de registros). Debe limitar el rango de años y seleccionar al menos un país de importación/exportación o un taxón"
     csv_limit_exceeded_2: "Debe limitar el rango de años y seleccionar al menos un país de importación/exportación o un taxón"
     web_limit_exceeded_1: "Vista en línea no está disponible para grandes subconjuntos"
     web_limit_exceeded_2: "Puede descargar los resultados en formato CSV"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,7 +5,7 @@ fr:
   errors:
     no_data_1: "Votre recherche n'a retourné aucune donnée"
     no_data_2: "S'il vous plaît sélectionner autres variables"
-    csv_limit_exceeded_1: "Votre recherche a retourné un sous-ensemble trop grand"
+    csv_limit_exceeded_1: "Votre recherche a retourné un sous-ensemble trop grand (plus d’1 million d'enregistrements). Vous devez limiter la sélection temporelle (l’intervalle d’années) et sélectionner au moins un pays importateur/exportateur ou un taxon."
     csv_limit_exceeded_2: "Vous devez limiter la gamme des années et selectionner au moins un pays importateur/exportateur ou un taxon"
     web_limit_exceeded_1: "Vue en ligne n'est pas disponible pour les grands sous-ensembles"
     web_limit_exceeded_2: "Vous pouvez télécharger les résultats en format CSV"
@@ -19,7 +19,7 @@ fr:
   export_text: "Pays d'exportation"
   export_tip: "Entrez le nom du/des pays que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les pays, laissez 'Tous les Pays' sélectionné"
   import_text: "Pays importateurs"
-  import_tip: "Entrez le nom du/des pays que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les pays, laissez 'Tous les Pays' sélectionné" 
+  import_tip: "Entrez le nom du/des pays que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les pays, laissez 'Tous les Pays' sélectionné"
   source_text: "Source"
   source_tip: "Entrez le source/les sources (par ex. 'W- Prélevés dans la nature') que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les sources, laissez 'Tous les Sources' sélectionné"
   purpose_text: "But"
@@ -27,7 +27,7 @@ fr:
   trade_text: "Termes du Commerce"
   trade_tip: "Entrez le terme/les termes (par ex. 'vivant' ou 'peau') que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les termes, laissez 'Tous les Termes' sélectionné"
   taxon_text: "Recherche par taxon :"
-  taxon_tip: "Pour récupérer des données pour un taxon spécifique, tapez le nom du taxon. Les données sur les spécimens enregistrés dans le commerce à un niveau taxonomique supérieur (par exemple Scleractinia spp.) peuvent aussi être récupérées par cette recherche. Pour récupérer des données pour toutes les espèces dans un genre particulier, sélectionnez un genre dans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides."
+  taxon_tip: "Pour récupérer des données pour un taxon spécifique, tapez le nom du taxon. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  sélectionnez un niveau taxonomique supérieurdans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides."
   taxon_title: "Recherche par taxon:"
   genus_title: "Sélectionnez un genre"
 
@@ -54,11 +54,11 @@ fr:
   comparative_tabulations: "Tabulations Comparatives"
   trade_tabulations: "Tabulations du Commerce Brut/Net"
   get_report: "Obtenir le rapport"
-  new_search: "Nouvelle Recherche" 
+  new_search: "Nouvelle Recherche"
 
   from: "De"
   to: "A"
-  species: "Espèce" 
+  species: "Espèce"
 
   gross_exports: "Exportations Brutes"
   gross_imports: "Importations Brutes"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,8 +26,8 @@ fr:
   purpose_tip: "Entrez le but/les buts (par ex. 'T- Transaction commerciale' ou 'S- Fins scientifiques') que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous buts, laissez 'Tous les Buts' sélectionné"
   trade_text: "Termes du Commerce"
   trade_tip: "Entrez le terme/les termes (par ex. 'vivant' ou 'peau') que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les termes, laissez 'Tous les Termes' sélectionné"
-  taxon_text: "Recherche par taxon :"
-  taxon_tip: "Pour récupérer des données pour un taxon spécifique, tapez le nom du taxon. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  sélectionnez un niveau taxonomique supérieurdans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides."
+  taxon_text: "Recherche par taxon"
+  taxon_tip: "Pour récupérer des données pour un espèce spécifique, tapez le nom du espèce. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  tapez le nom et sélectionnez un niveau taxonomique supérieurdans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides. Il est conseillé de limiter votre demande de données a un taxon spécifique en raison du volume de données (il y a une limite de 1 million de lignes pour les téléchargements de données)."
   taxon_title: "Recherche par taxon:"
   genus_title: "Sélectionnez un genre"
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,7 +5,7 @@ fr:
   errors:
     no_data_1: "Votre recherche n'a retourné aucune donnée"
     no_data_2: "S'il vous plaît sélectionner autres variables"
-    csv_limit_exceeded_1: "Votre recherche a retourné un sous-ensemble trop grand (plus d’1 million d'enregistrements). Vous devez limiter la sélection temporelle (l’intervalle d’années) et sélectionner au moins un pays importateur/exportateur ou un taxon."
+    csv_limit_exceeded_1: "Votre recherche a retourné un sous-ensemble trop grand (plus d’1 million d'enregistrements). Vous devez limiter la sélection temporelle (l’intervalle d’années) et sélectionner au moins un pays importateur/exportateur ou un taxon"
     csv_limit_exceeded_2: "Vous devez limiter la gamme des années et selectionner au moins un pays importateur/exportateur ou un taxon"
     web_limit_exceeded_1: "Vue en ligne n'est pas disponible pour les grands sous-ensembles"
     web_limit_exceeded_2: "Vous pouvez télécharger les résultats en format CSV"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,7 +27,7 @@ fr:
   trade_text: "Termes du Commerce"
   trade_tip: "Entrez le terme/les termes (par ex. 'vivant' ou 'peau') que vous souhaitez inclure dans votre rapport de sortie final. Pour incluire les données de tous les termes, laissez 'Tous les Termes' sélectionné"
   taxon_text: "Recherche par taxon"
-  taxon_tip: "Pour récupérer des données pour un espèce spécifique, tapez le nom du espèce. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  tapez le nom et sélectionnez un niveau taxonomique supérieurdans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides. Il est conseillé de limiter votre demande de données a un taxon spécifique en raison du volume de données (il y a une limite de 1 million de lignes pour les téléchargements de données)."
+  taxon_tip: "Pour récupérer des données pour une espèce spécifique, tapez le nom l’espèce. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  tapez le nom et sélectionnez un niveau taxonomique supérieur dans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides. Il est conseillé de limiter votre demande de données à un taxon spécifique en raison du volume important de données (une limite de 1 million de lignes est imposée  pour les téléchargements de données)."
   taxon_title: "Recherche par taxon:"
   genus_title: "Sélectionnez un genre"
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,6 +29,7 @@ fr:
   taxon_text: "Recherche par taxon"
   taxon_tip: "Pour récupérer des données pour une espèce spécifique, tapez le nom l’espèce. Pour récupérer des données pour toutes les espèces dans un niveau taxonomique supérieur particulier (par exemple genre, famille, ordre, classe etc.)  tapez le nom et sélectionnez un niveau taxonomique supérieur dans le menu déroulant ci-dessous. Pour sélectionner tous les taxons, laissez ces sections vides. Il est conseillé de limiter votre demande de données à un taxon spécifique en raison du volume important de données (une limite de 1 million de lignes est imposée  pour les téléchargements de données)."
   taxon_title: "Recherche par taxon:"
+  taxon_search: "Recherche par espèce ou taxon supérieur"
   genus_title: "Sélectionnez un genre"
 
   all_countries: "Tous les Pays"

--- a/lib/tasks/import_distributions.rake
+++ b/lib/tasks/import_distributions.rake
@@ -12,6 +12,7 @@ namespace :import do
 
       csv_headers = csv_headers(file)
       has_tc_id = csv_headers.include? 'taxon_concept_id'
+      has_reference = csv_headers.include? 'Reference'
       has_reference_id = csv_headers.include? 'Reference IDs'
       kingdom = has_tc_id ? '' : file.split('/').last.split('_')[0].titleize
 
@@ -63,6 +64,7 @@ namespace :import do
             INNER JOIN geo_entities ge ON ge.iso_code2 = tmp.iso2
             INNER JOIN distributions d ON d.taxon_concept_id = tmp.taxon_concept_id
             AND d.geo_entity_id = ge.id
+            AND tmp.reference_id IS NOT NULL
 
             EXCEPT
 
@@ -70,6 +72,46 @@ namespace :import do
           ) AS subquery
         SQL
         ActiveRecord::Base.connection.execute(sql)
+      end
+      if has_reference
+        puts "There are #{Reference.count} references in the database."
+        sql = <<-SQL
+          INSERT INTO "references"
+            (citation, created_at, updated_at)
+          SELECT subquery.*, NOW(), NOW()
+          FROM(
+            SELECT tmp.citation
+            FROM #{TMP_TABLE} tmp
+
+            EXCEPT
+
+            SELECT r.citation
+            FROM "references" r
+          ) AS subquery
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+        puts "There are now #{Reference.count} references in the database"
+
+        distribution_references = DistributionReference.count
+        sql = <<-SQL
+          INSERT INTO "distribution_references"
+            (distribution_id, reference_id, created_at, updated_at)
+          SELECT subquery.*, NOW(), NOW()
+          FROM(
+            SELECT d.id, r.id
+            FROM #{TMP_TABLE} tmp
+            INNER JOIN "references" r ON r.citation = tmp.citation
+            INNER JOIN geo_entities ge ON ge.iso_code2 = tmp.iso2
+            INNER JOIN distributions d ON d.taxon_concept_id = tmp.taxon_concept_id
+            AND d.geo_entity_id = ge.id
+
+            EXCEPT
+
+            SELECT distribution_id, reference_id FROM distribution_references
+          ) AS subquery
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+        puts "Extra #{DistributionReference.count - distribution_references} distribution references have been added to the database"
       end
     end
     puts "There are now #{Distribution.count} taxon concept distributions in the database"

--- a/lib/tasks/import_species.rake
+++ b/lib/tasks/import_species.rake
@@ -95,7 +95,6 @@ def import_data_for(kingdom, rank, synonyms = nil)
           ON (
             parent_taxon_concepts.id = tmp.parent_id
             AND parent_taxon_concepts.rank_id = parent_ranks.id
-            AND parent_taxon_concepts.legacy_type = '#{kingdom}'
             AND parent_taxon_concepts.taxonomy_id = #{taxonomy.id}
           )
         WHERE
@@ -124,8 +123,8 @@ def import_data_for(kingdom, rank, synonyms = nil)
           AND taxon_concepts.taxonomy_id = to_be_inserted.taxonomy_id
           AND taxon_concepts.parent_id = to_be_inserted.parent_id
           AND UPPER(taxon_concepts.name_status) = UPPER(to_be_inserted.name_status)
-          AND UPPER(taxon_concepts.legacy_type) = UPPER(to_be_inserted.legacy_type)
           AND UPPER(BTRIM(taxon_concepts.data->'accepted_rank')) = to_be_inserted.data->'accepted_rank'
+          AND taxon_concepts.author_year = to_be_inserted.author_year
       RETURNING id;
     SQL
 

--- a/lib/tasks/import_species.rake
+++ b/lib/tasks/import_species.rake
@@ -123,6 +123,7 @@ def import_data_for(kingdom, rank, synonyms = nil)
           AND taxon_concepts.taxonomy_id = to_be_inserted.taxonomy_id
           AND taxon_concepts.parent_id = to_be_inserted.parent_id
           AND UPPER(taxon_concepts.name_status) = UPPER(to_be_inserted.name_status)
+          AND UPPER(taxon_concepts.legacy_type) = UPPER(to_be_inserted.legacy_type)
           AND UPPER(BTRIM(taxon_concepts.data->'accepted_rank')) = to_be_inserted.data->'accepted_rank'
           AND taxon_concepts.author_year = to_be_inserted.author_year
       RETURNING id;

--- a/spec/controllers/cites_trade/shipments_controller_spec.rb
+++ b/spec/controllers/cites_trade/shipments_controller_spec.rb
@@ -27,7 +27,7 @@ describe CitesTrade::ShipmentsController do
     end
     it "should return all comptab shipments" do
       get :index, format: :json
-      response.body.should have_json_size(6).at_path('shipment_comptab_export/rows')
+      response.body.should have_json_size(7).at_path('shipment_comptab_export/rows')
     end
     it "should return all gross_exports shipments" do
       get :index, filters: {
@@ -35,7 +35,7 @@ describe CitesTrade::ShipmentsController do
         time_range_start: 2012,
         time_range_end: 2013
       }, format: :json
-      response.body.should have_json_size(4).at_path('shipment_gross_net_export/rows')
+      response.body.should have_json_size(5).at_path('shipment_gross_net_export/rows')
     end
     it "should return genus & species shipments when searching by genus" do
       get :index, filters: {
@@ -43,6 +43,13 @@ describe CitesTrade::ShipmentsController do
         selection_taxon: 'taxonomic_cascade'
       }, format: :json
       response.body.should have_json_size(2).at_path('shipment_comptab_export/rows')
+    end
+    it "should return family, genus & species shipments when searching by family" do
+      get :index, filters: {
+        taxon_concepts_ids: [@animal_family.id],
+        selection_taxon: 'taxonomic_cascade'
+      }, format: :json
+      response.body.should have_json_size(3).at_path('shipment_comptab_export/rows')
     end
     it "should return genus shipments when searching by taxon" do
       get :index, filters: {

--- a/spec/controllers/cites_trade/shipments_controller_spec.rb
+++ b/spec/controllers/cites_trade/shipments_controller_spec.rb
@@ -33,7 +33,7 @@ describe CitesTrade::ShipmentsController do
       get :index, filters: {
         report_type: 'gross_exports',
         time_range_start: 2012,
-        time_range_end: 2013
+        time_range_end: 2014
       }, format: :json
       response.body.should have_json_size(5).at_path('shipment_gross_net_export/rows')
     end

--- a/spec/controllers/cites_trade/shipments_controller_spec.rb
+++ b/spec/controllers/cites_trade/shipments_controller_spec.rb
@@ -40,7 +40,7 @@ describe CitesTrade::ShipmentsController do
     it "should return genus & species shipments when searching by genus" do
       get :index, filters: {
         taxon_concepts_ids: [@animal_genus.id],
-        selection_taxon: 'genus'
+        selection_taxon: 'taxonomic_cascade'
       }, format: :json
       response.body.should have_json_size(2).at_path('shipment_comptab_export/rows')
     end

--- a/spec/controllers/trade/shipments_controller_spec.rb
+++ b/spec/controllers/trade/shipments_controller_spec.rb
@@ -9,7 +9,7 @@ describe Trade::ShipmentsController, sidekiq: :inline do
     before(:each) { Sapi::StoredProcedures.rebuild_cites_taxonomy_and_listings }
     it "should return all shipments" do
       get :index, format: :json
-      response.body.should have_json_size(6).at_path('shipments')
+      response.body.should have_json_size(7).at_path('shipments')
     end
     it "should return genus & species shipments when searching by genus" do
       get :index, taxon_concepts_ids: [@animal_genus.id], format: :json

--- a/spec/controllers/trade/shipments_controller_spec.rb
+++ b/spec/controllers/trade/shipments_controller_spec.rb
@@ -167,9 +167,9 @@ describe Trade::ShipmentsController, sidekiq: :inline do
         importers_ids: [@portugal.id.to_s, @argentina.id.to_s],
         taxon_concepts_ids: [@animal_species.id]
       }
-      Trade::Shipment.count.should == 5
+      Trade::Shipment.count.should == 6
     end
-    it "should delete 4 shipment" do
+    it "should delete 5 shipment" do
       post :destroy_batch, {
         time_range_start: @shipment1.year,
         time_range_end: @shipment2.year,
@@ -177,10 +177,10 @@ describe Trade::ShipmentsController, sidekiq: :inline do
         exporters_ids: [@portugal.id.to_s, @argentina.id.to_s],
         importers_ids: [@portugal.id.to_s, @argentina.id.to_s]
       }
-      Trade::Shipment.count.should == 1
+      Trade::Shipment.count.should == 2
     end
 
-    it "should delete 1 shipments" do
+    it "should delete 2 shipments" do
       post :destroy_batch, importers_ids: [@argentina.id.to_s]
       Trade::Shipment.count.should == 5
     end
@@ -197,7 +197,7 @@ describe Trade::ShipmentsController, sidekiq: :inline do
 
     it "shouldn't delete any shipments" do
       post :destroy_batch, purpose_blank: "true"
-      Trade::Shipment.count.should == 6
+      Trade::Shipment.count.should == 7
     end
 
     it "should delete 1 shipment" do
@@ -207,19 +207,19 @@ describe Trade::ShipmentsController, sidekiq: :inline do
 
     it "should delete 3 shipment" do
       post :destroy_batch, sources_ids: [@source_wild.id.to_s]
-      Trade::Shipment.count.should == 3
+      Trade::Shipment.count.should == 4
     end
 
     it "should delete 0 shipments" do
       post :destroy_batch, sources_ids: [@source_wild.id.to_s],
         reporter_type: 'E'
-      Trade::Shipment.count.should == 6
+      Trade::Shipment.count.should == 7
     end
 
     it "should delete 4 shipments" do
       post :destroy_batch, sources_ids: [@source_wild.id.to_s],
         reporter_type: 'I', source_blank: "true"
-      Trade::Shipment.count.should == 2
+      Trade::Shipment.count.should == 3
     end
 
     it "should delete orphaned permits" do

--- a/spec/models/trade/filter_spec.rb
+++ b/spec/models/trade/filter_spec.rb
@@ -131,26 +131,26 @@ describe Trade::Filter do
     context "when searching for terms_ids" do
       subject { Trade::Filter.new({ :terms_ids => [@term_cav.id] }).results }
       specify { subject.should include(@shipment1) }
-      specify { subject.length.should == 2 }
+      specify { subject.length.should == 3 }
     end
 
     context "when searching for units_ids" do
       subject { Trade::Filter.new({ :units_ids => [@unit.id] }).results }
       specify { subject.should include(@shipment1) }
-      specify { subject.length.should == 2 }
+      specify { subject.length.should == 3 }
     end
 
     context "when searching for purposes_ids" do
       subject { Trade::Filter.new({ :purposes_ids => [@purpose.id] }).results }
       specify { subject.should include(@shipment1) }
-      specify { subject.length.should == 6 }
+      specify { subject.length.should == 7 }
     end
 
     context "when searching for sources_ids" do
       context "when code" do
         subject { Trade::Filter.new({ :sources_ids => [@source.id] }).results }
         specify { subject.should include(@shipment1) }
-        specify { subject.length.should == 1 }
+        specify { subject.length.should == 2 }
       end
       context "when blank" do
         subject { Trade::Filter.new({ :source_blank => true }).results }
@@ -160,7 +160,7 @@ describe Trade::Filter do
       context "when both code and blank" do
         subject { Trade::Filter.new({ :sources_ids => [@source.id], :source_blank => true }).results }
         specify { subject.should include(@shipment1) }
-        specify { subject.length.should == 2 }
+        specify { subject.length.should == 3 }
       end
       context "when wild" do
         subject { Trade::Filter.new({ :sources_ids => [@source_wild.id], :source_blank => true }).results }
@@ -179,7 +179,7 @@ describe Trade::Filter do
     context "when searching for importers_ids" do
       subject { Trade::Filter.new({ :importers_ids => [@argentina.id] }).results }
       specify { subject.should include(@shipment1) }
-      specify { subject.length.should == 1 }
+      specify { subject.length.should == 2 }
     end
 
     context "when searching for exporters_ids" do
@@ -191,14 +191,14 @@ describe Trade::Filter do
     context "when searching for countries_of_origin_ids" do
       subject { Trade::Filter.new({ :countries_of_origin_ids => [@argentina.id] }).results }
       specify { subject.should include(@shipment1) }
-      specify { subject.length.should == 1 }
+      specify { subject.length.should == 2 }
     end
 
     context "when searching by year" do
       context "when time range specified" do
         subject { Trade::Filter.new({ :time_range_start => 2013, :time_range_end => 2015 }).results }
         specify { subject.should include(@shipment2) }
-        specify { subject.length.should == 5 }
+        specify { subject.length.should == 6 }
       end
       context "when time range specified incorrectly" do
         subject { Trade::Filter.new({ :time_range_start => 2013, :time_range_end => 2012 }).results }
@@ -207,7 +207,7 @@ describe Trade::Filter do
       context "when time range start specified" do
         subject { Trade::Filter.new({ :time_range_start => 2012 }).results }
         specify { subject.should include(@shipment1) }
-        specify { subject.length.should == 6 }
+        specify { subject.length.should == 7 }
       end
       context "when time range end specified" do
         subject { Trade::Filter.new({ :time_range_end => 2012 }).results }
@@ -219,7 +219,7 @@ describe Trade::Filter do
     context "when searching by reporter_type" do
       context "when reporter type is not I or E" do
         subject { Trade::Filter.new({ :internal => true, :reporter_type => 'K' }).results }
-        specify { subject.length.should == 6 }
+        specify { subject.length.should == 7 }
       end
 
       context "when reporter type is I" do
@@ -231,7 +231,7 @@ describe Trade::Filter do
       context "when reporter type is E" do
         subject { Trade::Filter.new({ :internal => true, :reporter_type => 'E' }).results }
         specify { subject.should include(@shipment1) }
-        specify { subject.length.should == 1 }
+        specify { subject.length.should == 2 }
       end
     end
 
@@ -272,7 +272,7 @@ describe Trade::Filter do
 
     context "when two match" do
       subject { Trade::Filter.new({ :purposes_ids => [@purpose.id] }) }
-      specify { subject.total_cnt.should == 6 }
+      specify { subject.total_cnt.should == 7 }
     end
 
   end

--- a/spec/shared/shipments.rb
+++ b/spec/shared/shipments.rb
@@ -203,7 +203,7 @@ shared_context 'Shipments' do
     @shipment7 = create(
       :shipment,
       :taxon_concept => @animal_species2,
-      :appendix => 'I',
+      :appendix => 'II',
       :purpose => @purpose,
       :source => @source,
       :term => @term_cav,
@@ -216,7 +216,7 @@ shared_context 'Shipments' do
       :import_permit_number => 'FFF',
       :export_permit_number => 'DDD;KKK',
       :origin_permit_number => 'EEE',
-      :quantity => 20
+      :quantity => 30
     )
   end
 end

--- a/spec/shared/shipments.rb
+++ b/spec/shared/shipments.rb
@@ -14,12 +14,25 @@ shared_context 'Shipments' do
       :taxon_name => create(:taxon_name, :scientific_name => 'Foobarus'),
       :parent => @animal_family
     )
+    @animal_genus2 = create_cites_eu_genus(
+      :taxon_name => create(:taxon_name, :scientific_name => 'Barfoos'),
+      :parent => @animal_family
+    )
     @animal_species = create_cites_eu_species(
       :taxon_name => create(:taxon_name, :scientific_name => 'abstractus'),
       :parent => @animal_genus
     )
+    @animal_species2 = create_cites_eu_species(
+      :taxon_name => create(:taxon_name, :scientific_name => 'abstractus'),
+      :parent => @animal_genus2
+    )
     create_cites_I_addition(
       :taxon_concept => @animal_species,
+      :effective_at => 1.day.ago,
+      :is_current => true
+    )
+    create_cites_I_addition(
+      :taxon_concept => @animal_species2,
       :effective_at => 1.day.ago,
       :is_current => true
     )
@@ -42,6 +55,13 @@ shared_context 'Shipments' do
     )
     @synonym_subspecies = create_cites_eu_subspecies(
       :parent => @animal_species,
+      :name_status => 'S'
+    )
+    @subspecies2 = create_cites_eu_subspecies(
+      :parent => @animal_species2
+    )
+    @synonym_subspecies2 = create_cites_eu_subspecies(
+      :parent => @animal_species2,
       :name_status => 'S'
     )
     create(
@@ -179,6 +199,24 @@ shared_context 'Shipments' do
       :year => 2013,
       :reported_by_exporter => false,
       :quantity => 50
+    )
+    @shipment7 = create(
+      :shipment,
+      :taxon_concept => @animal_species2,
+      :appendix => 'I',
+      :purpose => @purpose,
+      :source => @source,
+      :term => @term_cav,
+      :unit => @unit,
+      :importer => @argentina,
+      :exporter => @portugal,
+      :country_of_origin => @argentina,
+      :year => 2012,
+      :reported_by_exporter => true,
+      :import_permit_number => 'AAA',
+      :export_permit_number => 'BBB;CCC',
+      :origin_permit_number => 'EEE',
+      :quantity => 20
     )
   end
 end

--- a/spec/shared/shipments.rb
+++ b/spec/shared/shipments.rb
@@ -213,8 +213,8 @@ shared_context 'Shipments' do
       :country_of_origin => @argentina,
       :year => 2014,
       :reported_by_exporter => true,
-      :import_permit_number => 'AAA',
-      :export_permit_number => 'BBB;CCC',
+      :import_permit_number => 'FFF',
+      :export_permit_number => 'DDD;KKK',
       :origin_permit_number => 'EEE',
       :quantity => 20
     )

--- a/spec/shared/shipments.rb
+++ b/spec/shared/shipments.rb
@@ -211,7 +211,7 @@ shared_context 'Shipments' do
       :importer => @argentina,
       :exporter => @portugal,
       :country_of_origin => @argentina,
-      :year => 2012,
+      :year => 2014,
       :reported_by_exporter => true,
       :import_permit_number => 'AAA',
       :export_permit_number => 'BBB;CCC',


### PR DESCRIPTION
This changes the behaviour of the public CITES Trade database interface regarding the download.
The new functionality allows user to download data about taxa across the entire taxonomic tree.
Plus, some updates on the import scripts