### PR TITLE
Beginnings of a solution for the bug

### DIFF
--- a/app/models/checklist/timeline.rb
+++ b/app/models/checklist/timeline.rb
@@ -63,6 +63,43 @@ class Checklist::Timeline
     end
   end
 
+  def resolve_simultaneous_events
+    # Go through each timeline and iterate over each event in a timeline
+    # Where at least two events have the same effective_at date
+      # Check to see if deletions are present
+        # if deletion, set is_current to false for all of them / splice them out of the array
+    # map these changes to new timeline event arrays
+
+    # modified = (@timelines + [self]).flatten.each do |timeline|
+    #   prev_event = nil
+
+    #   timeline.timeline_events.each_with_index do |event, idx|
+    #     next_event = timeline.timeline_events[idx + 1]
+    #     if prev_event &&
+    #       (event.party_id.nil? || event.party_id == prev_event.party_id) &&
+    #       (event.effective_at_formatted == (prev_event.effective_at_formatted || next_event.effective_at_formatted))
+    #       # event.is_current = false
+    #       if !prev_event.is_deletion? && event.is_deletion?
+    #         timeline.timeline_events.slice!(idx)
+    #       end
+    #     end
+    #     prev_event = event
+    #   end
+    # end
+    # p modified
+    # modified
+    original = (@timelines + [self]).flatten.each { |timeline|
+      filtered = timeline.timeline_events.group_by(&:effective_at_formatted).each { |_, values|
+        values.reject!(&:is_deletion?) if values.length > 1
+        # timeline.timeline_events = filtered.values.flatten
+      }
+      # timeline.timeline_events = filtered.values.flatten
+      # p timeline.timeline_events
+    }
+    p original
+    original
+  end
+
   def add_intervals
     (@timelines + [self]).flatten.each do |timeline|
       timeline.timeline_events.each_with_index do |event, idx|

--- a/app/models/checklist/timelines_for_taxon_concept.rb
+++ b/app/models/checklist/timelines_for_taxon_concept.rb
@@ -46,6 +46,7 @@ class Checklist::TimelinesForTaxonConcept
       @raw_timelines[species_listing_name].add_event(timeline_event)
     end
     @raw_timelines.values.each do |t|
+      t.resolve_simultaneous_events
       t.change_consecutive_additions_to_amendments
       t.add_intervals
       @has_reservations = true if t.has_nested_timelines


### PR DESCRIPTION
This is hopefully a promising route towards a solution, however the underlying issue isn't solved and this just aims to filter out the errors produced as the bug only seems to cause visible front-end problems in a minority of cases. 

The method aims to group each timeline event by the `effective_at_formatted` value, looks at the value to evaluate whether multiple events share the same date, and if so, filter out any deletions for that date.

At the moment, the main obstacle is trying to get the changes to `@timeline_events` for each timeline  made permanent, but it doesn't save the edited array to the timeline. 