### PR TITLE
Add endpoint to check ID manual doc presence

### DIFF
--- a/app/controllers/checklist/documents_controller.rb
+++ b/app/controllers/checklist/documents_controller.rb
@@ -39,7 +39,7 @@ class Checklist::DocumentsController < ApplicationController
 
   def check_doc_presence
     doc_ids = MaterialDocIdsRetriever.run(params)
-    
+
     render :json => doc_ids.present?
   end
 
@@ -71,7 +71,6 @@ class Checklist::DocumentsController < ApplicationController
     doc_ids = doc_ids.map{ |d| d['id'] }
 
     @download = Download.create(params[:download])
-    # byebug
     ManualDownloadWorker.perform_async(@download.id, doc_ids, params)
 
     @download = @download.attributes.except("filename", "path")

--- a/app/controllers/checklist/documents_controller.rb
+++ b/app/controllers/checklist/documents_controller.rb
@@ -38,6 +38,16 @@ class Checklist::DocumentsController < ApplicationController
     end
   end
 
+  def check_doc_presence
+    params[:taxon_concepts_ids] = MTaxonConcept.descendants_ids(params[:taxon_concept_id])
+    docs = DocumentSearch.new(
+      params.merge(show_private: !access_denied?, per_page: 10_000), 'public'
+    )
+
+    doc_ids = docs.cached_results.map { |doc| locale_document(doc) }.flatten
+    render :json => doc_ids.present?
+  end
+
   def download_zip
     require 'zip'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,6 +231,7 @@ SAPI::Application.routes.draw do
       collection do
         get 'download_zip'
         get 'volume_download'
+        get 'check_doc_presence'
       end
     end
   end

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -1,0 +1,40 @@
+module MaterialDocIdsRetriever
+
+  def self.run(params)
+    params['taxon_concepts_ids'] =
+      if params['taxon_name'].present?
+        # retrieve the same taxa as shown in the page
+        MTaxonConcept.by_cites_eu_taxonomy
+                     .without_non_accepted
+                     .without_hidden
+                     .by_name(
+                        params['taxon_name'],
+                        { :synonyms => true, :common_names => true, :subspecies => false }
+                       )
+                     .pluck(:id)
+      elsif params['taxon_concept_id'].present?
+        #retrieve all the children taxa given a taxon(included)
+        MTaxonConcept.descendants_ids(params['taxon_concept_id'])
+      end
+
+    docs = DocumentSearch.new(
+      params.merge(show_private: false, per_page: 10_000), 'public'
+    )
+
+    doc_ids = docs.cached_results.map { |doc| locale_document(doc) }.flatten
+    doc_ids = doc_ids.map{ |d| d['id'] }
+  end
+
+  private
+
+  def self.document_language_versions(doc)
+    JSON.parse(doc.document_language_versions)
+  end
+
+  def self.locale_document(doc)
+    document = document_language_versions(doc).select { |h| h['locale_document'] == 'true' }
+    document = document_language_versions(doc).select { |h| h['locale_document'] == 'default' } if document.empty?
+    document
+  end
+
+end


### PR DESCRIPTION
Here an example query:

localhost:3000/checklist/documents/check_doc_presence?taxon_concept_id=1612&locale=en&document_type=Document::IdManual

this would return true or false.