### PR TITLE
hide keyword search when VC selected

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -11,6 +11,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
   autoCompleteTaxonConcept: null
   selectedEventType: null
   locationsDropdownVisible: true
+  keywordSearchVisible: true
 
   setFilters: (filtersHash) ->
     if filtersHash.taxon_concept_query == ''
@@ -103,12 +104,19 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     return contains
   )
 
+  toggleKeywordSearch: ((isVisible) ->
+    @set('keywordSearchVisible', isVisible)
+    if !isVisible
+      @set('titleQuery', '')
+  )
+
   actions:
     openSearchPage:->
       @transitionToRoute('documents', {queryParams: @getFilters()})
 
     handleDocumentTypeSelection: (documentType) ->
       @set('selectedDocumentType', documentType)
+      @toggleKeywordSearch(documentType.id != 'Document::VirtualCollege')
       if @containsDocTypeOrDocTypeUnselected(@get('identificationDocumentTypes'))
         @set('locationsDropdownVisible', false)
         @set('selectedGeoEntities', [])
@@ -117,6 +125,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     handleDocumentTypeDeselection: ->
       @set('selectedDocumentType', null)
       @set('locationsDropdownVisible', true)
+      @toggleKeywordSearch(true)
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       @set('autoCompleteTaxonConcept', autoCompleteTaxonConcept)
@@ -134,3 +143,4 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       @set('selectedDocumentType', null)
       @set('selectedInterSessionalDocType', null)
       @set('selectedProposalOutcome', null)
+      @toggleKeywordSearch(true)

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -108,14 +108,16 @@
       </div>
 
       <div class="documents-control-group">
-        <label>Search by title keyword(s)
-          <i class="fa fa-info-circle"
-            title="This search will only return results if there is an exact match with the word or phrase in the title of the document.">
-          </i>
-        </label>
-        <div class="text-input-wrapper keyword-search">
-          {{input type="text" value=titleQuery placeholder='e.g. NDF'}}
-        </div>
+        {{#if keywordSearchVisible}}
+          <label>Search by title keyword(s)
+            <i class="fa fa-info-circle"
+              title="This search will only return results if there is an exact match with the word or phrase in the title of the document.">
+            </i>
+          </label>
+          <div class="text-input-wrapper keyword-search">
+            {{input type="text" value=titleQuery placeholder='e.g. NDF'}}
+          </div>
+        {{/if}}
       </div>
     </fieldset>
     <div class="search-buttons-container">


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-id-manual/tickets/23

This hides and clears the keyword search in document search when virtual college materials are selected.