### PR TITLE
Ensure also '/admin/' redirects to sign in

### DIFF
--- a/lib/modules/custom_failure.rb
+++ b/lib/modules/custom_failure.rb
@@ -1,6 +1,9 @@
 class CustomFailure < Devise::FailureApp
   def redirect_url
-    if request.original_url == request.base_url + "/admin"
+    # Ensure both /admin and /admin/ redirect to sign in page
+    regexp = Regexp.new("#{admin_root_path}(\/)?")
+
+    if request.original_url.match(regexp)
       new_user_session_path
     else
       root_path

--- a/lib/modules/custom_failure.rb
+++ b/lib/modules/custom_failure.rb
@@ -1,9 +1,7 @@
 class CustomFailure < Devise::FailureApp
   def redirect_url
     # Ensure both /admin and /admin/ redirect to sign in page
-    regexp = Regexp.new("#{admin_root_path}(\/)?")
-
-    if request.original_url.match(regexp)
+    if request.original_url.match(admin_root_path)
       new_user_session_path
     else
       root_path


### PR DESCRIPTION
## Description

⚠️ The issue should also be affecting the live site, although I assumed this change can be merged alongside with the rails 4 upgrade.
⚠️ Also in this case, Travis fails but the fix is in a previous PR

Ensure both '/admin' and '/admin/' redirect to sign in page if admin user is not logged in.

[Related codebase ticket](https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/79)