### PR TITLE
Revert submission worker

### DIFF
--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -100,7 +100,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
       number_of_records_submitted: records_submitted
     })
 
-    ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
+    # This has been temporarily disabled as originally part of EPIX
+    #ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
   end
 
   def reported_by_exporter?

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -22,8 +22,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
   include ActiveModel::ForbiddenAttributesProtection
   track_who_does_it
   attr_accessible :csv_source_file, :trading_country_id, :point_of_view,
-                  :submitted_at, :submitted_by_id, :number_of_records_submitted,
-                  :aws_storage_path
+                  :submitted_at, :submitted_by_id, :number_of_rows,
+                  :number_of_records_submitted, :aws_storage_path
   mount_uploader :csv_source_file, Trade::CsvSourceFileUploader
   belongs_to :trading_country, :class_name => GeoEntity, :foreign_key => :trading_country_id
   validates :csv_source_file, :csv_column_headers => true, :on => :create
@@ -82,8 +82,6 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
     end
     return false unless sandbox.copy_from_sandbox_to_shipments(submitter)
 
-    ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
-
     records_submitted = sandbox.moved_rows_cnt
     # remove uploaded file
     store_dir = csv_source_file.store_dir
@@ -101,6 +99,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
       submitted_by_id: submitter.id,
       number_of_records_submitted: records_submitted
     })
+
+    ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
   end
 
   def reported_by_exporter?

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -39,8 +39,8 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
 
   # object that represents the particular sandbox table linked to this annual
   # report upload
-  def sandbox
-    return nil if submitted_at.present?
+  def sandbox(tmp=false)
+    return nil if submitted_at.present? && !tmp
     @sandbox ||= Trade::Sandbox.new(self)
   end
 
@@ -80,8 +80,27 @@ class Trade::AnnualReportUpload < ActiveRecord::Base
       self.errors[:base] << "Submit failed, primary validation errors present."
       return false
     end
+    return false unless sandbox.copy_from_sandbox_to_shipments(submitter)
 
-    SubmissionWorker.perform_async(self.id, submitter.id)
+    ChangesHistoryGeneratorWorker.perform_async(self.id, submitter.id)
+
+    records_submitted = sandbox.moved_rows_cnt
+    # remove uploaded file
+    store_dir = csv_source_file.store_dir
+    remove_csv_source_file!
+    puts '### removing uploads dir ###'
+    puts Rails.root.join('public', store_dir)
+    FileUtils.remove_dir(Rails.root.join('public', store_dir), :force => true)
+
+    # clear downloads cache
+    DownloadsCacheCleanupWorker.perform_async(:shipments)
+
+    # flag as submitted
+    update_attributes({
+      submitted_at: DateTime.now,
+      submitted_by_id: submitter.id,
+      number_of_records_submitted: records_submitted
+    })
   end
 
   def reported_by_exporter?

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -36,19 +36,6 @@ class Trade::Sandbox
     success
   end
 
-  def check_for_duplicates_in_shipments
-    Trade::Shipment.transaction do
-      pg_result = Trade::SandboxTemplate.connection.execute(
-        Trade::SandboxTemplate.send(:sanitize_sql_array, [
-          'SELECT * FROM check_for_duplicates_in_shipments(?)',
-          @annual_report_upload.id,
-        ])
-      )
-      duplicates = pg_result.values.first.first.delete('{}')
-      return duplicates
-    end
-  end
-
   def destroy
     Trade::SandboxTemplate.connection.execute(
       Trade::SandboxTemplate.drop_stmt(@table_name)

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -36,6 +36,19 @@ class Trade::Sandbox
     success
   end
 
+  def check_for_duplicates_in_shipments
+    Trade::Shipment.transaction do
+      pg_result = Trade::SandboxTemplate.connection.execute(
+        Trade::SandboxTemplate.send(:sanitize_sql_array, [
+          'SELECT * FROM check_for_duplicates_in_shipments(?)',
+          @annual_report_upload.id,
+        ])
+      )
+      duplicates = pg_result.values.first.first.delete('{}')
+      return duplicates
+    end
+  end
+
   def destroy
     Trade::SandboxTemplate.connection.execute(
       Trade::SandboxTemplate.drop_stmt(@table_name)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,7 +6,7 @@ common: &defaults
     username: <%= ENV["MAILER_USERNAME"] %>
     password: <%= ENV["MAILER_PASSWORD"] %>
     host: <%= ENV["MAILER_HOST"] %>
-    from: <%= ENV["MAILER_FROM"] %>
+    from: <%= ENV["MAILER_USERNAME"] %>
   redis:
     namespace: 'SAPI'
     url: 'redis://127.0.0.1:6379/1'

--- a/lib/modules/trade/changelog_csv_generator.rb
+++ b/lib/modules/trade/changelog_csv_generator.rb
@@ -15,7 +15,7 @@ class Trade::ChangelogCsvGenerator
 
     tempfile = Tempfile.new(["changelog_sapi_#{aru.id}-", ".csv"], Rails.root.join('tmp'))
 
-    ar_klass = aru.sandbox.ar_klass
+    ar_klass = aru.sandbox(true).ar_klass
 
     all_columns = DEFAULT_COLUMNS + data_columns.map(&:camelize)
     all_columns = all_columns + ['Duplicate'] if duplicates

--- a/spec/models/trade/annual_report_upload_spec.rb
+++ b/spec/models/trade/annual_report_upload_spec.rb
@@ -155,7 +155,8 @@ describe Trade::AnnualReportUpload, :drops_tables => true do
                         )
       @submitter = FactoryGirl.create(:user, role: User::MANAGER)
     end
-    context "it calls submission worker" do
+    pending "it calls submission worker" do
+      # This has been disabled due to some issues with asynchronous reports submission"
       subject { # aru no primary errors
         aru = build(:annual_report_upload, :trading_country_id => @argentina.id, :point_of_view => 'I')
         aru.save(:validate => false)

--- a/spec/workers/submission_worker_spec.rb
+++ b/spec/workers/submission_worker_spec.rb
@@ -27,7 +27,8 @@ describe SubmissionWorker do
     Trade::ChangelogCsvGenerator.stub(:call).and_return(Tempfile.new('changelog.csv'))
     SubmissionWorker.any_instance.stub(:upload_on_S3)
   end
-  context "when no primary errors" do
+  # Test temporarily disabled because SubmissionWorker has been disabled
+  pending "when no primary errors" do
     before(:each) do
       @aru = build(:annual_report_upload, :trading_country_id => @argentina.id, :point_of_view => 'I')
       @aru.save(:validate => false)
@@ -55,14 +56,14 @@ describe SubmissionWorker do
       SubmissionWorker.new.perform(@aru.id, @submitter.id)
       Trade::Permit.find_by_number('BBB').should_not be_nil
     end
-    context "when permit previously reported" do
+   pending "when permit previously reported" do
       before(:each) { create(:permit, :number => 'xxx') }
       specify {
         expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.to change { Trade::Permit.count }.by(2)
       }
     end
   end
-  context "when primary errors present" do
+  pending "when primary errors present" do
     before(:each) do
       @aru = build(:annual_report_upload)
       @aru.save(:validate => false)
@@ -80,7 +81,7 @@ describe SubmissionWorker do
       expect { SubmissionWorker.new.perform(@aru.id, @submitter.id) }.not_to change { Trade::Shipment.count }
     }
   end
-  context "when reported under a synonym" do
+  pending "when reported under a synonym" do
     before(:each) do
       @synonym = create_cites_eu_species(
         :name_status => 'S',


### PR DESCRIPTION
## Description

* Make annual report submission synchronous again
* As SubmissionWorker has been disabled, disable also the related tests
* Fetch correct email address to fix mailer

## Notes

The main reason for this work is that issues have been experienced with an asynchronous version of annual reports submission. Sidekiq jobs seemed to get stuck quite easily and the user interface wasn't friendly enough to help the user through the submission journey.
Reintroduction of SubmissionWorker could be reconsidered after the user journey and interface will be better studied and specified.