### PR TITLE
add parts and general filter and refactor to use id event

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -10,6 +10,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
   searchContext: 'documents'
   autoCompleteTaxonConcept: null
   selectedEventType: null
+  selectedGeneralSubType: null
   locationsDropdownVisible: true
 
   setFilters: (filtersHash) ->
@@ -33,6 +34,9 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       taxonConceptQuery = @get('taxonConceptQueryForDisplay')
     if @get('titleQuery') && @get('titleQuery').length > 0
       titleQuery = @get('titleQuery')
+    if @get('selectedGeneralSubType')
+      isGeneralSubType = @get('selectedGeneralSubType.id') == 'general'
+    
     {
       taxon_concept_query: taxonConceptQuery,
       geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),
@@ -41,6 +45,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       events_ids: @get('selectedEvents').mapProperty('id'),
       document_type: @get('selectedDocumentType.id'),
       proposal_outcome_id: @get('selectedProposalOutcome.id'),
+      general_subtype: isGeneralSubType
     }
 
   filteredDocumentTypes: ( ->
@@ -65,6 +70,10 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     @get('controllers.events.identificationDocumentTypes')
     ).property()
 
+  generalSubTypes: ( ->
+    @get('controllers.events.generalSubTypes')
+  ).property()
+
   documentTypeDropdownVisible: ( ->
     @get('selectedEventType.id') == 'EcSrg'
   ).property('selectedEventType')
@@ -74,18 +83,18 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
   ).property('selectedDocumentType', 'filteredDocumentTypes')
 
   interSessionalDocTypeDropdownVisible: ( ->
-    !@get('selectedEventType.id')? && @get('isDocTypeUnselectedOrInterSessional')
-  ).property('selectedEventType', 'isDocTypeUnselectedOrInterSessional')
+    !@get('selectedEventType.id')? && @get('isDocTypeUnselectedOrIntersessional')
+  ).property('selectedEventType', 'isDocTypeUnselectedOrIntersessional')
 
   identificationDocTypeDropdownVisible: ( ->
-    !@get('selectedEventType.id')? && @get('isDocTypeUnselectedOrIdentification')
-  ).property('selectedEventType', 'isDocTypeUnselectedOrIdentification')
+    @get('isEventTypeIdMaterials') || (!@get('selectedEventType')? && @get('isDocTypeUnselectedOrIdentification'))
+  ).property('selectedEventType', 'isDocTypeUnselectedOrIdentification', 'isEventTypeIdMaterials')
 
   isDocTypeUnselectedOrIdentification: ( ->
     @containsDocTypeOrDocTypeUnselected(@get('identificationDocumentTypes'))
   ).property('selectedDocumentType', 'identificationDocumentTypes')
 
-  isDocTypeUnselectedOrInterSessional: ( ->
+  isDocTypeUnselectedOrIntersessional: ( ->
     @containsDocTypeOrDocTypeUnselected(@get('interSessionalDocumentTypes'))
   ).property('selectedDocumentType', 'interSessionalDocumentTypes')
 
@@ -110,13 +119,20 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     handleDocumentTypeSelection: (documentType) ->
       @set('selectedDocumentType', documentType)
       if @containsDocTypeOrDocTypeUnselected(@get('identificationDocumentTypes'))
+        @handleEventTypeSelection(@get('controllers.events.idMaterialsEvent'))
         @set('locationsDropdownVisible', false)
         @set('selectedGeoEntities', [])
         @set('selectedGeoEntitiesIds', [])
 
     handleDocumentTypeDeselection: ->
+      if @get('isEventTypeIdMaterials')
+        @handleEventTypeDeselection(@get('controllers.events.idMaterialsEvent'))
+      @set('selectedGeneralSubType', null)
       @set('selectedDocumentType', null)
       @set('locationsDropdownVisible', true)
+
+    handleGeneralSubTypeSelection: (type) ->
+      @set('selectedGeneralSubType', type)
 
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       @set('autoCompleteTaxonConcept', autoCompleteTaxonConcept)
@@ -134,3 +150,4 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       @set('selectedDocumentType', null)
       @set('selectedInterSessionalDocType', null)
       @set('selectedProposalOutcome', null)
+      @set('selectedGeneralSubType', null)

--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -22,11 +22,24 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     if filtersHash.title_query == ''
       filtersHash.title_query = null
     @set('titleQuery', filtersHash.title_query)
-    @set('selectedEventType', @get('controllers.events.eventTypes').findBy('id', filtersHash.event_type))
+
+    allEventTypes = @get('controllers.events.eventTypes')
+    allEventTypes.push(@get('controllers.events.idMaterialsEvent')) 
+
+    @set('selectedEventType', allEventTypes.findBy('id', filtersHash.event_type))
     @set('selectedEventsIds', filtersHash.events_ids || [])
-    allDocumentTypes = @get('controllers.events.documentTypes').concat @get('controllers.events.interSessionalDocumentTypes')
+
+    allDocumentTypes = @get('controllers.events.documentTypes')
+      .concat @get('controllers.events.interSessionalDocumentTypes')
+      .concat @get('controllers.events.identificationDocumentTypes')
+    
     @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
-    @set('selectedProposalOutcomeId', filtersHash.proposal_outcome_id)
+    @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
+
+    @set('selectedGeneralSubType', 
+      @get('controllers.events.generalSubTypes')
+        .findBy('id', if filtersHash.general_subtype == 'true' then 'general' else 'parts'))
+
     @set('selectedReviewPhaseId', filtersHash.review_phase_id)
 
   getFilters: ->
@@ -35,8 +48,7 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     if @get('titleQuery') && @get('titleQuery').length > 0
       titleQuery = @get('titleQuery')
     if @get('selectedGeneralSubType')
-      isGeneralSubType = @get('selectedGeneralSubType.id') == 'general'
-    
+      isGeneralSubType = (@get('selectedGeneralSubType.id') == 'general').toString()
     {
       taxon_concept_query: taxonConceptQuery,
       geo_entities_ids: @get('selectedGeoEntities').mapProperty('id'),

--- a/app/assets/javascripts/species/controllers/events_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/events_controller.js.coffee
@@ -20,6 +20,11 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
     }
   ]
 
+  idMaterialsEvent: {
+    id: 'IdMaterials'
+    name: 'Identification Materials'
+  }
+
   documentTypes: [
     {
       id: 'Document::Proposal',
@@ -89,6 +94,17 @@ Species.EventsController = Ember.ArrayController.extend Species.ArrayLoadObserve
     {
       id: 'Document::VirtualCollege',
       name: 'Other identification materials'
+    }
+  ]
+
+  generalSubTypes: [
+    {
+      id: 'general',
+      name: 'General identification'
+    },
+    {
+      id: 'parts',
+      name: 'Parts and derivatives'
     }
   ]
 

--- a/app/assets/javascripts/species/mixins/event_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/event_lookup.js.coffee
@@ -14,23 +14,31 @@ Species.EventLookup = Ember.Mixin.create
   ).property('selectedEventType.id')
 
   eventsDropdownVisible: ( ->
-    @get('selectedEventType')?
-  ).property('selectedEventType.id')
+    @get('selectedEventType')? && !@get('isEventTypeIdMaterials')
+  ).property('selectedEventType.id', 'isEventTypeIdMaterials')
 
-  actions:
-    handleEventTypeSelection: (eventType) ->
-      @set('selectedEventType', eventType)
-      if @get('selectedEventType.id') != @get('selectedEvent.type')
-        @set('selectedEvents', [])
-        @set('selectedEventsIds', [])
-      if (@get('selectedDocumentType.eventTypes') && @get('selectedDocumentType.eventTypes').indexOf(@get('selectedEvent.type')) < 0) || eventType.id == 'EcSrg'
-        @set('selectedDocumentType', null)
+  isEventTypeIdMaterials: ( ->
+    @get('selectedEventType')? && @get('selectedEventType.id') == @get('controllers.events.idMaterialsEvent.id')
+  ).property('selectedEventType')
 
-    handleEventTypeDeselection: (eventType) ->
+  handleEventTypeSelection: (eventType) ->
+    @set('selectedEventType', eventType)
+    if @get('selectedEventType.id') != @get('selectedEvent.type')
+      @set('selectedEvents', [])
+      @set('selectedEventsIds', [])
+    if (@get('selectedDocumentType.eventTypes') && @get('selectedDocumentType.eventTypes').indexOf(@get('selectedEvent.type')) < 0) || eventType.id == 'EcSrg'
+      @set('selectedDocumentType', null)
+
+  handleEventTypeDeselection: (eventType) ->
       @set('selectedEventType', null)
       @set('selectedEvents', [])
       @set('selectedEventsIds', [])
       @set('selectedDocumentType', null)
+
+  actions:
+    handleEventTypeSelection: @handleEventTypeSelection
+
+    handleEventTypeDeselection: @handleEventTypeDeselection
 
     deleteEventSelection: (context) ->
       @get('selectedEvents').removeObject(context)

--- a/app/assets/javascripts/species/router.js.coffee
+++ b/app/assets/javascripts/species/router.js.coffee
@@ -14,7 +14,7 @@ Species.Router.map (match) ->
     queryParams: [
       'taxon_concept_query', 'geo_entities_ids', 'title_query',
       'event_type', 'events_ids', 'document_type',
-      'proposal_outcome_id', 'review_phase_id'
+      'proposal_outcome_id', 'review_phase_id', 'general_subtype'
     ]
   }
   @route 'about'

--- a/app/assets/javascripts/species/routes/documents_route.js.coffee
+++ b/app/assets/javascripts/species/routes/documents_route.js.coffee
@@ -56,9 +56,7 @@ Species.DocumentsRoute = Ember.Route.extend Species.Spinner,
     isLoadingProperty = eventType + 'DocsIsLoading'
 
     controller.set(isLoadingProperty, true)
-    @loadDocuments(eventQueryParams, (documents) =>
-      console.log(eventQueryParams)
-      
+    @loadDocuments(eventQueryParams, (documents) =>      
       controller.set(eventKey, documents)
     )
 

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -32,16 +32,18 @@
       </div>
 
       <div class="documents-control-group">
-        <div {{bind-attr class=":popup-area :events-area selectedEventType:events-visible"}}>
-          <label>Meeting</label>
-          {{view Species.EventsSearchButton
-            selectedEventsBinding="controller.selectedEvents"
-            loadedBinding="events.loaded"
-            shortPlaceholder=false
-            taxonConceptQueryBinding="controller.taxonConceptQueryForDisplay"
-          }}
-          {{view Species.EventsSearchDropdown controllerBinding="controller"}}
-        </div>
+        {{#if controller.eventsDropdownVisible}}
+          <div class="popup-area">
+            <label>Meeting</label>
+            {{view Species.EventsSearchButton
+              selectedEventsBinding="controller.selectedEvents"
+              loadedBinding="events.loaded"
+              shortPlaceholder=false
+              taxonConceptQueryBinding="controller.taxonConceptQueryForDisplay"
+            }}
+            {{view Species.EventsSearchDropdown controllerBinding="controller"}}
+          </div>
+        {{/if}}
       </div>
 
       <div class="documents-control-group">
@@ -77,6 +79,18 @@
           placeholder="All identification types"
           values=controller.identificationDocumentTypes
           selection=controller.selectedDocumentType
+        }}
+      </div>
+
+      <div class="documents-control-group">
+        {{single-dropdown
+          isVisible=controller.isEventTypeIdMaterials
+          action="handleGeneralSubTypeSelection"
+          clearAction="handleGeneralSubTypeDeselection"
+          title="Identification type"
+          placeholder="All identification types"
+          values=controller.generalSubTypes
+          selection=controller.selectedGeneralSubType
         }}
       </div>
 

--- a/app/assets/stylesheets/species/search.scss
+++ b/app/assets/stylesheets/species/search.scss
@@ -410,6 +410,3 @@ html.lt-ie9 .search-block .search-form {
   line-height: 30px;
   color: #2d3237;
 }
-
-.events-area { display: none; }
-.events-visible { display: block; }


### PR DESCRIPTION
Adds the general/parts filter plus edits to dependency logic as selecting an id doc is now simultaneously a doc and event selection. I think I've tried different filter combos and checked that selections don't persist after the filter has disappeared. It's a bit hacky, sorry.