### PR TITLE
Remove validation on eu decision type field

### DIFF
--- a/app/assets/javascripts/admin/taxon_concept.js.coffee
+++ b/app/assets/javascripts/admin/taxon_concept.js.coffee
@@ -8,7 +8,7 @@ $(document).ready ->
   $('.select2').select2({
     placeholder: "Choose an option",
     allowClear: true
-    })
+  })
 
   $(".datepicker").datepicker(
     format: "dd/mm/yyyy",

--- a/app/assets/javascripts/admin/taxon_concept.js.coffee
+++ b/app/assets/javascripts/admin/taxon_concept.js.coffee
@@ -5,7 +5,10 @@ $(document).ready ->
     .focus(-> $(@).animate(height: "15em", 500))
     .blur(-> $(@).animate(height: "4em", 500))
 
-  $('.select2').select2()
+  $('.select2').select2({
+    placeholder: "Choose an option",
+    allowClear: true
+    })
 
   $(".datepicker").datepicker(
     format: "dd/mm/yyyy",

--- a/app/models/eu_decision.rb
+++ b/app/models/eu_decision.rb
@@ -49,7 +49,6 @@ class EuDecision < ActiveRecord::Base
 
   validates :taxon_concept, presence: true
   validates :geo_entity, presence: true
-  validates :eu_decision_type, presence: true
 
   translates :nomenclature_note
 

--- a/app/views/admin/eu_opinions/_current_opinions_form.html.erb
+++ b/app/views/admin/eu_opinions/_current_opinions_form.html.erb
@@ -21,9 +21,11 @@
         <td><%= opinion.start_event && opinion.start_event.name %></td>
         <td><%= opinion.geo_entity && opinion.geo_entity.name_en %></td>
         <td>
-          <%= opinion.eu_decision_type.name %>
-          <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
-            eu_decision_type.tooltip.present? %>
+          <% if opinion.eu_decision_type %>
+            <%= opinion.eu_decision_type.name %>
+            <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
+              eu_decision_type.tooltip.present? %>
+          <% end %>
         </td>
         <td><%= opinion.term && opinion.term.code %></td>
         <td><%= opinion.source && opinion.source.code %></td>

--- a/app/views/admin/eu_opinions/_form.html.erb
+++ b/app/views/admin/eu_opinions/_form.html.erb
@@ -32,7 +32,7 @@
           :name_en,
           @eu_opinion.geo_entity_id
       ),
-        { :include_blank => true },
+        { },
         {:class => 'eu_opinion select2', :style => 'width: 220px' }
       %>
     </div>

--- a/app/views/admin/eu_opinions/_list.html.erb
+++ b/app/views/admin/eu_opinions/_list.html.erb
@@ -17,9 +17,11 @@
       <td><%= opinion.start_event.try(:name) %></td>
       <td><%= opinion.geo_entity && opinion.geo_entity.name_en %></td>
       <td>
-        <%= opinion.eu_decision_type.name %>
-        <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
-          eu_decision_type.tooltip.present? %>
+        <% if opinion.eu_decision_type %>
+          <%= opinion.eu_decision_type.try(:name) %>
+          <%= '(' + opinion.eu_decision_type.tooltip + ')' if opinion.
+            eu_decision_type.tooltip.present? %>
+        <% end %>
       </td>
       <td><%= opinion.term && opinion.term.code %></td>
       <td><%= opinion.source && opinion.source.code %></td>
@@ -41,4 +43,3 @@
     </tr>
   <% end -%>
 </tbody>
-

--- a/spec/controllers/admin/eu_opinions_controller_spec.rb
+++ b/spec/controllers/admin/eu_opinions_controller_spec.rb
@@ -87,29 +87,60 @@ describe Admin::EuOpinionsController do
     end
 
     context "when successful" do
-      it "renders taxon_concepts EU Opinions page" do
-        put :update,
-          :eu_opinion => {
-            :eu_decision_type_id => @eu_decision_type.id
-          },
-          :id => @eu_opinion.id,
-          :taxon_concept_id => @taxon_concept.id
-        response.should redirect_to(
-          admin_taxon_concept_eu_opinions_url(@taxon_concept)
-        )
+      context "when eu decision type is present" do
+        it "renders taxon_concepts EU Opinions page" do
+          put :update,
+            :eu_opinion => {
+              :eu_decision_type_id => @eu_decision_type.id
+            },
+            :id => @eu_opinion.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should redirect_to(
+            admin_taxon_concept_eu_opinions_url(@taxon_concept)
+          )
+        end
+      end
+
+      context "when eu decision type is not present" do
+        it "renders taxon_concepts EU Opinions page" do
+          put :update,
+            :eu_opinion => {
+              :eu_decision_type_id => nil
+            },
+            :id => @eu_opinion.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should redirect_to(
+            admin_taxon_concept_eu_opinions_url(@taxon_concept)
+          )
+        end
       end
     end
 
     context "when not successful" do
-      it "renders new" do
-        put :update,
-          :eu_opinion => {
-            :eu_decision_type_id => nil
-          },
-          :id => @eu_opinion.id,
-          :taxon_concept_id => @taxon_concept.id
-        get :new, :taxon_concept_id => @taxon_concept.id
-        response.should render_template('new')
+      context "when eu decision type is present" do
+        it "renders new" do
+          put :update,
+            :eu_opinion => {
+              :eu_decision_type_id => @eu_decision_type.id,
+              :start_date => nil
+            },
+            :id => @eu_opinion.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should render_template('new')
+        end
+      end
+
+      context "when eu decision type is not present" do
+        it "renders new" do
+          put :update,
+            :eu_opinion => {
+              :eu_decision_type_id => nil,
+              :start_date => nil
+            },
+            :id => @eu_opinion.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should render_template('new')
+        end
       end
     end
   end

--- a/spec/controllers/admin/eu_opinions_controller_spec.rb
+++ b/spec/controllers/admin/eu_opinions_controller_spec.rb
@@ -108,6 +108,7 @@ describe Admin::EuOpinionsController do
           },
           :id => @eu_opinion.id,
           :taxon_concept_id => @taxon_concept.id
+        get :new, :taxon_concept_id => @taxon_concept.id
         response.should render_template('new')
       end
     end

--- a/spec/controllers/admin/taxon_eu_suspensions_controller_spec.rb
+++ b/spec/controllers/admin/taxon_eu_suspensions_controller_spec.rb
@@ -111,6 +111,7 @@ describe Admin::TaxonEuSuspensionsController do
           },
           :id => @eu_suspension.id,
           :taxon_concept_id => @taxon_concept.id
+        get :new, :taxon_concept_id => @taxon_concept.id
         response.should render_template('new')
       end
     end

--- a/spec/controllers/admin/taxon_eu_suspensions_controller_spec.rb
+++ b/spec/controllers/admin/taxon_eu_suspensions_controller_spec.rb
@@ -83,36 +83,67 @@ describe Admin::TaxonEuSuspensionsController do
         :eu_suspension,
         :taxon_concept_id => @taxon_concept.id
       )
-      @eu_decision_type = create(:eu_decision_type)
     end
 
     context "when successful" do
-      it "renders taxon_concepts EU suspensions page" do
-        put :update,
-          :eu_suspension => {
-            :eu_decision_type_id => @eu_decision_type.id,
-            :geo_entity_id => create(
-              :geo_entity, :geo_entity_type_id => country_geo_entity_type.id
-            )
-          },
-          :id => @eu_suspension.id,
-          :taxon_concept_id => @taxon_concept.id
-        response.should redirect_to(
-          admin_taxon_concept_eu_suspensions_url(@taxon_concept)
-        )
+      context "when eu_decision_type is present" do
+        it "renders taxon_concepts EU suspensions page" do
+          put :update,
+            :eu_suspension => {
+              :eu_decision_type_id => create(:eu_decision_type),
+              :geo_entity_id => create(
+                :geo_entity, :geo_entity_type_id => country_geo_entity_type.id
+              )
+            },
+            :id => @eu_suspension.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should redirect_to(
+            admin_taxon_concept_eu_suspensions_url(@taxon_concept)
+          )
+        end
+      end
+      context "when eu_decision_type is not present" do
+        it "renders taxon_concepts EU suspensions page" do
+          put :update,
+            :eu_suspension => {
+              :eu_decision_type_id => nil,
+              :geo_entity_id => create(
+                :geo_entity, :geo_entity_type_id => country_geo_entity_type.id
+              )
+            },
+            :id => @eu_suspension.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should redirect_to(
+            admin_taxon_concept_eu_suspensions_url(@taxon_concept)
+          )
+        end
       end
     end
 
     context "when not successful" do
-      it "renders new" do
-        put :update,
-          :eu_suspension => {
-            :eu_decision_type_id => nil
-          },
-          :id => @eu_suspension.id,
-          :taxon_concept_id => @taxon_concept.id
-        get :new, :taxon_concept_id => @taxon_concept.id
-        response.should render_template('new')
+      context "when eu_decision_type is present" do
+        it "renders new" do
+          put :update,
+            :eu_suspension => {
+              :eu_decision_type_id => create(:eu_decision_type),
+              :geo_entity_id => nil
+            },
+            :id => @eu_suspension.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should render_template('new')
+        end
+      end
+      context "when eu_decision_type is not present" do
+        it "renders new" do
+          put :update,
+            :eu_suspension => {
+              :eu_decision_type_id => nil,
+              :geo_entity_id => nil
+            },
+            :id => @eu_suspension.id,
+            :taxon_concept_id => @taxon_concept.id
+          response.should render_template('new')
+        end
       end
     end
   end


### PR DESCRIPTION
This allows the creation of EU Opinions without any eu decision type associated.