### PR TITLE
add tracking of full db download

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -763,6 +763,13 @@ $(document).ready(function(){
 
   $('#button_report').click( function (e) {handleDownloadRequest(false) });
   $('#ignore_warning_button_report').click( function (e) {handleDownloadRequest(true) });
+  $('[data-full-trade-db-download]').click( function (e) {
+    ga('send', {
+      hitType: 'event',
+      eventCategory: 'Downloads: Full trade database',
+      eventAction: 'Format: CSV',
+    });
+  })
 
   //////////////////////////////
   // View results page specific:

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -7,7 +7,7 @@
 
       <div class='banner'>
         <p class='bold font-18'><%= t('full_db_download_available') %></p>
-        <a href=<%= cites_trade_download_db_path %> class='download-button'>
+        <a href=<%= cites_trade_download_db_path %> class='download-button' data-full-trade-db-download>
           <div>
             <p class='bold font-18 no-margin'><%= t('download_here') %> </p>
             <p class='no-margin'><%= t('file_size') %>: 237MB</p>
@@ -184,7 +184,7 @@
 <div class="grid_16 other_info">
   <p align="center" class='no-margin'>
     <strong><%= t('download') %>:</strong>
-    <a href=<%= cites_trade_download_db_path %>><%= t('full_db_download') %> (237MB)</a>
+    <a href=<%= cites_trade_download_db_path %> data-full-trade-db-download><%= t('full_db_download') %> (237MB)</a>
   </p>
   <p align="center">
     <strong><%= t('download') %>:</strong>


### PR DESCRIPTION
Adds event tracking for full database download on /en/cites_trade (also es and fr)