### PR TITLE
Rails4 fix invalid login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,10 +17,11 @@ class SessionsController < Devise::SessionsController
   protected
 
   def invalid_login_attempt
-    set_flash_message(:alert, :invalid)
+    @user = User.new
+    set_flash_message(:error, :invalid)
     respond_to do |format|
       format.html { render :new, status: 401 }
-      format.json { render json: flash[:alert], status: 401 }
+      format.json { render json: flash[:error], status: 401 }
     end
   end
 end


### PR DESCRIPTION
## Description

Failing login attempts were throwing an error with regards the form.
Assign an empty user for the form to work and ensure the alert message shows in red.

## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/62)