### PR TITLE
NULL values to be mapped correctly against criteria

### DIFF
--- a/app/models/trade/inclusion_validation_rule.rb
+++ b/app/models/trade/inclusion_validation_rule.rb
@@ -19,7 +19,6 @@ class Trade::InclusionValidationRule < Trade::ValidationRule
   attr_accessible :valid_values_view
 
   def matching_records_for_aru_and_error(annual_report_upload, validation_error)
-    sandbox_klass = Trade::SandboxTemplate.ar_klass(annual_report_upload.sandbox.table_name)
     @query = matching_records(annual_report_upload).
       where(
         "'#{validation_error.matching_criteria}'::JSONB @> (#{jsonb_matching_criteria_for_comparison})::JSONB"

--- a/app/models/trade/inclusion_validation_rule.rb
+++ b/app/models/trade/inclusion_validation_rule.rb
@@ -130,7 +130,7 @@ class Trade::InclusionValidationRule < Trade::ValidationRule
           column_reference
         else
           <<-EOT
-            '"' || #{column_reference} || '"'
+            '"' || COALESCE(#{column_reference}, '') || '"'
           EOT
         end
       <<-EOT


### PR DESCRIPTION
## Description

Validation rules correctly detect invalid records related to incorrect term-purpose pair with empty purpose; although when clicking on the validation error to fix, the invalid records are not shown and those can't be then fixed.
This PR fixes that making the records to show correctly.

More precisely, the issue was related to the fact that validation errors matching criteria uses an empty string to map an empty value, while the SQL used to fetch the invalid records was using the value in the table, which is `NULL` instead of an empty string. So I added a COALESCE function to account for that.

❗ This is something that seems also affecting the current live code. Hence why I branched off of develop even though this was reported as part of the Rails4 upgrade work.


## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/38)