### PR TITLE
Include hybrids in trade plus queries

### DIFF
--- a/db/migrate/20201008133057_create_all_taxon_concepts_and_ancestors_mview.rb
+++ b/db/migrate/20201008133057_create_all_taxon_concepts_and_ancestors_mview.rb
@@ -1,0 +1,12 @@
+class CreateAllTaxonConceptsAndAncestorsMview < ActiveRecord::Migration
+  def up
+    execute "DROP MATERIALIZED VIEW IF EXISTS all_taxon_concepts_and_ancestors_mview"
+    execute "CREATE MATERIALIZED VIEW all_taxon_concepts_and_ancestors_mview AS #{view_sql('20201008133057', 'all_taxon_concepts_and_ancestors_mview')}"
+    execute "CREATE UNIQUE INDEX ON all_taxon_concepts_and_ancestors_mview(ancestor_taxon_concept_id, taxon_concept_id)"
+    execute "CREATE INDEX ON all_taxon_concepts_and_ancestors_mview(taxonomy_id)"
+  end
+
+  def down
+    execute "DROP MATERIALIZED VIEW IF EXISTS all_taxon_concepts_and_ancestors_mview"
+  end
+end

--- a/db/mviews/010_rebuild_trade_plus_mviews.sql
+++ b/db/mviews/010_rebuild_trade_plus_mviews.sql
@@ -3,6 +3,8 @@ CREATE OR REPLACE FUNCTION rebuild_trade_plus_complete_mview() RETURNS void
   AS $$
   BEGIN
     DROP MATERIALIZED VIEW IF EXISTS trade_plus_complete_mview CASCADE;
+    -- Below is used for child taxa queries
+    REFRESH MATERIALIZED VIEW all_taxon_concepts_and_ancestors_mview;
 
     RAISE INFO 'Creating Trade Plus complete materialized view';
     CREATE MATERIALIZED VIEW trade_plus_complete_mview AS

--- a/db/views/all_taxon_concepts_and_ancestors_mview/20201008133057.sql
+++ b/db/views/all_taxon_concepts_and_ancestors_mview/20201008133057.sql
@@ -1,0 +1,10 @@
+SELECT id AS taxon_concept_id, taxonomy_id,
+(
+  data->(LOWER(UNNEST(higher_or_equal_ranks_names(data->'rank_name'))) || '_id')
+)::INT AS ancestor_taxon_concept_id,
+GENERATE_SUBSCRIPTS(higher_or_equal_ranks_names(data->'rank_name'), 1) - 1 AS tree_distance
+FROM taxon_concepts
+
+-- This query is like taxon_concepts_and_ancestors_mview 
+-- but it takes into consideration all taxa instead of just 'A', 'N' and 'H' names.
+-- Amending the original one could have had undesired impact on several other queries and views.

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -129,20 +129,13 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
   def child_taxa_query(tc_id=nil)
     return '' if @opts['taxon_id'].blank? && !tc_id
     tc_id = @opts['taxon_id'] || tc_id
+
     <<-SQL
-      WITH RECURSIVE selected_taxa AS (
-        SELECT UNNEST(ARRAY[#{tc_id}]) AS id
-      ),
-      child_taxa AS (
-        SELECT id
-        FROM selected_taxa
-
-        UNION ALL
-
-        SELECT tc.id
-        FROM taxon_concepts tc
-        JOIN child_taxa ON child_taxa.id = tc.parent_id
-      )
+    WITH child_taxa AS (
+      SELECT taxon_concept_id AS id
+      FROM all_taxon_concepts_and_ancestors_mview
+      WHERE ancestor_taxon_concept_id = #{tc_id}
+    )
     SQL
   end
 


### PR DESCRIPTION
## Description

Hybrids where not included in the queries because the child_taxa query was not taking into account that hybrids parents are linked via different attributes (taxon conceps parent_id was not enough).
To fix it, I have created a new materialized view that calculates all ancestor relationships regardless of name status.

There was already an mview doing this but it was not taking into account synonyms, which are instead needed for TradePlus.
Amending the original mview could have resulted in undesired behaviours elsewhere, hence why I decided to go for a new one.

## Notes
Need to run migrations.

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/75)