### PR TITLE
ID manual and VC resources importers

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -49,8 +49,10 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
 
   def show
     @document = Document.find(params[:id])
-    path_to_file = @document.filename.path
-    if !File.exists?(path_to_file)
+    path_to_file = @document.filename.path unless @document.is_link?
+    if @document.is_link?
+      redirect_to @document.filename
+    elsif !File.exists?(path_to_file)
       render :file => "#{Rails.root}/public/404.html", :status => 404
     else
       send_file(

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -32,9 +32,11 @@ class Api::V1::DocumentsController < ApplicationController
 
   def show
     @document = Document.find(params[:id])
-    path_to_file = @document.filename.path
+    path_to_file = @document.filename.path unless @document.is_link?
     if access_denied? && !@document.is_public
       render_403
+    elsif @document.is_link?
+      redirect_to @document.filename
     elsif !File.exists?(path_to_file)
       render_404
     else

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -66,7 +66,11 @@ class Document < ActiveRecord::Base
   end
 
   def filename
-    is_link? ? read_attribute(:filename) : super
+    if self.has_attribute? :type
+      is_link? ? read_attribute(:filename) : super
+    else
+      super
+    end
   end
 
   def is_link?
@@ -96,7 +100,7 @@ class Document < ActiveRecord::Base
   end
 
   def set_title
-    if title.blank? && filename_changed? && filename.file
+    if title.blank? && self.changed? && filename.file
       self.title = filename.file.filename.sub(/.\w+$/, '').humanize
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -74,7 +74,7 @@ class Document < ActiveRecord::Base
   end
 
   def is_link?
-    self.type == 'Document::VirtualCollege'
+    (self.elib_legacy_file_name =~ /\.pdf/).nil?
   end
 
   def self.display_name

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -61,6 +61,18 @@ class Document < ActiveRecord::Base
   before_validation :set_title
   before_validation :reset_designation_if_event_set
 
+  def filename=(arg)
+    is_link? ? write_attribute(:filename, arg) : super
+  end
+
+  def filename
+    is_link? ? read_attribute(:filename) : super
+  end
+
+  def is_link?
+    self.type == 'Document::VirtualCollege'
+  end
+
   def self.display_name
     'Document'
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -74,7 +74,7 @@ class Document < ActiveRecord::Base
   end
 
   def is_link?
-    (self.elib_legacy_file_name =~ /\.pdf/).nil?
+    self.type == 'Document::VirtualCollege' && (self.elib_legacy_file_name =~ /\.pdf/).nil?
   end
 
   def self.display_name

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -74,7 +74,7 @@ class Document < ActiveRecord::Base
   end
 
   def is_link?
-    self.type == 'Document::VirtualCollege' && (self.elib_legacy_file_name =~ /\.pdf/).nil?
+    self.type == 'Document::VirtualCollege' && !is_pdf?
   end
 
   def self.display_name
@@ -121,6 +121,12 @@ class Document < ActiveRecord::Base
 
   def geo_entity_names
     parse_pg_array(read_attribute(:geo_entity_names) || "").compact
+  end
+
+  private
+
+  def is_pdf?
+    (self.elib_legacy_file_name =~ /\.pdf/).present?
   end
 
 end

--- a/db/migrate/20200124152531_add_manual_id_attributes_to_documents.rb
+++ b/db/migrate/20200124152531_add_manual_id_attributes_to_documents.rb
@@ -1,6 +1,6 @@
 class AddManualIdAttributesToDocuments < ActiveRecord::Migration
   def change
     add_column :documents, :manual_id, :text
-    add_column :documents, :volume, :text
+    add_column :documents, :volume, :integer
   end
 end

--- a/db/migrate/20200124152531_add_manual_id_attributes_to_documents.rb
+++ b/db/migrate/20200124152531_add_manual_id_attributes_to_documents.rb
@@ -1,0 +1,6 @@
+class AddManualIdAttributesToDocuments < ActiveRecord::Migration
+  def change
+    add_column :documents, :manual_id, :text
+    add_column :documents, :volume, :text
+  end
+end

--- a/lib/tasks/elibrary/citations_manual_importer.rb
+++ b/lib/tasks/elibrary/citations_manual_importer.rb
@@ -1,0 +1,110 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::CitationsImporter
+  include Elibrary::Importable
+
+  def initialize(file_name)
+    @file_name = file_name
+    @file_name =~ /citations_(.+)\.csv$/
+    @document_group = $1
+  end
+
+  def table_name
+    :"elibrary_citations_#{@document_group}_import"
+  end
+
+  def columns_with_type
+    [
+      ['splus_taxon_concept_id', 'TEXT'],
+      ['Manual_ID', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries; end
+
+  def run_queries
+
+    ActiveRecord::Base.connection.execute('DROP TABLE IF EXISTS elibrary_citations_resolved_tmp')
+    ActiveRecord::Base.connection.execute('CREATE TABLE elibrary_citations_resolved_tmp (document_id INT, taxon_concept_id INT)')
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+      INSERT INTO elibrary_citations_resolved_tmp (document_id, taxon_concept_id)
+        SELECT
+        t.doc_id,
+        t.taxon_concept_id
+        FROM (
+          #{rows_to_insert_sql}
+        ) t
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute('CREATE INDEX ON elibrary_citations_resolved_tmp (document_id)')
+    ActiveRecord::Base.connection.execute('CREATE INDEX ON elibrary_citations_resolved_tmp (taxon_concept_id)')
+
+    sql = <<-SQL
+      WITH inserted_citations AS (
+        INSERT INTO document_citations (
+          document_id,
+          created_at,
+          updated_at
+        )
+        SELECT
+          document_id,
+          NOW(),
+          NOW()
+        FROM elibrary_citations_resolved_tmp rows_to_insert_resolved
+        RETURNING *
+      )
+      INSERT INTO document_citation_taxon_concepts (
+        document_citation_id,
+        taxon_concept_id,
+        created_at,
+        updated_at
+      )
+      SELECT DISTINCT
+        inserted_citations.id,
+        taxon_concept_id,
+        NOW(),
+        NOW()
+      FROM elibrary_citations_resolved_tmp rows_to_insert_resolved
+      JOIN inserted_citations ON inserted_citations.document_id = rows_to_insert_resolved.document_id
+      WHERE taxon_concept_id IS NOT NULL
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def rows_to_insert_sql
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        SELECT DISTINCT
+          d.id AS doc_id,
+          CAST(r.splus_taxon_concept_id AS INT) AS taxon_concept_id
+        FROM #{table_name} r
+        JOIN documents d
+        ON d.manual_id = r.manual_id
+      )
+      SELECT
+        doc_id,
+        taxon_concept_id
+      FROM rows_to_insert
+      JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id
+      WHERE taxon_concept_id IS NOT NULL
+      EXCEPT
+      SELECT DISTINCT
+        d.id,
+        c_tc.taxon_concept_id
+      FROM rows_to_insert r
+      JOIN document_citations c ON c.document_id = r.doc_id
+      JOIN documents d ON c.document_id = d.id
+      JOIN document_citation_taxon_concepts c_tc ON c_tc.taxon_concept_id = r.taxon_concept_id
+    SQL
+  end
+
+  def print_breakdown
+    puts "#{Time.now} There are #{DocumentCitation.count} citations in total"
+    DocumentCitation.includes(:document).group('documents.type').order('documents.type').count.each do |type, count|
+      puts "\t #{type} #{count}"
+    end
+  end
+
+end

--- a/lib/tasks/elibrary/citations_manual_importer.rb
+++ b/lib/tasks/elibrary/citations_manual_importer.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib/tasks/elibrary/importable.rb')
 
-class Elibrary::CitationsImporter
+class Elibrary::CitationsManualImporter
   include Elibrary::Importable
 
   def initialize(file_name)

--- a/lib/tasks/elibrary/citations_manual_importer.rb
+++ b/lib/tasks/elibrary/citations_manual_importer.rb
@@ -84,6 +84,7 @@ class Elibrary::CitationsManualImporter
       WHERE taxon_concept_id IS NOT NULL
     SQL
     ActiveRecord::Base.connection.execute(sql)
+    ActiveRecord::Base.connection.execute('DROP TABLE IF EXISTS elibrary_citations_resolved_tmp')
   end
 
   def rows_to_insert_sql
@@ -102,7 +103,9 @@ class Elibrary::CitationsManualImporter
       FROM rows_to_insert
       JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id
       WHERE taxon_concept_id IS NOT NULL
+
       EXCEPT
+      
       SELECT DISTINCT
         d.id,
         c_tc.taxon_concept_id

--- a/lib/tasks/elibrary/documents_identification_importer.rb
+++ b/lib/tasks/elibrary/documents_identification_importer.rb
@@ -20,19 +20,13 @@ class Elibrary::DocumentsIdentificationImporter
       ['DocumentTitle', 'TEXT'],
       ['LanguageName', 'TEXT'],
       ['Master_Document_ID', 'TEXT'],
+      ['Volume', 'INT'],
       ['Type', 'TEXT'],
-      ['DocumentFileName', 'TEXT'],
-      ['Volume', 'TEXT']
+      ['DocumentFileName', 'TEXT']
     ]
   end
 
-  def run_preparatory_queries
-  #   ActiveRecord::Base.connection.execute("DELETE FROM #{table_name} WHERE Type LIKE 'CITES%'")
-  #   ActiveRecord::Base.connection.execute("DELETE FROM #{table_name} WHERE Type LIKE 'Virtual%'")
-  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentTitle = NULL WHERE DocumentTitle='NULL'")
-  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentDate = NULL WHERE DocumentDate='NULL'")
-  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentFileName = NULL WHERE DocumentFileName='NULL'")
-  end
+  def run_preparatory_queries; end
 
   def run_queries
     # insert master documents

--- a/lib/tasks/elibrary/documents_identification_importer.rb
+++ b/lib/tasks/elibrary/documents_identification_importer.rb
@@ -118,7 +118,6 @@ class Elibrary::DocumentsIdentificationImporter
   end
 
   def all_rows_sql
-    byebug
     sql = <<-SQL
       SELECT
         CASE WHEN BTRIM(t.Type) LIKE '%Manual%' THEN 'Document::IdManual'
@@ -137,7 +136,6 @@ class Elibrary::DocumentsIdentificationImporter
   end
 
   def rows_to_insert_sql
-    byebug
     sql = <<-SQL
       SELECT * FROM (
         #{all_rows_sql}

--- a/lib/tasks/elibrary/documents_identification_importer.rb
+++ b/lib/tasks/elibrary/documents_identification_importer.rb
@@ -145,7 +145,9 @@ class Elibrary::DocumentsIdentificationImporter
         AND DocumentFileName IS NOT NULL
         AND DocumentTitle IS NOT NULL
         AND Master_Document_ID IS NULL
+
       EXCEPT
+      
       SELECT
         d.type,
         d.manual_id,

--- a/lib/tasks/elibrary/documents_identification_importer.rb
+++ b/lib/tasks/elibrary/documents_identification_importer.rb
@@ -1,0 +1,182 @@
+require Rails.root.join('lib/tasks/elibrary/importable.rb')
+
+class Elibrary::DocumentsIdentificationImporter
+  include Elibrary::Importable
+
+  def initialize(file_name)
+    @file_name = file_name
+    @file_name =~ /documents_(.+)\.csv$/
+    @document_group = $1
+  end
+
+  def table_name
+    :"elibrary_documents_#{@document_group}_import"
+  end
+
+  def columns_with_type
+    [
+      ['DocumentDate', 'TEXT'],
+      ['Manual_ID', 'TEXT'],
+      ['DocumentTitle', 'TEXT'],
+      ['LanguageName', 'TEXT'],
+      ['Master_Document_ID', 'TEXT'],
+      ['Type', 'TEXT'],
+      ['DocumentFileName', 'TEXT'],
+      ['Volume', 'TEXT']
+    ]
+  end
+
+  def run_preparatory_queries
+  #   ActiveRecord::Base.connection.execute("DELETE FROM #{table_name} WHERE Type LIKE 'CITES%'")
+  #   ActiveRecord::Base.connection.execute("DELETE FROM #{table_name} WHERE Type LIKE 'Virtual%'")
+  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentTitle = NULL WHERE DocumentTitle='NULL'")
+  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentDate = NULL WHERE DocumentDate='NULL'")
+  #   ActiveRecord::Base.connection.execute("UPDATE #{table_name} SET DocumentFileName = NULL WHERE DocumentFileName='NULL'")
+  end
+
+  def run_queries
+    # insert master documents
+    sql = <<-SQL
+      WITH rows_to_insert AS (
+        #{rows_to_insert_sql}
+      ), rows_to_insert_resolved AS (
+        SELECT
+        Type,
+        Manual_ID,
+        DocumentTitle,
+        DocumentDate,
+        DocumentFileName AS filename,
+        DocumentFileName,
+        DocumentIsPubliclyAccessible,
+        lng.id AS language_id,
+        Volume
+        FROM rows_to_insert
+        LEFT JOIN languages lng ON UPPER(lng.iso_code1) = UPPER(rows_to_insert.LanguageName)
+      )
+
+      INSERT INTO "documents" (
+        type,
+        manual_id,
+        title,
+        date,
+        filename,
+        elib_legacy_file_name,
+        is_public,
+        language_id,
+        volume,
+        created_at,
+        updated_at
+      )
+      SELECT
+        rows_to_insert_resolved.*,
+        NOW(),
+        NOW()
+      FROM rows_to_insert_resolved
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+
+    # now insert the documents to be linked with the master document
+    sql = <<-SQL
+      WITH rows_with_master_document_id AS (
+        SELECT
+        rows_to_insert.Type,
+        rows_to_insert.Manual_ID,
+        DocumentTitle,
+        DocumentDate,
+        DocumentFileName AS filename,
+        DocumentFileName,
+        DocumentIsPubliclyAccessible,
+        lng.id AS language_id,
+        rows_to_insert.Volume,
+        master_documents.id AS primary_language_document_id
+        FROM (
+          #{all_rows_sql}
+          WHERE Master_Document_ID IS NOT NULL
+          ) rows_to_insert
+        JOIN documents master_documents ON master_documents.manual_id = rows_to_insert.Master_Document_ID
+        LEFT JOIN languages lng ON UPPER(lng.iso_code1) = UPPER(rows_to_insert.LanguageName)
+          AND rows_to_insert.DocumentDate = master_documents.date
+          AND rows_to_insert.Type = master_documents.type
+          AND master_documents.language_id IS NOT NULL
+      )
+
+      INSERT INTO "documents" (
+        type,
+        manual_id,
+        title,
+        date,
+        filename,
+        elib_legacy_file_name,
+        is_public,
+        language_id,
+        volume,
+        primary_language_document_id,
+        created_at,
+        updated_at
+      )
+      SELECT
+        rows_with_master_document_id.*,
+        NOW(),
+        NOW()
+      FROM rows_with_master_document_id
+    SQL
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def all_rows_sql
+    byebug
+    sql = <<-SQL
+      SELECT
+        CASE WHEN BTRIM(t.Type) LIKE '%Manual%' THEN 'Document::IdManual'
+             WHEN BTRIM(t.Type) LIKE '%Virtual%' THEN 'Document::VirtualCollege'
+        END AS Type,
+        Manual_ID,
+        BTRIM(DocumentTitle) AS DocumentTitle,
+        TO_DATE(DocumentDate::TEXT, 'YYYY-MM-DD') AS DocumentDate,
+        BTRIM(DocumentFileName) AS DocumentFileName,
+        TRUE AS DocumentIsPubliclyAccessible,
+        LanguageName,
+        Master_Document_ID,
+        Volume
+      FROM #{table_name} t
+    SQL
+  end
+
+  def rows_to_insert_sql
+    byebug
+    sql = <<-SQL
+      SELECT * FROM (
+        #{all_rows_sql}
+      ) all_rows_in_table_name
+      WHERE DocumentDate IS NOT NULL
+        AND Type IS NOT NULL
+        AND DocumentFileName IS NOT NULL
+        AND DocumentTitle IS NOT NULL
+        AND Master_Document_ID IS NULL
+      EXCEPT
+      SELECT
+        d.type,
+        d.manual_id,
+        d.title,
+        d.date,
+        d.elib_legacy_file_name,
+        d.is_public,
+        lng.iso_code1,
+        NULL,
+        d.volume
+      FROM (
+        #{all_rows_sql}
+      ) nd
+      JOIN documents d ON d.manual_id = nd.Manual_ID
+      LEFT JOIN languages lng ON lng.id = d.language_id
+    SQL
+  end
+
+  def print_breakdown
+    puts "#{Time.now} There are #{Document.count} documents in total"
+    Document.group(:type).order(:type).count.each do |type, count|
+      puts "\t #{type} #{count}"
+    end
+  end
+
+end

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -75,7 +75,16 @@ namespace :elibrary do
       importer.run
     end
   end
-  namespace :document_discussions do
+  namespace :identification_documents do
+    require Rails.root.join('lib/tasks/elibrary/documents_identification_importer.rb')
+    desc 'Import manual id documents and VC resources from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::DocumentsIdentificationImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
+    namespace :document_discussions do
     require Rails.root.join('lib/tasks/elibrary/document_discussions_importer.rb')
     desc 'Import document discussions'
     task :import => :environment do |task_name|
@@ -92,6 +101,17 @@ namespace :elibrary do
         fail "Usage: SOURCE_DIR=/abs/path/to/dir TARGET_DIR=/abs/path/to/dir rake elibrary:import:#{task_name}"
       end
       importer = Elibrary::DocumentFilesImporter.new(ENV['SOURCE_DIR'], ENV['TARGET_DIR'])
+      importer.run
+    end
+  end
+  namespace :manual_document_files do
+    require Rails.root.join('lib/tasks/elibrary/manual_document_files_importer.rb')
+    desc 'Import Manual ID and Virtual College files'
+    task :import => :environment do |task_name|
+      if ENV['SOURCE_DIR'].blank? || ENV['TARGET_DIR'].blank?
+        fail "Usage: SOURCE_DIR=/abs/path/to/dir TARGET_DIR=/abs/path/to/dir rake elibrary:import:#{task_name}"
+      end
+      importer = Elibrary::ManualDocumentFilesImporter.new(ENV['SOURCE_DIR'], ENV['TARGET_DIR'])
       importer.run
     end
   end
@@ -146,6 +166,15 @@ namespace :elibrary do
     task :import => :environment do |task_name|
       check_file_provided(task_name)
       importer = Elibrary::CitationsImporter.new(ENV['FILE'])
+      importer.run
+    end
+  end
+  namespace :citations_manual do
+    require Rails.root.join('lib/tasks/elibrary/citations_manual_importer.rb')
+    desc 'Import Manual ID and VC citations from csv file'
+    task :import => :environment do |task_name|
+      check_file_provided(task_name)
+      importer = Elibrary::CitationsManualImporter.new(ENV['FILE'])
       importer.run
     end
   end

--- a/lib/tasks/elibrary/manual_document_files_importer.rb
+++ b/lib/tasks/elibrary/manual_document_files_importer.rb
@@ -1,0 +1,55 @@
+require 'fileutils'
+# The purpose of this is to go over all document records and match them
+# with respective files.
+# Where files are present, create the expected directory structure, e.g.
+# /private/elibrary/documents/1/filename
+# Where files are missing, generate a report.
+# source_dir is the path to the directory with flat file structure
+# target dir is the path to the /private/elibrary
+class Elibrary::ManualDocumentFilesImporter
+  def initialize(source_dir, target_dir)
+    @source_dir = source_dir
+    @target_dir = target_dir
+  end
+
+  def copy_with_path(src, dst)
+    FileUtils.mkdir_p(File.dirname(dst))
+    FileUtils.cp(src, dst)
+  end
+
+  def run
+    total = Document.count
+    Document.where("type IN ('Document::IdManual', 'Document::VirtualCollege')")
+            .order(:type, :date)
+            .select([:id, :elib_legacy_file_name, :type])
+            .each_with_index do |doc, idx|
+      info_txt = "#{doc.elib_legacy_file_name} (#{idx} of #{total})"
+      target_location = @target_dir + "/documents/#{doc.id}/#{doc.elib_legacy_file_name}"
+      # check if file exists at target location
+      if File.exists?(target_location)
+        puts "TARGET PRESENT #{target_location}" + info_txt
+        next
+      end
+      source_location = @source_dir + "/#{doc.elib_legacy_file_name}"
+      # check if file exists at source location
+      unless File.exists?(source_location)
+        case doc.type
+        when 'Document::IdManual'
+          puts "SOURCE MISSING #{source_location}" + info_txt
+          next
+        when 'Document::VirtualCollege'
+          unless doc.elib_legacy_file_name =~ /\.pdf/
+            puts "THIS IS A LINK TO EXTERNAL RESOURCES, NOT A PDF #{source_location}" + info_txt
+          else
+            remote_doc = Document.find(doc.id)
+            remote_doc.remote_filename_url = doc.elib_legacy_file_name
+            remote_doc.save!
+          end
+          next
+        end
+      end
+      copy_with_path(source_location, target_location)
+      puts "COPIED " + info_txt
+    end
+  end
+end

--- a/lib/tasks/elibrary/manual_document_files_importer.rb
+++ b/lib/tasks/elibrary/manual_document_files_importer.rb
@@ -19,10 +19,7 @@ class Elibrary::ManualDocumentFilesImporter
 
   def run
     total = Document.count
-    Document.where("type IN ('Document::IdManual', 'Document::VirtualCollege')")
-            .order(:type, :date)
-            .select([:id, :elib_legacy_file_name, :type])
-            .each_with_index do |doc, idx|
+    identification_docs.each_with_index do |doc, idx|
       info_txt = "#{doc.elib_legacy_file_name} (#{idx} of #{total})"
       target_location = @target_dir + "/documents/#{doc.id}/#{doc.elib_legacy_file_name}"
       # check if file exists at target location
@@ -51,5 +48,11 @@ class Elibrary::ManualDocumentFilesImporter
       copy_with_path(source_location, target_location)
       puts "COPIED " + info_txt
     end
+  end
+
+  def identification_docs
+    Document.where("type IN ('Document::IdManual', 'Document::VirtualCollege')")
+            .order(:type, :date)
+            .select([:id, :elib_legacy_file_name, :type])
   end
 end


### PR DESCRIPTION
This includes a workaround to create a document without any filename attached in the first place. 

This includes a db migration to add the `manual_id` and `volume` attribute to Documents.

This includes the documents importer, the citations importer and the files importer:

- `DocumentsIdentificationImporter` read a csv and create in the db all the Document object related
- `CitationsManualImporter` read a csv and create the associations in the db among the Documents and the related TaxonConcepts (done through the _DocumentCitationTaxonConcept_ db table)
- `ManualDocumentFilesImporter` goes over all document records and match them
 with respective files.

:warning:  Please ask for the csv and pdf files once you wanna test this

Steps to follow for the import process:

- put the 2 csvs provided (one for the documents one for the citations) in the `lib/data/` folder
- make sure to have redis up and running before launching the importers
- import the documents using the docs csv provided:  `FILE=/abs/path/to/file bundle exec rake elibrary:identification_documents:import`
- import citations and taxon concepts using the citations csv provided: `FILE=/abs/path/to/file bundle exec rake elibrary:citations_manual:import`
- import the pdf files (you should have received an email with a link to the relative dropbox folder) into your local `private/elibrary` folder using: `SOURCE_DIR=/abs/path/to/dir TARGET_DIR=/abs/path/to/dir rake elibrary:manual_document_files:import` where source_dir is the path to the directory with flat file structure and target dir is the path to the private/elibrary