### PR TITLE
Validate tmp_taxon_concept correctly

### DIFF
--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -180,7 +180,10 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def validate_tmp_taxon_concept
     @tmp_taxon_concept = tmp_taxon_concept
-    return false unless tmp_taxon_concept
+    unless tmp_taxon_concept
+      errors.add(:new_taxon_concept, "can\'t be blank")
+      return false
+    end
 
     return true if @tmp_taxon_concept.valid?
     @tmp_taxon_concept.errors.each do |attribute, message|

--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -141,10 +141,9 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def tmp_taxon_concept
     name_status_to_save = (new_name_status.present? ? new_name_status : name_status)
-    return nil unless display_full_name
 
     scientific_name =
-      if ['A', 'N'].include?(name_status_to_save)
+      if ['A', 'N'].include?(name_status_to_save) && display_full_name
         display_full_name.split.last
       else
         display_full_name
@@ -180,9 +179,8 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def validate_tmp_taxon_concept
     @tmp_taxon_concept = tmp_taxon_concept
-    unless tmp_taxon_concept
+    unless @tmp_taxon_concept
       errors.add(:new_taxon_concept, "can\'t be blank")
-      return false
     end
 
     return true if @tmp_taxon_concept.valid?

--- a/app/models/nomenclature_change/output.rb
+++ b/app/models/nomenclature_change/output.rb
@@ -141,6 +141,8 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def tmp_taxon_concept
     name_status_to_save = (new_name_status.present? ? new_name_status : name_status)
+    return nil unless display_full_name
+
     scientific_name =
       if ['A', 'N'].include?(name_status_to_save)
         display_full_name.split.last
@@ -178,6 +180,8 @@ class NomenclatureChange::Output < ActiveRecord::Base
 
   def validate_tmp_taxon_concept
     @tmp_taxon_concept = tmp_taxon_concept
+    return false unless tmp_taxon_concept
+
     return true if @tmp_taxon_concept.valid?
     @tmp_taxon_concept.errors.each do |attribute, message|
       if [:parent_id, :rank_id, :name_status, :author_year, :full_name].

--- a/spec/models/nomenclature_change/output_spec.rb
+++ b/spec/models/nomenclature_change/output_spec.rb
@@ -30,7 +30,6 @@
 #
 
 require 'spec_helper'
-require 'byebug'
 
 describe NomenclatureChange::Output do
   before(:each) { cites_eu }

--- a/spec/models/nomenclature_change/output_spec.rb
+++ b/spec/models/nomenclature_change/output_spec.rb
@@ -30,6 +30,7 @@
 #
 
 require 'spec_helper'
+require 'byebug'
 
 describe NomenclatureChange::Output do
   before(:each) { cites_eu }
@@ -52,8 +53,8 @@ describe NomenclatureChange::Output do
       }
       specify { expect(output).to have(1).errors_on(:new_scientific_name) }
       specify { expect(output).to have(1).errors_on(:new_parent_id) }
-      specify { expect(output).to have(1).errors_on(:new_rank_id) }
-      specify { expect(output).to have(1).errors_on(:new_name_status) }
+      specify { expect(output).to have(1).errors_on(:new_taxon_concept) }
+
     end
     context "when new taxon concept invalid" do
       let(:output) {

--- a/spec/models/nomenclature_change/output_spec.rb
+++ b/spec/models/nomenclature_change/output_spec.rb
@@ -53,6 +53,8 @@ describe NomenclatureChange::Output do
       }
       specify { expect(output).to have(1).errors_on(:new_scientific_name) }
       specify { expect(output).to have(1).errors_on(:new_parent_id) }
+      specify { expect(output).to have(1).errors_on(:new_rank_id) }
+      specify { expect(output).to have(1).errors_on(:new_name_status) }
       specify { expect(output).to have(1).errors_on(:new_taxon_concept) }
 
     end

--- a/spec/models/nomenclature_change/output_spec.rb
+++ b/spec/models/nomenclature_change/output_spec.rb
@@ -55,7 +55,6 @@ describe NomenclatureChange::Output do
       specify { expect(output).to have(1).errors_on(:new_rank_id) }
       specify { expect(output).to have(1).errors_on(:new_name_status) }
       specify { expect(output).to have(1).errors_on(:new_taxon_concept) }
-
     end
     context "when new taxon concept invalid" do
       let(:output) {


### PR DESCRIPTION
## Description

Some nomenclature changes forms were not validating input correctly on step 1.
The fix in this PR is about ensuring the fields to assigns are populated, otherwise return invalid flag.

This applies to the following nomenclature changes:
  * change into accepted name
  * change into a synonym
  * swap between accepted name and synonym

## Notes

Even though this has been reported in the Rails 4 board, this was also an issue in the main branch.
[Codebase Ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/20)