### PR TITLE
Country page

### DIFF
--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -43,6 +43,25 @@ class Api::V1::ShipmentsController < ApplicationController
     render :json => @data
   end
 
+  def country_query
+    limit = grouped_params[:limit].present? ? grouped_params[:limit].to_i : ''
+    _grouped_params = grouped_params.merge(limit: limit, with_defaults: true)
+    # taxonomic_params = {
+    #   taxonomic_level: grouped_params[:taxonomic_level],
+    #   group_name: grouped_params[:group_name]
+    # }
+
+    query = @grouping_class.new(sanitized_attributes, _grouped_params)
+    params_hash = { attribute: 'year' }
+    sanitized_attributes.map { |p| params_hash[p] = p }
+    @data = # Rails.cache.fetch(['grouped_data', grouped_params], expires_in: 1.week) do
+                      # sanitized_attributes.first.empty? ? query.taxonomic_grouping(taxonomic_params) :
+                query.json_by_attribute(query.country_data, params_hash)
+           # end
+
+    render :json => @data
+  end
+
   # Compliance tool search & full list action
   def search_query
     query = @grouping_class.new(sanitized_attributes, params)
@@ -131,7 +150,7 @@ class Api::V1::ShipmentsController < ApplicationController
       :group_by, :grouping_type, :term_names, :term_ids, :purpose_names, :purpose_ids,
       :source_names, :source_ids, :unit_name, :unit_id, :appendices, :reported_by,
       :taxonomic_level, :taxonomic_group_name, :importer, :exporter, :origin, :taxon_id,
-      :taxonomic_group
+      :taxonomic_group, :country_id, :reported_by_party
     )
   end
 

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -46,17 +46,17 @@ class Api::V1::ShipmentsController < ApplicationController
   def country_query
     limit = grouped_params[:limit].present? ? grouped_params[:limit].to_i : ''
     _grouped_params = grouped_params.merge(limit: limit, with_defaults: true)
-    # taxonomic_params = {
-    #   taxonomic_level: grouped_params[:taxonomic_level],
-    #   group_name: grouped_params[:group_name]
-    # }
+    taxonomic_params = {
+      taxonomic_level: grouped_params[:taxonomic_level],
+      group_name: grouped_params[:group_name]
+    }
 
     query = @grouping_class.new(sanitized_attributes, _grouped_params)
     params_hash = { attribute: 'year' }
     sanitized_attributes.map { |p| params_hash[p] = p }
     @data = # Rails.cache.fetch(['grouped_data', grouped_params], expires_in: 1.week) do
-                      # sanitized_attributes.first.empty? ? query.taxonomic_grouping(taxonomic_params) :
-                query.json_by_attribute(query.country_data, params_hash)
+                      sanitized_attributes.first.empty? ? query.country_taxonomic_grouping(taxonomic_params) :
+                                                          query.json_by_attribute(query.country_data, params_hash)
            # end
 
     render :json => @data

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ShipmentsController < ApplicationController
 
   before_filter :authenticate
   before_filter :load_grouping_type
-  after_filter only: [:grouped_query] do
+  after_filter only: [:grouped_query, :country_query] do
     set_pagination_headers(:data, :grouped_params)
   end
 
@@ -54,10 +54,10 @@ class Api::V1::ShipmentsController < ApplicationController
     query = @grouping_class.new(sanitized_attributes, _grouped_params)
     params_hash = { attribute: 'year' }
     sanitized_attributes.map { |p| params_hash[p] = p }
-    @data = # Rails.cache.fetch(['grouped_data', grouped_params], expires_in: 1.week) do
-                      sanitized_attributes.first.empty? ? query.country_taxonomic_grouping(taxonomic_params) :
+    @data = Rails.cache.fetch(['country_data', grouped_params], expires_in: 1.week) do
+                      sanitized_attributes.first.empty? ? query.taxonomic_grouping(taxonomic_params) :
                                                           query.json_by_attribute(query.country_data, params_hash)
-           # end
+            end
 
     render :json => @data
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ SAPI::Application.routes.draw do
       get '/shipments/chart' => 'shipments#chart_query'
       get '/shipments/grouped' => 'shipments#grouped_query'
       get '/shipments/over_time' => 'shipments#over_time_query'
+      get '/shipments/country' => 'shipments#country_query'
       get '/shipments/search' => 'shipments#search_query'
       get '/shipments/download' => 'shipments#download_data'
       get '/shipments/search_download' => 'shipments#search_download_data'

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -124,7 +124,6 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
   def group_query
     columns = @attributes.compact.uniq.join(',')
     quantity_field = "#{@reported_by}_reported_quantity"
-    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT
         #{sanitise_column_names},
@@ -177,7 +176,6 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     # while the @query variable is assigned as well because of the grouped_query
     sanitised_column_names = @sanitised_column_names.compact.uniq.join(',')
 
-    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT ROW_TO_JSON(row)
       FROM (
@@ -209,7 +207,6 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
       END AS name,
     SQL
 
-    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT ROW_TO_JSON(row)
       FROM(

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -123,6 +123,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
   def group_query
     columns = @attributes.compact.uniq.join(',')
     quantity_field = "#{@reported_by}_reported_quantity"
+    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT
         #{sanitise_column_names},
@@ -143,6 +144,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     # while the @query variable is assigned as well because of the grouped_query
     sanitised_column_names = @sanitised_column_names.compact.uniq.join(',')
 
+    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT ROW_TO_JSON(row)
       FROM (
@@ -174,6 +176,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
       END AS name,
     SQL
 
+    # TODO Double check IS NOT NULL is the correct replacement for <> 'NA'
     <<-SQL
       SELECT ROW_TO_JSON(row)
       FROM(

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -160,8 +160,8 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
         ROUND(SUM(#{quantity_field}::FLOAT)) AS value,
         COUNT(*) OVER () AS total_count
       FROM #{shipments_table}
-      WHERE #{@reported_by}_id = #{country_id} -- @reported_by = importer if importing-from chart, exporter if exporting-to chart
-      AND ((reported_by_exporter = #{!reported_by_party} AND importer_id = #{country_id}) OR (reported_by_exporter = #{reported_by_party} AND exporter_id = #{country_id}))
+      WHERE #{@reported_by}_id IN (#{country_id}) -- @reported_by = importer if importing-from chart, exporter if exporting-to chart
+      AND ((reported_by_exporter = #{!reported_by_party} AND importer_id IN (#{country_id})) OR (reported_by_exporter = #{reported_by_party} AND exporter_id IN (#{country_id})))
       AND #{@condition} AND #{quantity_field} IS NOT NULL
       GROUP BY #{columns} -- exporter if @reported_by = importer and otherway round
       ORDER BY value DESC
@@ -253,7 +253,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     return unless @country_id
     country_id = @country_id
     reported_by_party = sanitise_boolean
-    "AND #{@reported_by}_id = #{country_id} AND ((reported_by_exporter = #{!reported_by_party} AND importer_id = #{country_id}) OR (reported_by_exporter = #{reported_by_party} AND exporter_id = #{country_id}))"
+    "AND #{@reported_by}_id IN (#{country_id}) AND ((reported_by_exporter = #{!reported_by_party} AND importer_id IN (#{country_id})) OR (reported_by_exporter = #{reported_by_party} AND exporter_id IN (#{country_id})))"
   end
 
   def limit

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -32,6 +32,12 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     data.map { |d| JSON.parse(d['row_to_json']) }
   end
 
+  #TODO remove and generalize the one already in place
+  def country_taxonomic_grouping(opts={})
+    data = db.execute(country_taxonomic_query(opts))
+    data.map { |d| JSON.parse(d['row_to_json']) }
+  end
+
   # TODO better define hash key
   def json_by_attribute(data, opts={})
     key = data.fields.first
@@ -174,12 +180,17 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     SQL
   end
 
+  #TODO refactor avoiding variable repetition
   def over_time_query
-    quantity_field = "#{@reported_by}_reported_quantity"
+    quantity_field = @country_id.present? ? "#{entity_quantity}_reported_quantity" : "#{@reported_by}_reported_quantity"
     columns = @attributes.compact.uniq.join(',')
     # @sanitised_column_names value is assigned in the super class
     # while the @query variable is assigned as well because of the grouped_query
     sanitised_column_names = @sanitised_column_names.compact.uniq.join(',')
+
+    country_id = @country_id
+    reported_by_party = sanitise_boolean
+    country_over_time = "AND #{@reported_by}_id = #{country_id} AND ((reported_by_exporter = #{!reported_by_party} AND importer_id = #{country_id}) OR (reported_by_exporter = #{reported_by_party} AND exporter_id = #{country_id}))" if @country_id
 
     <<-SQL
       SELECT ROW_TO_JSON(row)
@@ -188,7 +199,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
         FROM (
           SELECT year, #{sanitise_column_names}, ROUND(SUM(#{quantity_field}::FLOAT)) AS value
           FROM #{shipments_table}
-          WHERE #{@condition} AND #{quantity_field} IS NOT NULL
+          WHERE #{@condition} AND #{quantity_field} IS NOT NULL #{country_over_time}
           GROUP BY year, #{columns}
           ORDER BY value DESC
           #{limit}
@@ -229,6 +240,47 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     SQL
   end
 
+  #TODO remove and generalize the one already in place
+  def country_taxonomic_query(opts)
+    reported_by_party = sanitise_boolean
+    country_id = @country_id
+    entity = if (reported_by_party && (@reported_by == 'importer')) || (!reported_by_party && (@reported_by == 'exporter'))
+                 'importer'
+               elsif (reported_by_party && (@reported_by == 'exporter')) || (!reported_by_party && (@reported_by == 'importer'))
+                 'exporter'
+               end
+    quantity_field = "#{entity}_reported_quantity"
+    taxonomic_level = opts[:taxonomic_level] || 'class'
+    taxonomic_level_name = "#{taxonomic_level}_name"
+    group_name = opts[:group_name]
+    group_name_condition = " AND LOWER(group_name) = '#{group_name.downcase}'" if group_name
+
+    check_for_plants = <<-SQL
+      CASE
+        WHEN COALESCE(#{taxonomic_level_name}, '') = '' THEN 'Plants'
+        ELSE #{taxonomic_level_name}
+      END AS name,
+    SQL
+
+    <<-SQL
+      SELECT ROW_TO_JSON(row)
+      FROM(
+        SELECT
+          NULL AS id,
+          #{['phylum', 'class'].include?(taxonomic_level) ? check_for_plants : "#{taxonomic_level_name} AS name," }
+          ROUND(SUM(#{quantity_field}::FLOAT)) AS value,
+          COUNT(*) OVER () AS total_count
+        FROM #{shipments_table}
+        WHERE #{@condition} AND #{quantity_field} IS NOT NULL #{group_name_condition}
+        AND #{@reported_by}_id = #{country_id} -- @reported_by = importer if importing-from chart, exporter if exporting-to chart
+        AND ((reported_by_exporter = #{!reported_by_party} AND importer_id = #{country_id}) OR (reported_by_exporter = #{reported_by_party} AND exporter_id = #{country_id}))
+        GROUP BY #{taxonomic_level_name}
+        ORDER BY value DESC
+        #{limit}
+      ) row
+    SQL
+  end
+
   def sanitise_column_names
     return '' if @attributes.blank?
     @attributes.map do |attribute|
@@ -242,6 +294,15 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
   def sanitise_boolean
     return true if !['true', 'false'].include? @reported_by_party
     @reported_by_party == 'true'
+  end
+
+  def entity_quantity
+    reported_by_party = sanitise_boolean
+    if (reported_by_party && (@reported_by == 'importer')) || (!reported_by_party && (@reported_by == 'exporter'))
+      'importer'
+    elsif (reported_by_party && (@reported_by == 'exporter')) || (!reported_by_party && (@reported_by == 'importer'))
+      'exporter'
+    end
   end
 
   def limit

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -56,12 +56,14 @@ module Trade::TradePlusFilters
 
   def country_query
     <<-SQL
-      (WITH country_data AS (
+      WITH country_data AS (
         SELECT id,name_en,iso_code2
         FROM geo_entities
         WHERE geo_entity_type_id = 1
       )
-      SELECT 'countries' AS attribute_name, json_build_object('id', id, 'name', name_en, 'iso2', iso_code2)::jsonb AS data FROM country_data GROUP BY id,name_en,iso_code2)
+      SELECT 'countries' AS attribute_name, json_build_object('id', id, 'name', name_en, 'iso2', iso_code2)::jsonb AS data
+      FROM country_data
+      GROUP BY id,name_en,iso_code2
     SQL
   end
 

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -81,7 +81,7 @@ module Trade::TradePlusFilters
 <<<<<<< HEAD
 =======
     query << sub_query(['year', 'year'], 'years')
-    query << sub_query(['appendix', 'appendix'], 'appendix')
+    query << sub_query(['appendix', 'appendix'], 'appendixes')
     query << country_query
 >>>>>>> add full country list to filters endpoint
 

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -54,6 +54,17 @@ module Trade::TradePlusFilters
     SQL
   end
 
+  def country_query
+    <<-SQL
+      (WITH country_data AS (
+        SELECT id,name_en,iso_code2
+        FROM geo_entities
+        WHERE geo_entity_type_id = 1
+      )
+      SELECT 'countries' AS attribute_name, json_build_object('id', id, 'name', name_en, 'iso2', iso_code2)::jsonb AS data FROM country_data GROUP BY id,name_en,iso_code2)
+    SQL
+  end
+
   def inner_query
     query = []
     ATTRIBUTES.each do |attr|
@@ -67,6 +78,12 @@ module Trade::TradePlusFilters
     end
     query << sub_query(['taxon_name', 'taxon_id'], 'taxa')
     query << sub_query(['group_name', 'group_name'], 'taxonomic_groups')
+<<<<<<< HEAD
+=======
+    query << sub_query(['year', 'year'], 'years')
+    query << sub_query(['appendix', 'appendix'], 'appendix')
+    query << country_query
+>>>>>>> add full country list to filters endpoint
 
     <<-SQL
       #{query.join(' UNION ') }

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -78,12 +78,7 @@ module Trade::TradePlusFilters
     end
     query << sub_query(['taxon_name', 'taxon_id'], 'taxa')
     query << sub_query(['group_name', 'group_name'], 'taxonomic_groups')
-<<<<<<< HEAD
-=======
-    query << sub_query(['year', 'year'], 'years')
-    query << sub_query(['appendix', 'appendix'], 'appendixes')
     query << country_query
->>>>>>> add full country list to filters endpoint
 
     <<-SQL
       #{query.join(' UNION ') }


### PR DESCRIPTION
This creates the endpoint for the country page on Tradeview.

This includes the refactor of the filter endpoint to retrieve the full list of countries as well as importer/exporter list.

This is an example of the query you can test via postman or curl:
`http://localhost:9000/api/v1/shipments/country.json?time_range_start=2017&time_range_end=2018&grouping_type=TradePlusStatic&group_by=exporting&call=country&reported_by=importer&unit_name=Number%20of%20items&origin=direct&country_id=41&reported_by_party=true`

Switching `reported_by_party` value between true/false switch between Reported by Party / Reported by Partners tab respectively.
Switching  'reported_by' value between importer/exporter (and `group_by` accordingly exporting/importing) switch between Importing from / Exporting to chart respectively.

The `taxonomic` and `over_time` query have been refactored to work with the country query as well (passing the `country_id` parameter to the query).

Relative tradeview branch here https://github.com/unepwcmc/tradeplus/pull/50