### PR TITLE
Trade plus/cascade to lower taxa

### DIFF
--- a/lib/modules/trade/grouping/base.rb
+++ b/lib/modules/trade/grouping/base.rb
@@ -130,11 +130,17 @@ class Trade::Grouping::Base
     condition_attributes.map do |key, value|
       val = get_condition_value(key.to_sym, value)
       column = filtering_attributes[key.to_sym]
-      next if column == 'taxon_id' && @opts['taxon_id'].present?
+      # taxon_id equality check can be skipped as this is also managed through the recursive child_taxa query
+      # in TradeVis
+      next if column == 'taxon_id' && skip_taxon_id?
       column = (['year', 'appendix'].include?(column) || is_id_column?(column)) ? column : "LOWER(#{column})"
 
       "(#{column} #{val})"
     end.compact.join(' AND ')
+  end
+
+  def skip_taxon_id?
+    raise NotImplementedError
   end
 
   def is_id_column?(column)

--- a/lib/modules/trade/grouping/base.rb
+++ b/lib/modules/trade/grouping/base.rb
@@ -130,10 +130,11 @@ class Trade::Grouping::Base
     condition_attributes.map do |key, value|
       val = get_condition_value(key.to_sym, value)
       column = filtering_attributes[key.to_sym]
+      next if column == 'taxon_id' && @opts['taxon_id'].present?
       column = (['year', 'appendix'].include?(column) || is_id_column?(column)) ? column : "LOWER(#{column})"
 
       "(#{column} #{val})"
-    end.join(' AND ')
+    end.compact.join(' AND ')
   end
 
   def is_id_column?(column)

--- a/lib/modules/trade/grouping/compliance.rb
+++ b/lib/modules/trade/grouping/compliance.rb
@@ -341,4 +341,10 @@ class Trade::Grouping::Compliance < Trade::Grouping::Base
     query_imp = "SELECT COUNT(*) FROM trade_shipments_with_taxa_view WHERE importer_id = #{id} AND year = #{year}"
     db.execute(query_imp).values.flatten.first.to_i
   end
+
+  # Used in the base class to not skip taxon_id equality check.
+  # It can be skipped by other groupings
+  def skip_taxon_id?
+    false
+  end
 end

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -294,4 +294,10 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
 
     per_page > 0 ? "LIMIT #{pagination[:per_page]} OFFSET #{offset}" : ''
   end
+
+  # Used in the base class to skip taxon_id equality check
+  # as it will be managed by the child_taxa recursive query
+  def skip_taxon_id?
+    @opts['taxon_id'].present?
+  end
 end


### PR DESCRIPTION
## Description

Selecting one or multiple taxa in the filter dropdowns was not cascading the search to lower level taxa.
This PR fixes the behaviour.

Example:
when searching for Canis, the query now performs a search through Canis itself and all its children, recursively (e.g. Canis lupus, Canis aureus, Canis lupus irremotus, etc.)

## Notes

[Related Codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/149)