### PR TITLE
Refactor code causing internal exception on staging

### DIFF
--- a/app/controllers/admin/taxon_listing_changes_controller.rb
+++ b/app/controllers/admin/taxon_listing_changes_controller.rb
@@ -115,7 +115,7 @@ class Admin::TaxonListingChangesController < Admin::SimpleCrudController
   end
 
   def load_listing_changes
-    @listing_changes = @taxon_concept.listing_changes.
+    @listing_changes = end_of_association_chain.
       includes([
         :species_listing,
         :change_type,
@@ -125,6 +125,7 @@ class Admin::TaxonListingChangesController < Admin::SimpleCrudController
       ]).
       where("change_types.name <> '#{ChangeType::EXCEPTION}'").
       where("change_types.designation_id" => @designation.id).
+      where("taxon_concept_id" => @taxon_concept.id).
       order('listing_changes.effective_at DESC').
       page(params[:page]).where(:parent_id => nil)
   end


### PR DESCRIPTION
## Description

This is to fix a weird exception which seems to happen only on the staging instance for some reason.
The execption seem to be raised from an internal Rails code, potentially related to the gem used here.

## Notes

The refactored code should behave in the same way as it's another way of getting the same data.
The only difference I noticed is the data might be ordered a bit differently when the `effective_from` date is the same.

Ideally, it would be good to understand why this happens only on staging; but until then, this should temporarily (or even completely) fix things for all environments.

