### PR TITLE
Trade plus/speed up queries

### DIFF
--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -150,7 +150,8 @@ class Api::V1::ShipmentsController < ApplicationController
       :group_by, :grouping_type, :term_names, :term_ids, :purpose_names, :purpose_ids,
       :source_names, :source_ids, :unit_name, :unit_id, :appendices, :reported_by,
       :taxonomic_level, :taxonomic_group_name, :importer, :exporter, :origin, :taxon_id,
-      :taxonomic_group, :country_id, :reported_by_party
+      :taxonomic_group, :country_ids, :reported_by_party, :unit_ids,
+      :origin_ids, :importer_ids, :exporter_ids
     )
   end
 

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -115,8 +115,10 @@ class Api::V1::ShipmentsController < ApplicationController
 
   def set_pagination_headers(data, params)
     data = instance_variable_get("@#{data}").presence
+    # Make sure the count works for both TradeView and ComplianceTool
+    _count = data ? (data.first.is_a?(Array) ? data.count : data.first['total_count']) : 0
     params = send(params)
-    response.headers['X-Total-Count'] = data ? data.first['total_count'].to_s : '0'
+    response.headers['X-Total-Count'] = _count.to_s
     response.headers['X-Page'] = params[:page].to_s.presence || '1'
     response.headers['X-Per-Page'] = params[:per_page].to_s.presence || '25'
   end

--- a/db/mviews/010_rebuild_trade_plus_mviews.sql
+++ b/db/mviews/010_rebuild_trade_plus_mviews.sql
@@ -9,6 +9,14 @@ CREATE OR REPLACE FUNCTION rebuild_trade_plus_complete_mview() RETURNS void
     SELECT *
     FROM trade_plus_complete_view;
 
+    SELECT rebuild_trade_plus_complete_mview_indexes();
+  END
+  $$;
+
+CREATE OR REPLACE FUNCTION create_trade_plus_complete_mview_indexes() RETURNS void
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
     CREATE UNIQUE INDEX "index_trade_plus_complete_mview_on_id" ON trade_plus_complete_mview (id);
     CREATE INDEX "index_trade_plus_complete_mview_on_appendix" ON trade_plus_complete_mview USING btree (appendix);
     CREATE INDEX "index_trade_plus_complete_mview_on_origin_id" ON trade_plus_complete_mview USING btree (origin_id);

--- a/db/mviews/010_rebuild_trade_plus_mviews.sql
+++ b/db/mviews/010_rebuild_trade_plus_mviews.sql
@@ -9,8 +9,7 @@ CREATE OR REPLACE FUNCTION rebuild_trade_plus_complete_mview() RETURNS void
     SELECT *
     FROM trade_plus_complete_view;
 
-    ALTER TABLE trade_plus_complete_mview ADD PRIMARY KEY (id);
-
+    CREATE UNIQUE INDEX "index_trade_plus_complete_mview_on_id" ON trade_plus_complete_mview (id);
     CREATE INDEX "index_trade_plus_complete_mview_on_appendix" ON trade_plus_complete_mview USING btree (appendix);
     CREATE INDEX "index_trade_plus_complete_mview_on_origin_id" ON trade_plus_complete_mview USING btree (origin_id);
     CREATE INDEX "index_trade_plus_complete_mview_on_origin_iso" ON trade_plus_complete_mview USING btree (origin_iso);
@@ -31,5 +30,10 @@ CREATE OR REPLACE FUNCTION rebuild_trade_plus_complete_mview() RETURNS void
     CREATE INDEX "index_trade_plus_complete_mview_on_year" ON trade_plus_complete_mview USING brin (year);
     CREATE INDEX "index_trade_plus_complete_mview_on_year_exporter_id" ON trade_plus_complete_mview USING brin (year, exporter_id);
     CREATE INDEX "index_trade_plus_complete_mview_on_year_importer_id" ON trade_plus_complete_mview USING brin (year, importer_id);
+    CREATE INDEX "index_trade_plus_complete_mview_on_year_origin_id" ON trade_plus_complete_mview USING brin (year, origin_id);
+    CREATE INDEX "index_trade_plus_complete_mview_on_year_source_id" ON trade_plus_complete_mview USING brin (year, source_id);
+    CREATE INDEX "index_trade_plus_complete_mview_on_year_purpose_id" ON trade_plus_complete_mview USING brin (year, purpose_id);
+    CREATE INDEX "index_trade_plus_complete_mview_on_year_unit_id" ON trade_plus_complete_mview USING brin (year, unit_id);
+    CREATE INDEX "index_trade_plus_complete_mview_on_year_term_id" ON trade_plus_complete_mview USING brin (year, term_id);
   END
   $$;

--- a/db/mviews/010_rebuild_trade_plus_mviews.sql
+++ b/db/mviews/010_rebuild_trade_plus_mviews.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION rebuild_trade_plus_complete_mview() RETURNS void
     SELECT *
     FROM trade_plus_complete_view;
 
-    SELECT rebuild_trade_plus_complete_mview_indexes();
+    SELECT * FROM create_trade_plus_complete_mview_indexes();
   END
   $$;
 

--- a/lib/modules/sapi/stored_procedures.rb
+++ b/lib/modules/sapi/stored_procedures.rb
@@ -124,5 +124,11 @@ module Sapi
       puts "Procedure: #{view}"
       ActiveRecord::Base.connection.execute("SELECT * FROM rebuild_#{view}()")
     end
+
+    def self.create_trade_plus_mview_indexes
+      _function = 'create_trade_plus_complete_mview_indexes'
+      puts "Procedure: #{_function}"
+      ActiveRecord::Base.connection.execute("SELECT * FROM #{_function}()")
+    end
   end
 end

--- a/lib/modules/trade/grouping/compliance.rb
+++ b/lib/modules/trade/grouping/compliance.rb
@@ -1,6 +1,7 @@
 class Trade::Grouping::Compliance < Trade::Grouping::Base
 
   COUNTRIES = {
+    2019 => 182, #TODO Number to be double checked
     2018 => 182,
     2017 => 182,
     2016 => 182,

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -34,7 +34,7 @@ module Trade::TradePlusFilters
       when 'terms'
         v.map do |value|
           value = JSON.parse(value['data'])
-          value['id'], value['name'] = value['id'].capitalize, value['name'].capitalize
+          value['id'], value['name'] = value['id'], value['name'].capitalize
           _v << value
         end
         _v
@@ -69,7 +69,7 @@ module Trade::TradePlusFilters
   def inner_query
     query = []
     ATTRIBUTES.each do |attr|
-      if %w[term unit year appendix].include? attr
+      if %w[year appendix].include? attr
         query << sub_query([attr, attr], attr.pluralize)
       elsif %w[importer exporter origin].include? attr
         query << sub_query([attr, "#{attr}_id", "#{attr}_iso"], attr.pluralize)


### PR DESCRIPTION
## Description

* Use ids instead of names and iso codes to filter shipments
* Add more indexes to speed up queries

## Notes

Works with [this TradePlus PR](https://github.com/unepwcmc/tradeplus/pull/53).

⚠️ Need to rebuild the mview by doing `SELECT rebuild_trade_plus_complete_mview()` or, if you have the mview already, it might be quicker to just run the `CREATE INDEX` statements manually.

⚠️ Need to double check the changes to the grouping functions work with the ComplianceTool as well.