### PR TITLE
Material docs distribution

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -11,7 +11,6 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
   autoCompleteTaxonConcept: null
   selectedEventType: null
   selectedGeneralSubType: null
-  locationsDropdownVisible: true
   keywordSearchVisible: true
 
   setFilters: (filtersHash) ->
@@ -155,16 +154,12 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       @toggleKeywordSearch(documentType.id != 'Document::VirtualCollege' && documentType.id != '__all__' )
       if @containsDocTypeOrDocTypeUnselected(@get('identificationDocumentTypes'))
         @handleEventTypeSelection(@get('controllers.events.idMaterialsEvent'))
-        @set('locationsDropdownVisible', false)
-        @set('selectedGeoEntities', [])
-        @set('selectedGeoEntitiesIds', [])
 
     handleDocumentTypeDeselection: ->
       if @get('isEventTypeIdMaterials')
         @handleEventTypeDeselection(@get('controllers.events.idMaterialsEvent'))
       @set('selectedGeneralSubType', null)
       @set('selectedDocumentType', null)
-      @set('locationsDropdownVisible', true)
       @toggleKeywordSearch(true)
 
     handleGeneralSubTypeSelection: (type) ->

--- a/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
+++ b/app/assets/javascripts/species/templates/elibrary_search_form.handlebars
@@ -18,7 +18,21 @@
         {{view Species.TaxonConceptSearchView controllerBinding="controller" showSearchButton=false}}
       </div>
     </fieldset>
+
     <fieldset>
+      <div class="documents-control-group">
+        <div class="location-area popup-area">
+          <label>Countries and territories <i class="fa fa-info-circle" title="Including historic names"></i></label>
+          {{view Species.GeoEntitiesSearchButton
+            selectedGeoEntitiesBinding="controller.selectedGeoEntities"
+            loadedBinding="geoEntities.loaded"
+            shortPlaceholder=false
+            taxonConceptQueryBinding="controller.taxonConceptQueryForDisplay"
+          }}
+          {{view Species.GeoEntitiesSearchDropdown controllerBinding="controller"}}
+        </div>
+      </div>
+
       <div class="documents-control-group">
         {{single-dropdown
           isVisible=controller.meetingDocTypeDropdownVisible
@@ -104,21 +118,6 @@
           values=controllers.documentTags.proposalOutcomes
           selection=controller.selectedProposalOutcome
         }}
-      </div>
-
-      <div class="documents-control-group">
-        {{#if locationsDropdownVisible}}
-          <div class="location-area popup-area">
-            <label>Countries and territories <i class="fa fa-info-circle" title="Including historic names"></i></label>
-            {{view Species.GeoEntitiesSearchButton
-              selectedGeoEntitiesBinding="controller.selectedGeoEntities"
-              loadedBinding="geoEntities.loaded"
-              shortPlaceholder=false
-              taxonConceptQueryBinding="controller.taxonConceptQueryForDisplay"
-            }}
-            {{view Species.GeoEntitiesSearchDropdown controllerBinding="controller"}}
-          </div>
-        {{/if}}
       </div>
 
       <div class="documents-control-group">

--- a/app/models/checklist/checklist.rb
+++ b/app/models/checklist/checklist.rb
@@ -4,6 +4,7 @@ class Checklist::Checklist
   include SearchCache # this provides #cached_results and #cached_total_cnt
   attr_accessor :animalia, :plantae, :authors, :synonyms, :synonyms_with_authors,
   :english_common_names, :spanish_common_names, :french_common_names, :total_cnt
+  attr_reader :query
 
   # Constructs a query to retrieve CITES listed taxon concepts based on user
   # defined parameters

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -40,6 +40,8 @@ module MaterialDocIdsRetriever
         Checklist::Checklist.new(check_params).results.map(&:id)
       end
 
+    return [] if params['taxon_concepts_ids'].empty?
+
     docs = DocumentSearch.new(
       params.merge(show_private: false, per_page: 10_000), 'public'
     )

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -12,7 +12,7 @@ module MaterialDocIdsRetriever
         ids =
           if params['scientific_name'].present? ||  params['country_ids'].present? ||  params['cites_appendices'].present?
             check_params[:scientific_name] = params['taxon_name']
-            Checklist::Checklist.new(check_params).results.map(&:id)
+            Checklist::Checklist.new(check_params).query.pluck(:id)
 
           else
             MTaxonConcept.by_cites_eu_taxonomy

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -11,6 +11,7 @@ module MaterialDocIdsRetriever
         check_params = params.symbolize_keys
         ids =
           if params['scientific_name'].present? ||  params['country_ids'].present? ||  params['cites_appendices'].present?
+            check_params[:scientific_name] = params['taxon_name']
             Checklist::Checklist.new(check_params).results.map(&:id)
 
           else

--- a/lib/tasks/elibrary/identification_docs_distributions_importer.rb
+++ b/lib/tasks/elibrary/identification_docs_distributions_importer.rb
@@ -1,5 +1,6 @@
 class Elibrary::IdentificationDocsDistributionsImporter
-  def self.run
+  # import distribution on material documents tagged at species level
+  def self.import_species_distributions
     sql = <<-SQL
       WITH doc_taxon_tmp AS (
   	    SELECT dc.id doc_cit_id, dctc.taxon_concept_id tc_id
@@ -31,9 +32,67 @@ class Elibrary::IdentificationDocsDistributionsImporter
     SQL
 
     ActiveRecord::Base.connection.execute(sql)
+  end
+
+  # import distribution on material documents tagged at level higher than species
+  def self.import_higer_taxa_distributions
 
     sql = <<-SQL
-      
+    WITH doc_taxon_tmp AS (
+      SELECT DISTINCT(dc.id) doc_cit_id, UNNEST(d.taxon_concept_ids)tc_ids
+      FROM document_citation_taxon_concepts dctc
+      JOIN document_citations dc ON dc.id = dctc.document_citation_id
+      JOIN api_documents_mview d ON d.id = dc.document_id
+      WHERE d.document_type IN ('Document::IdManual', 'Document::VirtualCollege')
+    )
+    SELECT tmp.*
+    FROM doc_taxon_tmp tmp
+    LEFT OUTER JOIN taxon_concepts_mview tc ON tmp.tc_ids=tc.id
+    WHERE tc.countries_ids_ary IS NULL
     SQL
+
+    results = ActiveRecord::Base.connection.execute(sql)
+
+    results.to_a.each_slice(50) do |result|
+      sql, no_distr = [], []
+      result.each do |res|
+        doc_cit_id = res['doc_cit_id']
+
+        children = MTaxonConcept.descendants_ids(res['tc_ids'])
+
+        countries_ids = MTaxonConcept.where(id: children).pluck(:countries_ids_ary)
+                                     .compact.map{ |country| country.gsub(/[{}]/, '').split(',').map(&:to_i)}
+                                     .flatten.uniq.sort
+
+        if countries_ids.empty?
+          no_distr << [doc_cit_id, children]
+          next
+        end
+
+        sql << "SELECT #{doc_cit_id} document_citation_id, geo_entity_id
+                FROM UNNEST(ARRAY#{countries_ids}) geo_entity_id"
+      end
+
+      query = <<-SQL
+       WITH doc_cit_country_tmp AS (
+         #{sql.join("\n\nUNION\n\n")}
+       )
+       INSERT INTO "document_citation_geo_entities" (
+         document_citation_id,
+         geo_entity_id,
+         created_at,
+         updated_at
+       )
+       SELECT
+        doc_cit_country_tmp.*,
+        NOW(),
+        NOW()
+       FROM doc_cit_country_tmp
+
+       ON CONFLICT (geo_entity_id, document_citation_id) DO NOTHING
+
+      SQL
+      ActiveRecord::Base.connection.execute(query)
+    end
   end
 end

--- a/lib/tasks/elibrary/identification_docs_distributions_importer.rb
+++ b/lib/tasks/elibrary/identification_docs_distributions_importer.rb
@@ -1,9 +1,13 @@
 class Elibrary::IdentificationDocsDistributionsImporter
 
   def self.run
+    puts "Importing distributions at species level..."
     import_species_distributions
+    puts "Importing distributions at higher taxa level..."
     import_higher_taxa_distributions
+    puts "Managing exceptions"
     exceptions
+    puts "Refresh materialized views"
     DocumentSearch.refresh_citations_and_documents
   end
 

--- a/lib/tasks/elibrary/identification_docs_distributions_importer.rb
+++ b/lib/tasks/elibrary/identification_docs_distributions_importer.rb
@@ -1,0 +1,39 @@
+class Elibrary::IdentificationDocsDistributionsImporter
+  def self.run
+    sql = <<-SQL
+      WITH doc_taxon_tmp AS (
+  	    SELECT dc.id doc_cit_id, dctc.taxon_concept_id tc_id
+  	    FROM document_citation_taxon_concepts dctc
+  	    JOIN document_citations dc ON dc.id = dctc.document_citation_id
+  	    JOIN api_documents_mview d ON d.id = dc.document_id
+  	    WHERE d.document_type IN ('Document::IdManual', 'Document::VirtualCollege')
+      )
+
+      INSERT INTO "document_citation_geo_entities" (
+        document_citation_id,
+        geo_entity_id,
+        created_at,
+        updated_at
+      )
+
+      SELECT
+        doc_cit_id,
+        UNNEST(ARRAY_AGG(DISTINCT (country_id))) country_id,
+        NOW(),
+        NOW()
+      FROM (
+  	     SELECT doc_cit_id, UNNEST(countries_ids_ary)
+  	     FROM  doc_taxon_tmp tmp
+  	     LEFT OUTER JOIN taxon_concepts_mview tc ON tc_id=tc.id
+         ) AS t(doc_cit_id,country_id)
+      GROUP BY doc_cit_id
+      ORDER BY doc_cit_id DESC;
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    sql = <<-SQL
+      
+    SQL
+  end
+end

--- a/lib/tasks/elibrary/import.rake
+++ b/lib/tasks/elibrary/import.rake
@@ -178,4 +178,11 @@ namespace :elibrary do
       importer.run
     end
   end
+  namespace :identification_distribution do
+    require Rails.root.join('lib/tasks/elibrary/identification_docs_distributions_importer.rb')
+    desc 'Import taxon distributions on Identification documents'
+    task :import => :environment do |task_name|
+      Elibrary::IdentificationDocsDistributionsImporter.run
+    end
+  end
 end


### PR DESCRIPTION
This creates the relation between material docs and location based on the taxon distribution each docs is tagged with.

The distribution for docs tagged at a level higher than Species has been retrieved aggregating the distribution of each child altogether.