### PR TITLE
Rails4 fix material doc ids

### DIFF
--- a/app/serializers/checklist/document_serializer.rb
+++ b/app/serializers/checklist/document_serializer.rb
@@ -9,10 +9,6 @@ class Checklist::DocumentSerializer < ActiveModel::Serializer
     object.document_type.split(":").last
   end
 
-  def document_language_versions
-    JSON.parse(object.document_language_versions)
-  end
-
   def locale_document
     doc = document_language_versions.select { |h| h['locale_document'] == 'true' }
     doc = document_language_versions.select { |h| h['locale_document'] == 'default' } if doc.empty?
@@ -20,7 +16,7 @@ class Checklist::DocumentSerializer < ActiveModel::Serializer
   end
 
   def taxon_concept_ids
-    object.taxon_concept_ids.gsub(/[{}]/, '').split(',')
+    object.taxon_concept_ids
   end
 
   def is_link

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -47,7 +47,7 @@ module MaterialDocIdsRetriever
     )
 
     ordered_docs = docs.cached_results.sort_by do |doc|
-      doc_tc_ids = doc.taxon_concept_ids.split(',').map(&:to_i)
+      doc_tc_ids = doc.taxon_concept_ids
       params['taxon_concepts_ids'].index{ |id| doc_tc_ids.include? id }
     end
 
@@ -57,13 +57,9 @@ module MaterialDocIdsRetriever
 
   private
 
-  def self.document_language_versions(doc)
-    JSON.parse(doc.document_language_versions)
-  end
-
   def self.locale_document(doc)
-    document = document_language_versions(doc).select { |h| h['locale_document'] == 'true' }
-    document = document_language_versions(doc).select { |h| h['locale_document'] == 'default' } if document.empty?
+    document = doc.document_language_versions.select { |h| h['locale_document'] == 'true' }
+    document = doc.document_language_versions.select { |h| h['locale_document'] == 'default' } if document.empty?
     document
   end
 

--- a/lib/modules/material_doc_ids_retriever.rb
+++ b/lib/modules/material_doc_ids_retriever.rb
@@ -47,7 +47,7 @@ module MaterialDocIdsRetriever
     )
 
     ordered_docs = docs.cached_results.sort_by do |doc|
-      doc_tc_ids = doc.taxon_concept_ids.gsub(/[{}]/, '').split(',').map(&:to_i)
+      doc_tc_ids = doc.taxon_concept_ids.split(',').map(&:to_i)
       params['taxon_concepts_ids'].index{ |id| doc_tc_ids.include? id }
     end
 

--- a/lib/tasks/elibrary/identification_docs_distributions_importer.rb
+++ b/lib/tasks/elibrary/identification_docs_distributions_importer.rb
@@ -77,8 +77,7 @@ class Elibrary::IdentificationDocsDistributionsImporter
         children = MTaxonConcept.descendants_ids(res['tc_ids'])
 
         countries_ids = MTaxonConcept.where(id: children).pluck(:countries_ids_ary)
-                                     .compact.map{ |country| country.gsub(/[{}]/, '').split(',').map(&:to_i)}
-                                     .flatten.uniq.sort
+          .compact.flatten.uniq.sort
 
         if countries_ids.empty?
           no_distr << [doc_cit_id, children]


### PR DESCRIPTION
## Description

Update way arrays are managed within ID Manuals work and related also to Checklist.
This is because of the changes related to upgrading to Rails 4.

## Notes

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/69)