### PR TITLE
Eu opinions transfer scripts

### DIFF
--- a/lib/tasks/transfer_eu_opinions.rake
+++ b/lib/tasks/transfer_eu_opinions.rake
@@ -1,4 +1,5 @@
 namespace :eu_opinions do
+
   desc "transfer the current eu_opinions with iii) and iii)removed eu_decision type to the new SRG referral decision type"
   task :tranfer_to_srg_referral_type => :environment do
     old_decision_type_ids = EuDecisionType.where(name: ["iii)", "iii) removed"]).pluck(:id)
@@ -20,5 +21,28 @@ namespace :eu_opinions do
     SQL
     res = ActiveRecord::Base.connection.execute update_query
     puts "#{res.cmd_tuples} rows transferred to SRG Referral decision type"
+  end
+
+  desc "transfer the current eu_opinions with ii) and ii)removed eu_decision type to the new SRG History 'In consultation'"
+  task :transfer_to_srg_history => :environment do
+    old_decision_type_ids = EuDecisionType.where(name: ["ii)", "ii) removed"]).pluck(:id)
+    eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
+    srg_history_id = SrgHistory.find_by_name("In consultation").id
+    puts "There are #{eu_opinions.count} eu_opinions to be transferred"
+    update_query = <<-SQL
+      WITH current_eu_opinions_with_ii_type AS (
+        SELECT *
+        FROM eu_decisions
+        WHERE type = 'EuOpinion'
+        AND eu_decision_type_id IN (#{old_decision_type_ids.join(',')})
+        AND is_current = true
+      )
+      UPDATE eu_decisions
+      SET eu_decision_type_id = NULL, srg_history_id = #{srg_history_id}
+      FROM current_eu_opinions_with_ii_type
+      WHERE current_eu_opinions_with_ii_type.id = eu_decisions.id
+    SQL
+    res = ActiveRecord::Base.connection.execute update_query
+    puts "#{res.cmd_tuples} rows transferred to SRG History"
   end
 end

--- a/lib/tasks/transfer_eu_opinions.rake
+++ b/lib/tasks/transfer_eu_opinions.rake
@@ -1,20 +1,34 @@
 namespace :eu_opinions do
-  # Usage:
-  # bundle exec rake eu_opinions:transfer_current_eu_opinions_decision_type['eu_decision_type','SRG Referral','iii)']
-  # bundle exec rake eu_opinions:transfer_current_eu_opinions_decision_type['srg_history','In consultation','ii)']
-  desc "transfer current eu opinions to new decision type/Srg History"
-  task :transfer_current_eu_opinions_decision_type, [:model, :new_type, :old_type] => [:environment] do |t, args|
 
-    old_decision_type_ids = EuDecisionType.where('name ILIKE ?', "#{args[:old_type]}%").pluck(:id)
-    fail "Decision type #{args[:old_type]} not found" if old_decision_type_ids.empty?
+  desc "transfer the current eu_opinions with iii) and iii)removed eu_decision type to the new SRG referral decision type"
+  task :transfer_to_srg_referral_type => :environment do
+    old_decision_type_ids = EuDecisionType.where(name: ["iii)", "iii) removed"]).pluck(:id)
+    fail "Old decision type not found" if old_decision_type_ids.empty?
     eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
     fail "No eu opinions to transfer" if eu_opinions.count.zero?
-    new_decision_type_id = args[:model].camelize.constantize.find_by_name(args[:new_type]).try(:id)
-    fail "Decision type #{args[:new_type]} not found" if new_decision_type_id.nil?
+    new_decision_type_id = EuDecisionType.find_by_name("SRG Referral").try(:id)
+    fail "New decision type not found" if new_decision_type_id.nil?
 
     puts "There are #{eu_opinions.count} eu_opinions to be transferred"
 
-    query = query_builder(new_decision_type_id, args[:model], old_decision_type_ids)
+    query = query_builder(new_decision_type_id, 'eu_decision_type', old_decision_type_ids)
+    res = ActiveRecord::Base.connection.execute query
+
+    puts "#{res.cmd_tuples} rows transferred to new decision type"
+  end
+
+  desc "transfer the current eu_opinions with ii) and ii)removed eu_decision type to the new SRG History 'In consultation'"
+  task :transfer_to_srg_history => :environment do
+    old_decision_type_ids = EuDecisionType.where(name: ["ii)", "ii) removed"]).pluck(:id)
+    fail "Old decision type not found" if old_decision_type_ids.empty?
+    eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
+    fail "No eu opinions to transfer" if eu_opinions.count.zero?
+    srg_history_id = SrgHistory.find_by_name("In consultation").try(:id)
+    fail "New decision type not found" if srg_history_id.nil?
+
+    puts "There are #{eu_opinions.count} eu_opinions to be transferred"
+
+    query = query_builder(srg_history_id, 'srg_history', old_decision_type_ids)
     res = ActiveRecord::Base.connection.execute query
 
     puts "#{res.cmd_tuples} rows transferred to new decision type"
@@ -23,9 +37,9 @@ namespace :eu_opinions do
   def query_builder(new_type, model, old_types)
     set_query =
       if model =~ /history/i
-        "SET eu_decision_type_id = NULL, srg_history_id = #{new_type}"
+        "SET eu_decision_type_id = NULL, srg_history_id = #{new_type}, updated_at = CURRENT_TIMESTAMP"
       else
-        "SET eu_decision_type_id = #{new_type}"
+        "SET eu_decision_type_id = #{new_type}, updated_at = CURRENT_TIMESTAMP"
       end
     <<-SQL
       WITH current_eu_opinions_with_old_type AS (

--- a/lib/tasks/transfer_eu_opinions.rake
+++ b/lib/tasks/transfer_eu_opinions.rake
@@ -1,8 +1,8 @@
 namespace :eu_opinions do
 
-  desc "transfer the current eu_opinions with iii) and iii)removed eu_decision type to the new SRG referral decision type"
+  desc "transfer the current eu_opinions with iii) eu_decision type to the new SRG referral decision type"
   task :transfer_to_srg_referral_type => :environment do
-    old_decision_type_ids = EuDecisionType.where(name: ["iii)", "iii) removed"]).pluck(:id)
+    old_decision_type_ids = EuDecisionType.where(name: "iii)").pluck(:id)
     fail "Old decision type not found" if old_decision_type_ids.empty?
     eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
     fail "No eu opinions to transfer" if eu_opinions.count.zero?
@@ -17,9 +17,9 @@ namespace :eu_opinions do
     puts "#{res.cmd_tuples} rows transferred to new decision type"
   end
 
-  desc "transfer the current eu_opinions with ii) and ii)removed eu_decision type to the new SRG History 'In consultation'"
+  desc "transfer the current eu_opinions with ii) eu_decision type to the new SRG History 'In consultation'"
   task :transfer_to_srg_history => :environment do
-    old_decision_type_ids = EuDecisionType.where(name: ["ii)", "ii) removed"]).pluck(:id)
+    old_decision_type_ids = EuDecisionType.where(name: "ii)").pluck(:id)
     fail "Old decision type not found" if old_decision_type_ids.empty?
     eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
     fail "No eu opinions to transfer" if eu_opinions.count.zero?

--- a/lib/tasks/transfer_eu_opinions.rake
+++ b/lib/tasks/transfer_eu_opinions.rake
@@ -1,0 +1,24 @@
+namespace :eu_opinions do
+  desc "transfer the current eu_opinions with iii) and iii)removed eu_decision type to the new SRG referral decision type"
+  task :tranfer_to_srg_referral_type => :environment do
+    old_decision_type_ids = EuDecisionType.where(name: ["iii)", "iii) removed"]).pluck(:id)
+    eu_opinions = EuOpinion.where(eu_decision_type_id: old_decision_type_ids, is_current: true)
+    new_decision_type_id = EuDecisionType.find_by_name("SRG Referral").id
+    puts "There are #{eu_opinions.count} eu_opinions to be transferred"
+    update_query = <<-SQL
+      WITH current_eu_opinions_with_iii_type AS (
+        SELECT *
+        FROM eu_decisions
+        WHERE type = 'EuOpinion'
+        AND eu_decision_type_id IN (#{old_decision_type_ids.join(',')})
+        AND is_current = true
+      )
+      UPDATE eu_decisions
+      SET eu_decision_type_id = #{new_decision_type_id}
+      FROM current_eu_opinions_with_iii_type
+      WHERE current_eu_opinions_with_iii_type.id = eu_decisions.id
+    SQL
+    res = ActiveRecord::Base.connection.execute update_query
+    puts "#{res.cmd_tuples} rows transferred to SRG Referral decision type"
+  end
+end


### PR DESCRIPTION
This is to add the rake task to:

1) to transfer all the current no opinion iii)’s to the Srg Referral new decision type
2) move all the current ‘no opinion ii)’ decisions in Species+ to the new ‘SRG histories’  ‘In consultation’ type