### PR TITLE
Make sure ids are integers

### DIFF
--- a/app/workers/event_eu_suspension_copy_worker.rb
+++ b/app/workers/event_eu_suspension_copy_worker.rb
@@ -5,8 +5,8 @@ class EventEuSuspensionCopyWorker
   def perform(from_event_id, to_event_id)
     ActiveRecord::Base.connection.execute <<-SQL
       SELECT * FROM copy_eu_suspensions_across_events(
-        #{from_event_id},
-        #{to_event_id}
+        #{from_event_id.to_i},
+        #{to_event_id.to_i}
       )
     SQL
     eu_suspension_regulation = EuSuspensionRegulation.find(to_event_id)


### PR DESCRIPTION
## Description

Quick fix for suspensions not being copied over existing events.
Making sure the ids passed to the worker are actually integers.