### PR TITLE
Rails 4 improve admin error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 cache: bundler
 bundler_args: --without development production staging
 sudo: false

--- a/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
+++ b/app/assets/javascripts/admin/admin_in_place_editor.js.coffee
@@ -51,7 +51,16 @@ class AdminEditor
     alert.append('<a class="close" href="#" data-dismiss="alert">x</a>')
     alert.append(txt)
 
-    $(alert).insertBefore($('h1'))
+    $(alert).insertBefore($('.admin-header'))
+
+  alertError: (txt) ->
+    $('.alert').remove()
+
+    alert = $('<div class="alert alert-error">')
+    alert.append('<a class="close" href="#" data-dismiss="alert">x</a>')
+    alert.append(txt)
+
+    $(alert).insertBefore($('.admin-header'))
 
   initSearchTypeahead: () ->
     $('.search-typeahead').typeahead

--- a/app/controllers/admin/eu_suspension_regulations_controller.rb
+++ b/app/controllers/admin/eu_suspension_regulations_controller.rb
@@ -6,12 +6,14 @@ class Admin::EuSuspensionRegulationsController < Admin::EventsController
   def activate
     @eu_suspension_regulation = EuSuspensionRegulation.find(params[:id])
     @eu_suspension_regulation.activate!
+    @errors = @eu_suspension_regulation.errors.messages.values.flatten.join(' - ')
     render 'create'
   end
 
   def deactivate
     @eu_suspension_regulation = EuSuspensionRegulation.find(params[:id])
     @eu_suspension_regulation.deactivate!
+    @errors = @eu_suspension_regulation.errors.messages.values.flatten.join(' - ')
     render 'create'
   end
 

--- a/app/views/admin/simple_crud/create.js.erb
+++ b/app/views/admin/simple_crud/create.js.erb
@@ -1,4 +1,8 @@
 $('.modal').modal('hide');
 $('#admin-in-place-editor').html("<%= escape_javascript(render('list')) %>");
 window.adminEditor.initEditors();
-window.adminEditor.alertSuccess("Operation successful");
+<% if @errors %>
+  window.adminEditor.alertError("<%= @errors %>");
+<% else %>
+  window.adminEditor.alertSuccess("Operation successful");
+<% end %>


### PR DESCRIPTION
## Description

⚠️ Please note this is also an improvement for the current version of the site, although I felt like adding it to the rails 4 upgrade branch given it's only related to displaying an error message. 

* Add ability to display error message if can't batch update EU suspensions
* Fix Travis complaining about not being able to find bundler and other gems. Used previous version of Travis dist for now.

[Related codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/85)