### PR TITLE
Make enter key trigger click on IE and Chrome

### DIFF
--- a/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
+++ b/app/assets/javascripts/species/views/elibrary_search_form/elibrary_search_form_view.js.coffee
@@ -4,7 +4,7 @@ Species.ElibrarySearchFormView = Ember.View.extend
 
   keyDown: (event) ->
     if event.keyCode == 13
-      $('.elibrary-search-button').click()
+      $('.elibrary-search-button').focus().trigger('click')
 
   actions:
     toggleSearchOptions: () ->


### PR DESCRIPTION
## Description

⚠️ Travis is failing but a fix for this is in the previous PR.

Make "enter" key trigger click on document search (public interface) for Edge (IE too?) and Chrome.
[Related codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/84)
