### PR TITLE
Add rake task to export users to CSV

### DIFF
--- a/lib/tasks/export_users.rake
+++ b/lib/tasks/export_users.rake
@@ -1,0 +1,15 @@
+namespace :export do
+  desc 'Export all users'
+  task :users => :environment do
+    FILENAME = "tmp/users_#{Date.today.to_s}.csv".freeze
+    COLUMN_NAMES = %w(id name email role organisation is_cites_authority is_active).freeze
+
+    CSV.open(FILENAME, 'w') do |csv|
+      csv << [COLUMN_NAMES, 'country'].flatten
+      User.order(:name).each do |user|
+        country = user.geo_entity && user.geo_entity.name_en
+        csv << user.attributes.slice(*COLUMN_NAMES).merge(country: country).values
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This is a simple PR about adding a rake task to export users to CSV.
This kind of export is required a couple of times during the year, so this should come in handy.

## Notes

I branched this out straight from master as it doesn't have a direct impact on the functionalities of the application.