### PR TITLE
Add rake task to export trade db records by dates

### DIFF
--- a/app/models/trade/shipment_report_queries.rb
+++ b/app/models/trade/shipment_report_queries.rb
@@ -301,6 +301,75 @@ module Trade::ShipmentReportQueries
     LIMIT #{limit} OFFSET #{offset}"
   end
 
+  def self.partial_db_query(limit, offset, updated_at: nil, created_at: nil)
+    full_db_query(limit, offset) unless updated_at || created_at
+    where = if updated_at && !created_at
+              "shipments.updated_at > '#{updated_at}'"
+            elsif created_at && !updated_at
+              "shipments.created_at > '#{created_at}'"
+            else
+              "shipments.updated_at > '#{updated_at}' AND shipments.created_at < '#{created_at}'"
+            end
+    "SELECT
+      shipments.id AS id,
+      year AS year,
+      appendix AS appendix,
+      full_name_with_spp(ranks.name, taxon_concept_full_name) AS taxon,
+      taxon_concept_id AS taxon_id,
+      taxon_concept_class_name AS class,
+      taxon_concept_order_name AS order,
+      taxon_concept_family_name AS family,
+      taxon_concept_genus_name AS genus,
+      full_name_with_spp(reported_taxon_ranks.name, reported_taxon_concept_full_name) AS reported_taxon,
+      reported_taxon_concept_id AS reported_taxon_id,
+      terms.name_en AS term,
+      CASE WHEN quantity = 0 THEN NULL ELSE quantity END,
+      units.name_en AS unit,
+      importers.iso_code2 AS importer,
+      exporters.iso_code2 AS exporter,
+      countries_of_origin.iso_code2 AS origin,
+      purposes.code AS purpose,
+      sources.code AS source,
+      CASE
+        WHEN reported_by_exporter THEN 'E'
+        ELSE 'I'
+      END AS reporter_type,
+      import_permit_number AS import_permit,
+      export_permit_number AS export_permit,
+      origin_permit_number AS origin_permit,
+      legacy_shipment_number AS legacy_shipment_no,
+      uc.name AS created_by,
+      uu.name AS updated_by,
+      shipments.updated_at AS updated_at,
+      shipments.created_at AS created_at
+    FROM trade_shipments_with_taxa_view AS shipments
+    JOIN ranks
+      ON ranks.id = taxon_concept_rank_id
+    LEFT JOIN ranks AS reported_taxon_ranks
+      ON reported_taxon_ranks.id = reported_taxon_concept_rank_id
+    JOIN geo_entities importers
+      ON importers.id = importer_id
+    JOIN geo_entities exporters
+      ON exporters.id = exporter_id
+    LEFT JOIN geo_entities countries_of_origin
+      ON countries_of_origin.id = country_of_origin_id
+    LEFT JOIN trade_codes units
+      ON units.id = unit_id
+    JOIN trade_codes terms
+      ON terms.id = term_id
+    LEFT JOIN trade_codes purposes
+      ON purposes.id = purpose_id
+    LEFT JOIN trade_codes sources
+      ON sources.id = source_id
+    LEFT JOIN users as uc
+      ON shipments.created_by_id = uc.id
+    LEFT JOIN users as uu
+      ON shipments.updated_by_id = uu.id
+    WHERE #{where}
+    ORDER BY shipments.id
+    LIMIT #{limit} OFFSET #{offset}"
+  end
+
   def comptab_query(options)
     "SELECT
       year,

--- a/lib/tasks/export_trade_db.rake
+++ b/lib/tasks/export_trade_db.rake
@@ -51,6 +51,7 @@ namespace :export do
   def export_in_single_file(ntuples, offset, dir)
     i = 0
     filename = 'trade_db_full_export.csv'
+    path_to_file = dir + filename
     begin
       while(ntuples == RECORDS_PER_FILE) do
         i = i + 1
@@ -61,7 +62,7 @@ namespace :export do
 
         Rails.logger.info("Query executed returning #{ntuples} records!")
 
-        File.open("#{dir}#{filename}", 'a') do |file|
+        File.open(path_to_file, 'a') do |file|
           if i == 1
             columns = results.fields
             columns.map do |column|
@@ -82,8 +83,9 @@ namespace :export do
       Rails.logger.info("Trade database completely exported!")
       zipfile = 'tmp/trade_db_files/trade_db.zip'
       Zip::File.open(zipfile, Zip::File::CREATE) do |zipfile|
-          zipfile.add(filename, dir + filename)
+          zipfile.add(filename, path_to_file)
       end
+      delete_csv_files(dir)
     rescue => e
       Rails.logger.info("Export aborted!")
       Rails.logger.info("Caught exception #{e}")
@@ -150,6 +152,7 @@ namespace :export do
           end
         end
       end
+      delete_csv_files(dir)
     rescue => e
       Rails.logger.info("Export aborted!")
       Rails.logger.info("Caught exception #{e}")
@@ -184,14 +187,20 @@ namespace :export do
       Zip::File.open(zipfile, Zip::File::CREATE) do |zipfile|
         (1..i).each do |index|
           filename = "trade_db_#{index}.csv"
-          zipfile.add(filename, dir + filename)
+          path_to_file = dir + filename
+          zipfile.add(filename, path_to_file)
         end
       end
+      delete_csv_files(dir)
     rescue => e
       Rails.logger.info("Export aborted!")
       Rails.logger.info("Caught exception #{e}")
       Rails.logger.info(e.message)
     end
+  end
+
+  def delete_csv_files(dir)
+    Dir.glob("#{dir}/trade_db*.csv").each { |file| File.delete(file) }
   end
 
   def process_results(results, options)


### PR DESCRIPTION
## Description

Add rake tasks and query to export trade db partially and based on updated_at and created_at dates.

## Notes

Examples:
```
# exports records created after 29/01/19
> bundle exec rake export:trade_db_from_created_at['2019-01-29']
# exports records updated after 29/01/19 and created prior 30/01/19
> bundle exec rake export:trade_db_from_updated_at['2019-01-29','2019-01-30']
```