### PR TITLE
open docs in new tab

### DIFF
--- a/app/assets/javascripts/species/templates/components/document-result.handlebars
+++ b/app/assets/javascripts/species/templates/components/document-result.handlebars
@@ -2,7 +2,7 @@
 <td class='event-date-col'>{{unbound doc.date}}</td>
 <td class='title-col'>
 
-  <a {{bind-attr class=":legal-links isLongTitle:tooltip"}} {{action "startDownload" on="click"}}>
+  <a {{bind-attr class=":legal-links isLongTitle:tooltip"}} {{action "startDownload" on="click"}} target="_blank">
 
     {{#if isLongTitle}}
       {{truncate fullTitle}}

--- a/app/assets/javascripts/species/views/documents/document_result_component.js.coffee
+++ b/app/assets/javascripts/species/views/documents/document_result_component.js.coffee
@@ -57,4 +57,4 @@ Species.DocumentResultComponent = Ember.Component.extend
         eventValue: 1
       }
       ga('send', trackingInfo)
-      window.location = url
+      window.open(url, '_blank')

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::DocumentsController < ApplicationController
         path_to_file,
           :filename => File.basename(path_to_file),
           :type => @document.filename.content_type,
-          :disposition => 'attachment',
+          :disposition => 'inline',
           :url_based_filename => true
       )
     end


### PR DESCRIPTION
This opens docs in a new tab rather than downloading them. Should work for all docs, but only tested for Id ones as these are the only ones I have at the moment. 404 opens in another tab too. I don't think editing this on the documents#show action has affects elsewhere, but worth bearing in mind.