### PR TITLE
Eu opinions srg history field

### DIFF
--- a/app/controllers/admin/eu_decision_types_controller.rb
+++ b/app/controllers/admin/eu_decision_types_controller.rb
@@ -8,12 +8,6 @@ class Admin::EuDecisionTypesController < Admin::StandardAuthorizationController
     end
   end
 
-  def create
-    create! do |failure|
-      failure.js { render 'new' }
-    end
-  end
-
   protected
 
   def collection

--- a/app/controllers/admin/eu_opinions_controller.rb
+++ b/app/controllers/admin/eu_opinions_controller.rb
@@ -40,6 +40,7 @@ class Admin::EuOpinionsController < Admin::StandardAuthorizationController
     @geo_entities = GeoEntity.order(:name_en).joins(:geo_entity_type).
       where(:geo_entity_types => { :name => GeoEntityType::SETS[GeoEntityType::DEFAULT_SET] })
     @eu_decision_types = EuDecisionType.opinions
+    @srg_histories = SrgHistory.order(:name)
     @ec_srgs = Event.where("type = 'EcSrg' OR
       type = 'EuRegulation' AND name IN ('No 338/97', 'No 938/97', 'No 750/2013')"
     ).order("effective_at DESC")

--- a/app/controllers/admin/srg_histories_controller.rb
+++ b/app/controllers/admin/srg_histories_controller.rb
@@ -1,0 +1,23 @@
+class Admin::SrgHistoriesController < Admin::StandardAuthorizationController
+
+  def index
+    index! do |format|
+      format.json {
+        render :json => SrgHistory.all.to_json
+      }
+    end
+  end
+
+  def create
+    create! do |failure|
+      failure.js { render 'new' }
+    end
+  end
+
+  protected
+
+  def collection
+    @srg_histories ||= end_of_association_chain.page(params[:page]).
+      order('UPPER(name) ASC')
+  end
+end

--- a/app/controllers/admin/srg_histories_controller.rb
+++ b/app/controllers/admin/srg_histories_controller.rb
@@ -1,19 +1,4 @@
 class Admin::SrgHistoriesController < Admin::StandardAuthorizationController
-
-  def index
-    index! do |format|
-      format.json {
-        render :json => SrgHistory.all.to_json
-      }
-    end
-  end
-
-  def create
-    create! do |failure|
-      failure.js { render 'new' }
-    end
-  end
-
   protected
 
   def collection

--- a/app/models/eu_decision.rb
+++ b/app/models/eu_decision.rb
@@ -34,12 +34,13 @@ class EuDecision < ActiveRecord::Base
     :is_current, :notes, :start_date, :start_event_id, :eu_decision_type_id,
     :taxon_concept_id, :type, :conditions_apply, :term_id, :source_id,
     :nomenclature_note_en, :nomenclature_note_es, :nomenclature_note_fr,
-    :created_by_id, :updated_by_id
+    :created_by_id, :updated_by_id, :srg_history_id
 
   belongs_to :taxon_concept
   belongs_to :m_taxon_concept, :foreign_key => :taxon_concept_id
   belongs_to :geo_entity
   belongs_to :eu_decision_type
+  belongs_to :srg_history
   belongs_to :source, :class_name => 'TradeCode'
   belongs_to :term, :class_name => 'TradeCode'
   belongs_to :start_event, :class_name => 'Event'

--- a/app/models/eu_decision_type.rb
+++ b/app/models/eu_decision_type.rb
@@ -14,7 +14,7 @@ class EuDecisionType < ActiveRecord::Base
   attr_accessible :name, :tooltip, :decision_type
   include Dictionary
   build_dictionary :negative_opinion, :positive_opinion, :no_opinion,
-    :suspension
+    :suspension, :srg_referral
 
   scope :opinions, where('decision_type <> ?', EuDecisionType::SUSPENSION).
     order('UPPER(name) ASC')

--- a/app/models/srg_history.rb
+++ b/app/models/srg_history.rb
@@ -1,0 +1,7 @@
+class SrgHistory < ActiveRecord::Base
+  attr_accessible :name, :tooltip
+
+  has_many :eu_decisions
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/serializers/species/eu_decision_serializer.rb
+++ b/app/serializers/species/eu_decision_serializer.rb
@@ -3,6 +3,7 @@ class Species::EuDecisionSerializer < ActiveModel::Serializer
     :is_current, :subspecies_info, :nomenclature_note_en, :nomenclature_note_fr,
     :nomenclature_note_es,
     :eu_decision_type,
+    :srg_history,
     :geo_entity,
     :start_event,
     :source,
@@ -11,6 +12,10 @@ class Species::EuDecisionSerializer < ActiveModel::Serializer
 
   def eu_decision_type
     object['eu_decision_type'] && JSON.parse(object['eu_decision_type'])
+  end
+
+  def srg_history
+    object['srg_history'] && JSON.parse(object['srg_history'])
   end
 
   def geo_entity

--- a/app/serializers/species/show_taxon_concept_serializer_cites.rb
+++ b/app/serializers/species/show_taxon_concept_serializer_cites.rb
@@ -124,6 +124,7 @@ class Species::ShowTaxonConceptSerializerCites < Species::ShowTaxonConceptSerial
               eu_decisions.nomenclature_note_fr,
               eu_decisions.nomenclature_note_es,
               eu_decision_type,
+              srg_history,
               start_event,
               end_event,
               geo_entity_en,

--- a/app/views/admin/eu_opinions/_current_opinions_form.html.erb
+++ b/app/views/admin/eu_opinions/_current_opinions_form.html.erb
@@ -5,6 +5,7 @@
       <th>Regulation</th>
       <th>Country or Territory</th>
       <th>Type</th>
+      <th>SRG history</th>
       <th>Term</th>
       <th>Source</th>
       <th>Notes</th>
@@ -24,6 +25,13 @@
           <%= opinion.eu_decision_type.name %>
           <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
             eu_decision_type.tooltip.present? %>
+        </td>
+        <td>
+          <% if opinion.srg_history %>
+            <%= opinion.srg_history.name %>
+            <%= '(' + opinion.srg_history.tooltip + ')' if opinion.
+              srg_history.tooltip.present? %>
+          <% end %>
         </td>
         <td><%= opinion.term && opinion.term.code %></td>
         <td><%= opinion.source && opinion.source.code %></td>

--- a/app/views/admin/eu_opinions/_form.html.erb
+++ b/app/views/admin/eu_opinions/_form.html.erb
@@ -59,6 +59,18 @@
   </div>
 
   <div class="control-group">
+    <%= f.label :srg_history_id, "SRG History", :class => 'control-label' %>
+    <div class="controls">
+      <%= f.select :srg_history_id,
+        options_from_collection_for_select(@srg_histories,
+          :id, :name, @eu_opinion.srg_history_id),
+        { :include_blank => true },
+        {:class => 'eu_opinion', :style => 'width: 220px' }
+      %>
+    </div>
+  </div>
+
+  <div class="control-group">
     <label class="control-label">Notes</label>
     <div class="controls">
       <%= f.text_area :notes, :class => 'eu_opinion', :value => @eu_opinion.notes %>

--- a/app/views/admin/eu_opinions/_form.html.erb
+++ b/app/views/admin/eu_opinions/_form.html.erb
@@ -65,7 +65,7 @@
         options_from_collection_for_select(@srg_histories,
           :id, :name, @eu_opinion.srg_history_id),
         { :include_blank => true },
-        {:class => 'eu_opinion', :style => 'width: 220px' }
+        {:class => 'eu_opinion select2', :style => 'width: 220px' }
       %>
     </div>
   </div>

--- a/app/views/admin/eu_opinions/_list.html.erb
+++ b/app/views/admin/eu_opinions/_list.html.erb
@@ -23,9 +23,11 @@
           eu_decision_type.tooltip.present? %>
       </td>
       <td>
-        <%= opinion.srg_history.try(:name) %>
-        <%= '(' + opinion.srg_history.tooltip + ')' if opinion.
-          srg_history.try(:tooltip).present? %>
+        <% if opinion.srg_history %>
+          <%= opinion.srg_history.name %>
+          <%= '(' + opinion.srg_history.tooltip + ')' if opinion.
+            srg_history.tooltip.present? %>
+        <% end %>
       </td>
       <td><%= opinion.term && opinion.term.code %></td>
       <td><%= opinion.source && opinion.source.code %></td>

--- a/app/views/admin/eu_opinions/_list.html.erb
+++ b/app/views/admin/eu_opinions/_list.html.erb
@@ -3,6 +3,7 @@
   <th>Regulation</th>
   <th>Country or Territory</th>
   <th>Type</th>
+  <th>SRG history</th>
   <th>Term</th>
   <th>Source</th>
   <th>Notes</th>
@@ -20,6 +21,11 @@
         <%= opinion.eu_decision_type.name %>
         <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
           eu_decision_type.tooltip.present? %>
+      </td>
+      <td>
+        <%= opinion.srg_history.try(:name) %>
+        <%= '(' + opinion.srg_history.tooltip + ')' if opinion.
+          srg_history.try(:tooltip).present? %>
       </td>
       <td><%= opinion.term && opinion.term.code %></td>
       <td><%= opinion.source && opinion.source.code %></td>

--- a/app/views/admin/srg_histories/_form.html.erb
+++ b/app/views/admin/srg_histories/_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_for :srg_history, :url => collection_url, :remote => true do |f| %>
+
+  <%= error_messages_for(@srg_history) %>
+
+  <label>Name</label><%= f.text_field :name %><br />
+  <label>Tooltip</label><%= f.text_field :tooltip %><br />
+<% end %>

--- a/app/views/admin/srg_histories/_list.html.erb
+++ b/app/views/admin/srg_histories/_list.html.erb
@@ -1,0 +1,30 @@
+<thead>
+  <th>Name</th>
+  <th>Tooltip</th>
+  <th width="10%">Actions</th>
+</thead>
+<tbody>
+
+  <% collection.each do |srg_history| -%>
+    <tr>
+      <td>
+        <a href="#" class="editable editable-click editable-required" data-type="text" data-resource="srg_history" data-name="name"
+          data-placeholder="Required" data-original-title="Enter the decision type name"
+          data-url="<%= resource_url(srg_history) %>" data-pk="<%= srg_history.id %>">
+          <%= srg_history.name %>
+        </a>
+      </td>
+      <td>
+        <a href="#" class="editable editable-click editable-required" data-type="text" data-resource="srg_history" data-name="tooltip"
+          data-placeholder="Required" data-original-title="Enter the decision type tooltip"
+          data-url="<%= resource_url(srg_history) %>" data-pk="<%= srg_history.id %>">
+          <%= srg_history.tooltip %>
+        </a>
+      </td>
+      <td>
+        <%= link_to delete_icon, resource_url(srg_history), :confirm => "Warning: you are about to delete data. Are you sure?", :method => :delete %>
+      </td>
+    </tr>
+  <% end -%>
+
+</tbody>

--- a/app/views/shared/_topbar.html.erb
+++ b/app/views/shared/_topbar.html.erb
@@ -56,6 +56,9 @@
               <li class="<%= if controller_name == 'eu_decision_types' then 'active' end%>">
                 <%= link_to 'EU decision types', admin_eu_decision_types_path %>
               </li>
+              <li class="<%= if controller_name == 'srg_histories' then 'active' end%>">
+                <%= link_to 'Srg Histories', admin_srg_histories_path %>
+              </li>
               <li class="<%= if controller_name == 'languages' then 'active' end%>">
                 <%= link_to 'Languages', admin_languages_path %>
               </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ SAPI::Application.routes.draw do
     resources :ranks, :only => [:index, :create, :update, :destroy]
     resources :tags, :only => [:index, :create, :update, :destroy]
     resources :eu_decision_types, :only => [:index, :create, :update, :destroy]
+    resources :srg_histories, only: [:index, :create, :update, :destroy]
     resources :events do
       resource :document_batch, :only => [:new, :create]
       resources :documents, :only => [:index, :edit, :update, :destroy] do

--- a/db/migrate/20200513105319_create_srg_histories.rb
+++ b/db/migrate/20200513105319_create_srg_histories.rb
@@ -9,6 +9,12 @@ class CreateSrgHistories < ActiveRecord::Migration
 
     add_column :eu_decisions, :srg_history_id, :integer
     add_foreign_key :eu_decisions, :srg_histories, name: 'eu_decisions_srg_history_id_fk'
+
+    execute(<<-SQL
+      INSERT INTO srg_histories(name, tooltip, created_at, updated_at)
+      VALUES ('In consultation', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), ('Discussed at SRG (no decision taken)', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    SQL
+    )
   end
 
   def down

--- a/db/migrate/20200513105319_create_srg_histories.rb
+++ b/db/migrate/20200513105319_create_srg_histories.rb
@@ -12,7 +12,7 @@ class CreateSrgHistories < ActiveRecord::Migration
 
     execute(<<-SQL
       INSERT INTO srg_histories(name, tooltip, created_at, updated_at)
-      VALUES ('In consultation', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), ('Discussed at SRG (no decision taken)', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      VALUES ('In consultation', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP), ('Discussed at SRG', 'no decision taken', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
     SQL
     )
   end

--- a/db/migrate/20200513105319_create_srg_histories.rb
+++ b/db/migrate/20200513105319_create_srg_histories.rb
@@ -1,0 +1,19 @@
+class CreateSrgHistories < ActiveRecord::Migration
+  def up
+    create_table :srg_histories do |t|
+      t.string :name
+      t.string :tooltip
+
+      t.timestamps
+    end
+
+    add_column :eu_decisions, :srg_history_id, :integer
+    add_foreign_key :eu_decisions, :srg_histories, name: 'eu_decisions_srg_history_id_fk'
+  end
+
+  def down
+    remove_foreign_key :eu_decisions, name: 'eu_decisions_srg_history_id_fk'
+    remove_column :eu_decisions, :srg_history_id
+    drop_table :srg_histories
+  end
+end

--- a/db/migrate/20200514150717_add_srg_history_to_eu_decisions_view.rb
+++ b/db/migrate/20200514150717_add_srg_history_to_eu_decisions_view.rb
@@ -1,0 +1,27 @@
+class AddSrgHistoryToEuDecisionsView < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TYPE api_srg_history AS (
+        name TEXT,
+        description TEXT
+      );
+    SQL
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20200514150717', 'api_eu_decisions_view')}"
+
+    execute "DROP VIEW IF EXISTS eu_decisions_view"
+    execute "CREATE VIEW eu_decisions_view AS #{view_sql('20200514150717', 'eu_decisions_view')}"
+  end
+
+  def down
+    execute "DROP VIEW IF EXISTS api_eu_decisions_view"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20150210140508', 'api_eu_decisions_view')}"
+
+    execute "DROP VIEW IF EXISTS eu_decisions_view"
+    execute "CREATE VIEW eu_decisions_view AS #{view_sql('20150210140508', 'eu_decisions_view')}"
+
+    execute <<-SQL
+      DROP TYPE api_srg_history
+    SQL
+  end
+end

--- a/db/migrate/20200514150717_add_srg_history_to_eu_decisions_view.rb
+++ b/db/migrate/20200514150717_add_srg_history_to_eu_decisions_view.rb
@@ -15,7 +15,7 @@ class AddSrgHistoryToEuDecisionsView < ActiveRecord::Migration
 
   def down
     execute "DROP VIEW IF EXISTS api_eu_decisions_view"
-    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20150210140508', 'api_eu_decisions_view')}"
+    execute "CREATE VIEW api_eu_decisions_view AS #{view_sql('20150126161813', 'api_eu_decisions_view')}"
 
     execute "DROP VIEW IF EXISTS eu_decisions_view"
     execute "CREATE VIEW eu_decisions_view AS #{view_sql('20150210140508', 'eu_decisions_view')}"

--- a/db/views/api_eu_decisions_view/20200514150717.sql
+++ b/db/views/api_eu_decisions_view/20200514150717.sql
@@ -1,0 +1,136 @@
+SELECT
+eu_decisions.id,
+eu_decisions.type,
+eu_decisions.taxon_concept_id,
+ROW_TO_JSON(
+ ROW(
+   taxon_concept_id,
+   taxon_concepts.full_name,
+   taxon_concepts.author_year,
+   taxon_concepts.data->'rank_name'
+ )::api_taxon_concept
+) AS taxon_concept,
+eu_decisions.notes,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.start_date::DATE
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN start_event.effective_at::DATE
+END AS start_date,
+CASE
+  WHEN eu_decisions.type = 'EuOpinion'
+  THEN eu_decisions.is_current
+  WHEN eu_decisions.type = 'EuSuspension'
+  THEN
+    CASE
+      WHEN start_event.effective_at <= current_date AND start_event.is_current = true
+        AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+      THEN TRUE
+      ELSE
+        FALSE
+    END
+END AS is_current,
+eu_decisions.geo_entity_id,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_en,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_en,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_es,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_es,
+ROW_TO_JSON(
+  ROW(
+    geo_entities.iso_code2,
+    geo_entities.name_fr,
+    geo_entity_types.name
+  )::api_geo_entity
+) AS geo_entity_fr,
+eu_decisions.start_event_id,
+ROW_TO_JSON(
+  ROW(
+    start_event.name || CASE WHEN start_event.type = 'EcSrg' THEN ' Soc' ELSE '' END,
+    start_event.effective_at::DATE,
+    start_event.url
+  )::api_event
+) AS start_event,
+eu_decisions.end_event_id,
+ROW_TO_JSON(
+  ROW(
+    end_event.name,
+    end_event.effective_at::DATE,
+    end_event.url
+  )::api_event
+) AS end_event,
+eu_decisions.term_id,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_en
+  )::api_trade_code
+) AS term_en,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_es
+  )::api_trade_code
+) AS term_es,
+ROW_TO_JSON(
+  ROW(
+    terms.code,
+    terms.name_fr
+  )::api_trade_code
+) AS term_fr,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_en
+  )::api_trade_code
+) AS source_en,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_es
+  )::api_trade_code
+) AS source_es,
+ROW_TO_JSON(
+  ROW(
+    sources.code,
+    sources.name_fr
+  )::api_trade_code
+) AS source_fr,
+eu_decisions.source_id,
+eu_decisions.eu_decision_type_id,
+ROW_TO_JSON(
+  ROW(
+    eu_decision_types.name,
+    eu_decision_types.tooltip,
+    eu_decision_types.decision_type
+  )::api_eu_decision_type
+) AS eu_decision_type,
+eu_decisions.srg_history_id,
+ROW_TO_JSON(
+  ROW(
+    srg_histories.name,
+    srg_histories.tooltip
+  )::api_srg_history
+) AS srg_history,
+eu_decisions.nomenclature_note_en,
+eu_decisions.nomenclature_note_fr,
+eu_decisions.nomenclature_note_es
+FROM eu_decisions
+JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+JOIN geo_entity_types ON geo_entities.geo_entity_type_id = geo_entity_types.id
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN trade_codes terms ON terms.id = eu_decisions.term_id AND terms.type = 'Term'
+LEFT JOIN trade_codes sources ON sources.id = eu_decisions.source_id AND sources.type = 'Source'
+LEFT JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id
+LEFT JOIN srg_histories ON srg_histories.id = eu_decisions.srg_history_id;

--- a/db/views/eu_decisions_view/20200514150717.sql
+++ b/db/views/eu_decisions_view/20200514150717.sql
@@ -1,0 +1,86 @@
+SELECT
+  taxon_concept_id,
+  taxon_concepts.taxonomic_position,
+  (taxon_concepts.data->'kingdom_id')::INT AS kingdom_id,
+  (taxon_concepts.data->'phylum_id')::INT AS phylum_id,
+  (taxon_concepts.data->'class_id')::INT AS class_id,
+  (taxon_concepts.data->'order_id')::INT AS order_id,
+  (taxon_concepts.data->'family_id')::INT AS family_id,
+  taxon_concepts.data->'kingdom_name' AS kingdom_name,
+  taxon_concepts.data->'phylum_name' AS phylum_name,
+  taxon_concepts.data->'class_name' AS class_name,
+  taxon_concepts.data->'order_name' AS order_name,
+  taxon_concepts.data->'family_name' AS family_name,
+  taxon_concepts.data->'genus_name' AS genus_name,
+  LOWER(taxon_concepts.data->'species_name') AS species_name,
+  LOWER(taxon_concepts.data->'subspecies_name') AS subspecies_name,
+  taxon_concepts.full_name AS full_name,
+  taxon_concepts.data->'rank_name' AS rank_name,
+  eu_decisions.start_date,
+  TO_CHAR(eu_decisions.start_date, 'DD/MM/YYYY') AS start_date_formatted,
+  t.original_start_date,
+  TO_CHAR(t.original_start_date, 'DD/MM/YYYY') AS original_start_date_formatted,
+  geo_entity_id,
+  geo_entities.name_en AS party,
+  CASE
+    WHEN eu_decision_types.name ~* '^i+\)'
+    THEN '(No opinion) ' || eu_decision_types.name
+    ELSE eu_decision_types.name
+  END AS decision_type_for_display,
+  eu_decision_types.decision_type AS decision_type,
+  srg_histories.name AS srg_history,
+  sources.name_en AS source_name,
+  sources.code || ' - ' || sources.name_en AS source_code_and_name,
+  terms.name_en AS term_name,
+  eu_decisions.notes,
+  start_event.name AS start_event_name,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN TRUE
+    ELSE FALSE
+  END AS is_valid,
+  CASE
+    WHEN (
+      eu_decisions.type = 'EuOpinion' AND eu_decisions.is_current
+    )
+    OR (
+      eu_decisions.type = 'EuSuspension'
+      AND start_event.effective_at < current_date
+      AND start_event.is_current = true
+      AND (eu_decisions.end_event_id IS NULL OR end_event.effective_at > current_date)
+    )
+    THEN 'Valid'
+    ELSE 'Not Valid'
+  END AS is_valid_for_display,
+  CASE
+    WHEN eu_decisions.type = 'EuOpinion'
+      THEN eu_decisions.start_date
+    WHEN eu_decisions.type = 'EuSuspension'
+      THEN start_event.effective_at
+  END AS ordering_date,
+  CASE
+    WHEN LENGTH(eu_decisions.notes) > 0 THEN strip_tags(eu_decisions.notes)
+    ELSE ''
+  END
+  || CASE
+    WHEN LENGTH(eu_decisions.nomenclature_note_en) > 0 THEN E'\n' || strip_tags(eu_decisions.nomenclature_note_en)
+    ELSE ''
+  END AS full_note_en
+FROM eu_decisions
+LEFT JOIN eu_decision_types ON eu_decision_types.id = eu_decisions.eu_decision_type_id -- Eu Decision Type can be empty now
+JOIN taxon_concepts ON taxon_concepts.id = eu_decisions.taxon_concept_id
+LEFT JOIN srg_histories ON srg_histories.id = eu_decisions.srg_history_id
+LEFT JOIN events AS start_event ON start_event.id = eu_decisions.start_event_id
+LEFT JOIN events AS end_event ON end_event.id = eu_decisions.end_event_id
+LEFT JOIN geo_entities ON geo_entities.id = eu_decisions.geo_entity_id
+LEFT JOIN trade_codes sources ON sources.type = 'Source' AND sources.id = eu_decisions.source_id
+LEFT JOIN trade_codes terms ON terms.type = 'Term' AND terms.id = eu_decisions.term_id
+LEFT JOIN eu_suspensions_applicability_view t ON t.id = eu_decisions.id;

--- a/lib/tasks/import_eu_decisions.rake
+++ b/lib/tasks/import_eu_decisions.rake
@@ -73,7 +73,7 @@ namespace :import do
           AND UPPER(taxon_concepts.legacy_type) = BTRIM(UPPER(q.kingdom))
           AND taxon_concepts.rank_id = ranks.id
         INNER JOIN geo_entities ON UPPER(geo_entities.iso_code2) = BTRIM(UPPER(q.country_iso2))
-        INNER JOIN eu_decision_types ON UPPER(eu_decision_types.name) = BTRIM(UPPER(q.opinion))
+        INNER JOIN eu_decision_types ON UPPER(eu_decision_types.name) = BTRIM(UPPER(q.opinion)) -- Eu Decision Type can be empty now. Consider LEFT JOIN if importing other files
         INNER JOIN events ON events.legacy_id = q.event_legacy_id
           AND events.designation_id = #{designation_id}
         LEFT JOIN trade_codes AS sources ON UPPER(sources.code) = BTRIM(UPPER(q.source))

--- a/lib/tasks/import_eu_opinions.rake
+++ b/lib/tasks/import_eu_opinions.rake
@@ -24,7 +24,7 @@ namespace :import do
           FROM #{TMP_TABLE} t
           JOIN taxon_concepts ON taxon_concepts.id = t.taxon_concept_id
           JOIN events ON events.name = t.start_event_name
-          JOIN eu_decision_types ON t.opinion_name = eu_decision_types.name
+          JOIN eu_decision_types ON t.opinion_name = eu_decision_types.name -- Eu Decision Type can be empty now. Consider LEFT JOIN if importing other files
           JOIN geo_entities ON SQUISH_NULL(t.country_name) = geo_entities.name_en
           LEFT JOIN trade_codes terms on t.term_code = terms.code
           LEFT JOIN trade_codes sources on t.source_code = sources.code

--- a/lib/tasks/set_eu_opinions_to_not_current.rake
+++ b/lib/tasks/set_eu_opinions_to_not_current.rake
@@ -16,7 +16,7 @@ task :set_eu_opinions_to_not_current => :environment do
         sources.id AS source_id
       FROM #{TMP_TABLE} t
       JOIN events ON events.name = t.start_regulation_name
-      JOIN eu_decision_types ON t.opinion_name = eu_decision_types.name
+      JOIN eu_decision_types ON t.opinion_name = eu_decision_types.name -- Eu Decision Type can be empty now. Consider LEFT JOIN if importing other files
       JOIN geo_entities ON SQUISH_NULL(t.country_name) = geo_entities.name_en
       LEFT JOIN trade_codes terms on t.term_code = terms.code
       LEFT JOIN trade_codes sources on t.source_code = sources.code

--- a/spec/controllers/admin/eu_opinions_controller_spec.rb
+++ b/spec/controllers/admin/eu_opinions_controller_spec.rb
@@ -9,24 +9,24 @@ describe Admin::EuOpinionsController do
 
   describe "GET index" do
     it "renders the index template" do
-      get :index, :taxon_concept_id => @taxon_concept.id
+      get :index, taxon_concept_id: @taxon_concept.id
       response.should render_template("index")
     end
     it "renders the taxon_concepts_layout" do
-      get :index, :taxon_concept_id => @taxon_concept.id
+      get :index, taxon_concept_id: @taxon_concept.id
       response.should render_template('layouts/taxon_concepts')
     end
   end
 
   describe "GET new" do
     it "renders the new template" do
-      get :new, :taxon_concept_id => @taxon_concept.id
+      get :new, taxon_concept_id: @taxon_concept.id
       response.should render_template('new')
     end
     it "assigns @geo_entities (country and territory) with two objects" do
-      territory = create(:geo_entity, :geo_entity_type_id => territory_geo_entity_type.id)
-      country = create(:geo_entity)
-      get :new, :taxon_concept_id => @taxon_concept.id
+      create(:geo_entity, :geo_entity_type_id => territory_geo_entity_type.id)
+      create(:geo_entity)
+      get :new, taxon_concept_id: @taxon_concept.id
       assigns(:geo_entities).size.should == 2
     end
   end
@@ -35,25 +35,27 @@ describe Admin::EuOpinionsController do
     context "when successful" do
       before do
         @eu_decision_type = create(:eu_decision_type)
+        @srg_history = create(:srg_history)
       end
       it "redirects to the EU Opinions index" do
         post :create,
-          :eu_opinion => {
-            :eu_decision_type_id => @eu_decision_type.id,
-            :start_date => Date.today,
-            :geo_entity_id => create(
-              :geo_entity, :geo_entity_type_id => country_geo_entity_type.id
+          eu_opinion: {
+            eu_decision_type_id: @eu_decision_type.id,
+            srg_history_id: @srg_history.id,
+            start_date: Date.today,
+            geo_entity_id: create(
+              :geo_entity, geo_entity_type_id: country_geo_entity_type.id
             )
           },
-          :taxon_concept_id => @taxon_concept.id
+          taxon_concept_id: @taxon_concept.id
         response.should redirect_to(admin_taxon_concept_eu_opinions_url(@taxon_concept.id))
       end
     end
 
     context "when not successful" do
       it "renders new" do
-        post :create, :eu_opinion => {},
-          :taxon_concept_id => @taxon_concept.id
+        post :create, eu_opinion: {},
+          taxon_concept_id: @taxon_concept.id
         response.should render_template("new")
       end
     end
@@ -63,16 +65,16 @@ describe Admin::EuOpinionsController do
     before(:each) do
       @eu_opinion = create(
         :eu_opinion,
-        :taxon_concept_id => @taxon_concept.id
+        taxon_concept_id: @taxon_concept.id
       )
     end
     it "renders the edit template" do
-      get :edit, :id => @eu_opinion.id, :taxon_concept_id => @taxon_concept.id
+      get :edit, id: @eu_opinion.id, taxon_concept_id: @taxon_concept.id
       response.should render_template('edit')
     end
     it "assigns @geo_entities" do
-      territory = create(:geo_entity, :geo_entity_type_id => territory_geo_entity_type.id)
-      get :edit, :id => @eu_opinion.id, :taxon_concept_id => @taxon_concept.id
+      territory = create(:geo_entity, geo_entity_type_id: territory_geo_entity_type.id)
+      get :edit, id: @eu_opinion.id, taxon_concept_id: @taxon_concept.id
       assigns(:geo_entities).should include(territory)
     end
   end
@@ -81,7 +83,7 @@ describe Admin::EuOpinionsController do
     before(:each) do
       @eu_opinion = create(
         :eu_opinion,
-        :taxon_concept_id => @taxon_concept.id
+        taxon_concept_id: @taxon_concept.id
       )
       @eu_decision_type = create(:eu_decision_type)
     end
@@ -89,11 +91,11 @@ describe Admin::EuOpinionsController do
     context "when successful" do
       it "renders taxon_concepts EU Opinions page" do
         put :update,
-          :eu_opinion => {
-            :eu_decision_type_id => @eu_decision_type.id
+          eu_opinion: {
+            eu_decision_type_id: @eu_decision_type.id
           },
-          :id => @eu_opinion.id,
-          :taxon_concept_id => @taxon_concept.id
+          id: @eu_opinion.id,
+          taxon_concept_id: @taxon_concept.id
         response.should redirect_to(
           admin_taxon_concept_eu_opinions_url(@taxon_concept)
         )
@@ -103,11 +105,11 @@ describe Admin::EuOpinionsController do
     context "when not successful" do
       it "renders new" do
         put :update,
-          :eu_opinion => {
-            :eu_decision_type_id => nil
+          eu_opinion: {
+            eu_decision_type_id: nil
           },
-          :id => @eu_opinion.id,
-          :taxon_concept_id => @taxon_concept.id
+          id: @eu_opinion.id,
+          taxon_concept_id: @taxon_concept.id
         response.should render_template('new')
       end
     end
@@ -117,12 +119,12 @@ describe Admin::EuOpinionsController do
     before(:each) do
       @eu_opinion = create(
         :eu_opinion,
-        :taxon_concept_id => @taxon_concept.id
+        taxon_concept_id: @taxon_concept.id
       )
     end
     it "redirects after delete" do
-      delete :destroy, :id => @eu_opinion.id,
-        :taxon_concept_id => @taxon_concept.id
+      delete :destroy, id: @eu_opinion.id,
+        taxon_concept_id: @taxon_concept.id
       response.should redirect_to(
         admin_taxon_concept_eu_opinions_url(@taxon_concept)
       )

--- a/spec/controllers/admin/srg_histories_controller_spec.rb
+++ b/spec/controllers/admin/srg_histories_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Admin::SrgHistoriesController do
+  login_admin
+
+  describe "GET index" do
+    it "renders the index template" do
+      get :index
+      response.should render_template("index")
+    end
+  end
+
+  describe "POST create" do
+    context "when successful" do
+      before do
+        @srg_history = create(:srg_history)
+      end
+
+      it "renders the create js template" do
+        post :create, srg_history: { name: 'test' }, format: :js
+
+        response.should render_template("create")
+      end
+    end
+
+    context "when not successful" do
+      it "renders new" do
+        post :create, srg_history: {}, format: :js
+
+        response.should render_template("new")
+      end
+    end
+  end
+
+  describe "PUT update" do
+    before(:each) do
+      @srg_history = create(:srg_history)
+    end
+
+    context "when successful" do
+      it "renders the create js template" do
+        put :update, id: @srg_history.id, format: :js
+
+        response.should render_template("create")
+      end
+    end
+
+    context "when not successful" do
+      it "renders new" do
+        put :update,
+          srg_history: { name: nil },
+          id: @srg_history.id,
+          format: :js
+
+        response.should render_template('new')
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    before(:each) do
+      @srg_history = create(:srg_history)
+    end
+
+    it "redirects after delete" do
+      delete :destroy, id: @srg_history.id
+
+      response.should redirect_to(admin_srg_histories_url)
+    end
+  end
+end

--- a/spec/factories/srg_history.rb
+++ b/spec/factories/srg_history.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :srg_history do
+    sequence(:name) { |n| "srg_history#{n}" }
+    tooltip 'asdfasdf'
+  end
+end


### PR DESCRIPTION
## Description

Initial implementation related to adding the new SRG History field.
It currently adds:

* New srg_histories database table with `name` and `tooltip`
* Ability to add/edit/destroy SRG histories from the admin interface
* Ability to select an SRG history from a dropdown in the EU Opinions form
* Add SRG Referral decision type

## Notes
Migrate needed