### PR TITLE
Refresh compliance mviews

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 set :output, 'log/cron.log'
 
-every :day, :at => '2:42am' do
+every :day, :at => '1:42am' do
   rake "db:migrate:rebuild"
 end
 

--- a/db/mviews/009_rebuild_compliance_mviews.sql
+++ b/db/mviews/009_rebuild_compliance_mviews.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION rebuild_trade_shipments_appendix_i_mview() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    DROP MATERIALIZED VIEW IF EXISTS trade_shipments_appendix_i_mview CASCADE;
+
+    RAISE INFO 'Creating appendix I materialized view';
+    CREATE MATERIALIZED VIEW trade_shipments_appendix_i_mview AS
+    SELECT *
+    FROM trade_shipments_appendix_i_view;
+  END;
+  $$;
+
+CREATE OR REPLACE FUNCTION rebuild_trade_shipments_mandatory_quotas_mview() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    DROP MATERIALIZED VIEW IF EXISTS trade_shipments_mandatory_quotas_mview CASCADE;
+    RAISE INFO 'Creating mandatory quotas materialized view';
+    CREATE MATERIALIZED VIEW trade_shipments_mandatory_quotas_mview AS
+    SELECT *
+    FROM trade_shipments_mandatory_quotas_view;
+  END;
+  $$;
+
+CREATE OR REPLACE FUNCTION rebuild_trade_shipments_cites_suspensions_mview() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    DROP MATERIALIZED VIEW IF EXISTS trade_shipments_cites_suspensions_mview CASCADE;
+    RAISE INFO 'Creating CITES suspensions materialized view';
+    CREATE MATERIALIZED VIEW trade_shipments_cites_suspensions_mview AS
+    SELECT *
+    FROM trade_shipments_cites_suspensions_view;
+
+  END;
+  $$;

--- a/lib/modules/sapi/stored_procedures.rb
+++ b/lib/modules/sapi/stored_procedures.rb
@@ -17,7 +17,10 @@ module Sapi
         :valid_taxon_concept_appendix_year_mview,
         :touch_cites_taxon_concepts,
         :touch_eu_taxon_concepts,
-        :touch_cms_taxon_concepts
+        :touch_cms_taxon_concepts,
+        :trade_shipments_appendix_i_mview,
+        :trade_shipments_mandatory_quotas_mview,
+        :trade_shipments_cites_suspensions_mview
       ].each { |p|
         puts "Procedure: #{p}"
         ActiveRecord::Base.connection.execute("SELECT * FROM rebuild_#{p}()")
@@ -100,6 +103,17 @@ module Sapi
         (permits_ids);
       SQL
       ActiveRecord::Base.connection.execute(sql)
+    end
+
+    def self.rebuild_compliance_mviews
+      [
+        :trade_shipments_appendix_i_mview,
+        :trade_shipments_mandatory_quotas_mview,
+        :trade_shipments_cites_suspensions_mview
+      ].each { |p|
+        puts "Procedure: #{p}"
+        ActiveRecord::Base.connection.execute("SELECT * FROM rebuild_#{p}()")
+      }
     end
   end
 end


### PR DESCRIPTION
This adds a plpgsql script to be used to refresh the compliance mviews every day.
The script has been added in the queue of scripts to process during the night with `db:migrate:rebuild`.
The `schedule.rb` file has been amended to start the entire process an hour earlier to accomodate the new scripts.