### PR TITLE
Fix param event name passed to inherited resource

### DIFF
--- a/app/views/admin/eu_regulations_common/_list.html.erb
+++ b/app/views/admin/eu_regulations_common/_list.html.erb
@@ -12,7 +12,7 @@
     <tr class="<%= if eu_regulation.is_current? then "current_listing" end %>">
       <td>
         <a href="#" class="editable editable-click editable-required"
-          data-type="text" data-resource="eu_regulation" data-name="name"
+          data-type="text" data-resource="<%= eu_regulation.type.underscore %>" data-name="name"
           data-placeholder="Required" data-original-title="Enter the EU Regulation's name"
           data-url="<%= resource_url(eu_regulation) %>" data-pk="<%= eu_regulation.id %>">
           <%= eu_regulation.name %>
@@ -20,7 +20,7 @@
       </td>
       <td>
         <a href="#" class="editable editable-click editable-required"
-          data-type="text" data-resource="eu_regulation" data-name="description"
+          data-type="text" data-resource="<%= eu_regulation.type.underscore %>" data-name="description"
           data-placeholder="Required" data-original-title="Enter the EU Regulation's description"
           data-url="<%= resource_url(eu_regulation) %>" data-pk="<%= eu_regulation.id %>">
           <%= eu_regulation.description %>


### PR DESCRIPTION
[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/60)

The gem inherited resource expects the param name to be consistent with the model(resource) name. For the eu_regulations we are using the same partial for all the three different eu_regulations type, and so the param name was the same and not consistent with the model type. 
This fix still use a single partial but assign the param name dynamically based on the regulation type.