### PR TITLE
If distribution is a new object, copy tags

### DIFF
--- a/app/models/nomenclature_change/reassignment_copy_processor.rb
+++ b/app/models/nomenclature_change/reassignment_copy_processor.rb
@@ -99,7 +99,7 @@ class NomenclatureChange::ReassignmentCopyProcessor < NomenclatureChange::Reassi
     if reassignable.taggings.count == 0
       copied_object.taggings.destroy_all if copied_object.taggings.count > 0
       return
-    elsif copied_object.taggings.count == 0
+    elsif copied_object.id && copied_object.taggings.count == 0
       return
     end
 


### PR DESCRIPTION
## Description

⚠️ Even though this has been reported in the Rails4 board, this issue also affects the live site

The issue is already explained in the [related Codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/71).

To summarise, when copying distribution tags it's necessary to check whether the related distribution object is an entirely new object before also checking for the associated taggings.

The general rule (better described in the ticket) is that distribution with no tagging take precedence when copying and when there's already the same distribution for the output taxon.
Given that it's possible we are looking into an entirely new distribution for the output taxon, we can't return earlier as we need to copy that distribution. To check whether that is a new object is sufficient to check if the `id` is empty as that object is not yet saved in the db at the given time.