### PR TITLE
use custom transitions for trade app

### DIFF
--- a/app/assets/javascripts/shared-mixins/custom_transition.js.coffee
+++ b/app/assets/javascripts/shared-mixins/custom_transition.js.coffee
@@ -4,6 +4,8 @@
 
 # @refresh has been used in queryParamsDidChange in ..._route.js files to make sure that the new model is loaded when the parameters change. This might be able to be removed when updating Ember.
 
+# Note the trade and species apps both pass array parameters differently.
+
 ROUTES = {
   species: {
     'taxonConcept': {
@@ -29,11 +31,12 @@ isNotUndefinedOrNull = (x) ->
   App.CustomTransition = Ember.Mixin.create
     customTransitionToRoute: (emberRoute, arg2, arg3) ->
       @routes = ROUTES[appName]
+      @appName = appName
       @paramsMapping = @get('propertyMapping')
 
       @assignArguments(arguments)
       path = @getPath()
-      base_url = window.location.origin + '/' + appName + '#/' + path
+      base_url = window.location.origin + '/' + @appName + '#/' + path
       queryString = if @queryParams then @getQueryString(@queryParams) else ''
       
       window.location.href = base_url + queryString
@@ -72,9 +75,12 @@ isNotUndefinedOrNull = (x) ->
     getQueryString: (queryParams) -> 
       queryString = '?'
 
-      queryString += Object.keys(queryParams).map((key) =>
-        @getQueryStringItem(key, queryParams[key])
-      ).filter(isNotUndefinedOrNull).join('&')
+      if @appName == 'trade'
+        queryString += $.param(queryParams)
+      else
+        queryString += Object.keys(queryParams).map((key) =>
+          @getQueryStringItem(key, queryParams[key])
+        ).filter(isNotUndefinedOrNull).join('&')
 
     getQueryStringItem: (key, param) ->    
       if Array.isArray(param)

--- a/app/assets/javascripts/trade/controllers/annual_report_upload_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/annual_report_upload_controller.js.coffee
@@ -1,4 +1,4 @@
-Trade.AnnualReportUploadController = Ember.ObjectController.extend Trade.Flash, Trade.AuthoriseUser,
+Trade.AnnualReportUploadController = Ember.ObjectController.extend Trade.Flash, Trade.AuthoriseUser, Trade.CustomTransition,
   needs: ['geoEntities', 'terms', 'units', 'sources', 'purposes', 'sandboxShipments']
   content: null
   currentShipment: null
@@ -18,7 +18,7 @@ Trade.AnnualReportUploadController = Ember.ObjectController.extend Trade.Flash, 
       @userCanEdit( =>
         onSuccess = =>
           @set('sandboxShipmentsSubmitting', false)
-          @transitionToRoute('search')
+          @customTransitionToRoute('search')
           @flashSuccess(message: "#{@get('numberOfRows')} shipments submitted.", persists: true)
         onError = (xhr, msg, error) =>
           @set('sandboxShipmentsSubmitting', false)
@@ -47,7 +47,7 @@ Trade.AnnualReportUploadController = Ember.ObjectController.extend Trade.Flash, 
         validation_error_id: error.get('id')
         page: 1
       }
-      @transitionToRoute('sandbox_shipments', {
+      @customTransitionToRoute('sandbox_shipments', {
         queryParams: params
       })
 

--- a/app/assets/javascripts/trade/controllers/annual_report_uploads_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/annual_report_uploads_controller.js.coffee
@@ -1,4 +1,4 @@
-Trade.AnnualReportUploadsController = Ember.ArrayController.extend Trade.AuthoriseUser,
+Trade.AnnualReportUploadsController = Ember.ArrayController.extend Trade.AuthoriseUser, Trade.CustomTransition,
   content: null
   needs: ['geoEntities']
 
@@ -6,7 +6,7 @@ Trade.AnnualReportUploadsController = Ember.ArrayController.extend Trade.Authori
     if (!aru.get('isSaving'))
       aru.one('didDelete', @, ->
         @get('content').removeObject(aru)
-        @transitionToRoute('annual_report_uploads')
+        @customTransitionToRoute('annual_report_uploads')
       )
       aru.deleteRecord()
       aru.get('transaction').commit()
@@ -14,13 +14,13 @@ Trade.AnnualReportUploadsController = Ember.ArrayController.extend Trade.Authori
   actions:
     transitionToReportUploadFromList: (aru)->
       aru.reload()
-      @transitionToRoute('annual_report_upload', aru)
+      @customTransitionToRoute('annual_report_upload', aru)
 
     transitionToReportUpload: (aru)->
-      @transitionToRoute('annual_report_upload', aru)
+      @customTransitionToRoute('annual_report_upload', aru)
 
     transitionToReportUploads: ()->
-      @transitionToRoute('annual_report_uploads')
+      @customTransitionToRoute('annual_report_uploads')
 
     deleteUpload: (aru) ->
       @userCanEdit( =>

--- a/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
@@ -1,4 +1,4 @@
-Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPagination, Trade.Flash, Trade.AuthoriseUser,
+Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPagination, Trade.Flash, Trade.AuthoriseUser, Trade.CustomTransition,
   needs: ['annualReportUpload', 'geoEntities', 'terms', 'units', 'sources', 'purposes']
   content: null
   updatesVisible: false
@@ -41,7 +41,7 @@ Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPa
 
   transitionToParentController: ->
     @get('controllers.annualReportUpload.content').reload()
-    @transitionToRoute(
+    @customTransitionToRoute(
       'annual_report_upload',
       @get('controllers.annualReportUpload.id')
     )

--- a/app/assets/javascripts/trade/controllers/search_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_controller.js.coffee
@@ -1,4 +1,4 @@
-Trade.SearchController = Ember.Controller.extend Trade.QueryParams, Trade.Flash,
+Trade.SearchController = Ember.Controller.extend Trade.QueryParams, Trade.Flash, Trade.CustomTransition,
   needs: ['geoEntities', 'terms', 'units', 'sources', 'purposes']
   content: null
   currentShipment: null
@@ -240,9 +240,9 @@ Trade.SearchController = Ember.Controller.extend Trade.QueryParams, Trade.Flash,
   actions:
     search: ->
       @flashClear()
-      @transitionToRoute('search.results', {queryParams: @get('searchParams')})
+      @customTransitionToRoute('search.results', {queryParams: @get('searchParams')})
 
     resetFilters: ->
       @flashClear()
       @resetFilters()
-      @transitionToRoute('search.results', {queryParams: @get('searchParams')})
+      @customTransitionToRoute('search.results', {queryParams: @get('searchParams')})

--- a/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
@@ -1,4 +1,4 @@
-Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, Trade.ShipmentPagination, Trade.Flash,
+Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, Trade.ShipmentPagination, Trade.Flash, Trade.CustomTransition,
   needs: ['search', 'geoEntities', 'terms', 'units', 'sources', 'purposes']
   content: null
   currentShipment: null
@@ -59,7 +59,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
     else
       parseInt(@get('page')) - 1
     @set('page', page)
-    @transitionToRoute('search.results', {queryParams: {page: page}})
+    @customTransitionToRoute('search.results', {queryParams: {page: page}})
 
   userCanEdit: (callback) ->
     $.ajax({
@@ -135,7 +135,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
 
     deleteBatch: ->
       @userCanEdit( =>
-        @transitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
+        @customTransitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
         .then(
           # resolve
           (() =>
@@ -169,7 +169,7 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
       $('.shipment-form-modal').modal('show')
 
     editBatch: ->
-      @transitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
+      @customTransitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
       .then(
         # resolve
         (() =>


### PR DESCRIPTION
@Levia This *should* be the last of the frontend query params work. I'm not familiar with the trade part of the site, so have tried to test against the live site, but may have missed some stuff.

This uses a custom transitionTo method, rather than the one built in. It mostly matches up with the species ember app, although the species side handles array params as a comma separated string and the trade side does not.

P.S. The last commit on `manually-upgrade-Gemfile-to-Rails4` was accidentally put straight onto that branch. This is just refactoring, but you may want to take a look!

Tests seem to be failing because bundler can't be found... Have you seen this before? 