### PR TITLE
Full list action

### DIFF
--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -97,7 +97,7 @@ class Api::V1::ShipmentsController < ApplicationController
   def set_pagination_headers(data, params)
     data = instance_variable_get("@#{data}").presence
     params = send(params)
-    response.headers['X-Total-Count'] = data ? data.first['total_count'].to_s : 0
+    response.headers['X-Total-Count'] = data ? data.first['total_count'].to_s : '0'
     response.headers['X-Page'] = params[:page].to_s.presence || '1'
     response.headers['X-Per-Page'] = params[:per_page].to_s.presence || '25'
   end

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -39,9 +39,8 @@ class Api::V1::ShipmentsController < ApplicationController
                       sanitized_attributes.first.empty? ? query.taxonomic_grouping(taxonomic_params) :
                                                           query.json_by_attribute(query.run, params_hash)
            end
-    @grouped_data = limit.blank? ? Kaminari.paginate_array(@data).page(grouped_params[:page]).per(grouped_params[:per_page]) :
-                                   @data[0..limit.to_i]
-    render :json => @grouped_data
+
+    render :json => @data
   end
 
   # Compliance tool search & full list action
@@ -98,7 +97,7 @@ class Api::V1::ShipmentsController < ApplicationController
   def set_pagination_headers(data, params)
     data = instance_variable_get("@#{data}")
     params = send(params)
-    response.headers['X-Total-Count'] = data.count.to_s
+    response.headers['X-Total-Count'] = data.first['total_count'].to_s
     response.headers['X-Page'] = params[:page].to_s.presence || '1'
     response.headers['X-Per-Page'] = params[:per_page].to_s.presence || '25'
   end

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -95,9 +95,9 @@ class Api::V1::ShipmentsController < ApplicationController
   private
 
   def set_pagination_headers(data, params)
-    data = instance_variable_get("@#{data}")
+    data = instance_variable_get("@#{data}").presence
     params = send(params)
-    response.headers['X-Total-Count'] = data.first['total_count'].to_s
+    response.headers['X-Total-Count'] = data ? data.first['total_count'].to_s : 0
     response.headers['X-Page'] = params[:page].to_s.presence || '1'
     response.headers['X-Per-Page'] = params[:per_page].to_s.presence || '25'
   end

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ShipmentsController < ApplicationController
   before_filter :authenticate
   before_filter :load_grouping_type
   after_filter only: [:grouped_query] do
-    set_pagination_headers(:grouped_data, :grouped_params)
+    set_pagination_headers(:data, :grouped_params)
   end
 
   def index
@@ -35,12 +35,12 @@ class Api::V1::ShipmentsController < ApplicationController
     query = @grouping_class.new(sanitized_attributes, _grouped_params)
     params_hash = { attribute: 'year' }
     sanitized_attributes.map { |p| params_hash[p] = p }
-    data = Rails.cache.fetch(['grouped_data', grouped_params], expires_in: 1.week) do
+    @data = Rails.cache.fetch(['grouped_data', grouped_params], expires_in: 1.week) do
                       sanitized_attributes.first.empty? ? query.taxonomic_grouping(taxonomic_params) :
                                                           query.json_by_attribute(query.run, params_hash)
            end
-    @grouped_data = limit.blank? ? Kaminari.paginate_array(data).page(grouped_params[:page]).per(grouped_params[:per_page]) :
-                                   data[0..limit.to_i]
+    @grouped_data = limit.blank? ? Kaminari.paginate_array(@data).page(grouped_params[:page]).per(grouped_params[:per_page]) :
+                                   @data[0..limit.to_i]
     render :json => @grouped_data
   end
 

--- a/lib/modules/trade/grouping/base.rb
+++ b/lib/modules/trade/grouping/base.rb
@@ -15,6 +15,7 @@ class Trade::Grouping::Base
     @opts = opts.clone
     @condition = sanitise_condition
     @limit = sanitise_limit(opts[:limit])
+    @pagination = sanitise_pagination(opts)
     @query = group_query
   end
 
@@ -72,6 +73,10 @@ class Trade::Grouping::Base
     SQL
   end
 
+  def limit
+    @limit ? "LIMIT #{@limit}" : ''
+  end
+
   private
 
   def read_taxonomy_conversion
@@ -88,10 +93,6 @@ class Trade::Grouping::Base
     conversion
   end
 
-  def limit
-    @limit ? "LIMIT #{@limit}" : ''
-  end
-
   def sanitise_group(group)
     return nil unless group
     attributes[group.to_sym]
@@ -104,6 +105,15 @@ class Trade::Grouping::Base
 
   def sanitise_limit(limit)
     limit.is_a?(Integer) ? limit : nil
+  end
+
+  def sanitise_pagination(opts)
+    page, per_page = [opts[:page].to_i, opts[:per_page].to_i]
+    return {} unless page > 0 || per_page > 0
+    {
+      page: page,
+      per_page: per_page
+    }
   end
 
   def sanitise_condition

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -126,7 +126,8 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     <<-SQL
       SELECT
         #{sanitise_column_names},
-        ROUND(SUM(#{quantity_field}::FLOAT)) AS value
+        ROUND(SUM(#{quantity_field}::FLOAT)) AS value,
+        COUNT(*) OVER () AS total_count
       FROM #{shipments_table}
       WHERE #{@condition} AND #{quantity_field} IS NOT NULL
       GROUP BY #{columns}
@@ -197,5 +198,13 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
       @sanitised_column_names << name
       "#{attribute} AS #{name}"
     end.compact.uniq.join(',')
+  end
+
+  def limit
+    pagination = @pagination.presence || { page: 1, per_page: @limit || 0 }
+    per_page = pagination[:per_page]
+    offset = (pagination[:page] - 1) * per_page
+
+    per_page > 0 ? "LIMIT #{pagination[:per_page]} OFFSET #{offset}" : ''
   end
 end

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -34,7 +34,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     data.each do |d|
       hash[key] << d
     end
-    hash[key][0..4]
+    hash[key]
   end
 
   private

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -180,7 +180,8 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
         SELECT
           NULL AS id,
           #{['phylum', 'class'].include?(taxonomic_level) ? check_for_plants : "#{taxonomic_level_name} AS name," }
-          ROUND(SUM(#{quantity_field}::FLOAT)) AS value
+          ROUND(SUM(#{quantity_field}::FLOAT)) AS value,
+          COUNT(*) OVER () AS total_count
         FROM #{shipments_table}
         WHERE #{@condition} AND #{quantity_field} IS NOT NULL #{group_name_condition}
         GROUP BY #{taxonomic_level_name}


### PR DESCRIPTION
This is to add the Full list action still using the same `grouped` endpoint.
:warning:   Needs some FE tweaks, that should now pass to the BE the `limit` param at each request, ideally `limit=5` for the top 5 results and `limit=''` for the full list, along with the `page` and `per_page` ones for the pagination (these two are set to 1 and 25 as default respectively if not provided at the moment)

Example request on the SAPI side:
```http://localhost:9000/api/v1/shipments/grouped.json?time_range_start=2017&time_range_end=2018&grouping_type=TradePlusStatic&group_by=exporting&call=grouped&reported_by=exporter&unit_name=Number%20of%20items&origin=direct&limit=5```