### PR TITLE
Exclude empty strings at the selected taxonomic level

### DIFF
--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -232,6 +232,8 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     taxonomic_level_name = "#{taxonomic_level}_name"
     group_name = opts[:group_name]
     group_name_condition = " AND LOWER(group_name) = '#{group_name.downcase}'" if group_name
+    # Exclude blanks in taxonomic level (empty strings at the selected taxonomic level)
+    taxonomic_level_not_null = "#{taxonomic_level_name} IS NOT NULL"
 
     check_for_plants = <<-SQL
       CASE
@@ -251,10 +253,13 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
           #{ancestors_list(taxonomic_level)},
           COUNT(*) OVER () AS total_count
         FROM #{shipments_table}
-        WHERE #{@condition} AND #{quantity_field} IS NOT NULL #{group_name_condition}
+        WHERE #{@condition} AND
+        #{quantity_field} IS NOT NULL
+        #{group_name_condition}
+        AND #{taxonomic_level_not_null}
         AND #{country_condition}
         AND #{child_taxa_condition}
-        GROUP BY #{taxonomic_level_name}, #{ancestors_list(taxonomic_level)}
+        GROUP BY #{ancestors_list(taxonomic_level)}
         #{quantity_condition(quantity_field)}
         ORDER BY value DESC
         #{limit}


### PR DESCRIPTION
## Description

* Exclude BLANKS at the selected taxonomic level
* Refactor GROUP BY slightly as the taxonomic level selected was being added twice

## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/97)