### PR TITLE
Draft for filling missing taxonomy data

### DIFF
--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -228,11 +228,13 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     # Exclude blanks in taxonomic level (empty strings at the selected taxonomic level)
     taxonomic_level_not_null = "#{taxonomic_level_name} IS NOT NULL"
 
-    check_for_plants = <<-SQL
+    fill_missing_taxonomy = <<-SQL
       CASE
-        WHEN COALESCE(#{taxonomic_level_name}, '') = '' THEN 'Plants'
-        ELSE #{taxonomic_level_name}
-      END AS name,
+        -- There are still taxa with empty kingdom, so adding this condition
+        -- until this is resolved at the database level.
+        WHEN COALESCE(#{taxonomic_level_name}, kingdom_name, '') = '' THEN 'Unknown'
+        ELSE COALESCE(#{taxonomic_level_name}, kingdom_name)
+      END AS name
     SQL
 
     <<-SQL
@@ -241,7 +243,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
         #{child_taxa_query}
         SELECT
           NULL AS id,
-          #{['phylum', 'class'].include?(taxonomic_level) ? check_for_plants : "#{taxonomic_level_name} AS name," }
+          #{fill_missing_taxonomy},
           ROUND(SUM(#{quantity_field}::FLOAT)) AS value,
           #{ancestors_list(taxonomic_level)},
           COUNT(*) OVER () AS total_count
@@ -249,7 +251,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
         WHERE #{@condition} AND
         #{quantity_field} IS NOT NULL
         #{group_name_condition}
-        AND #{taxonomic_level_not_null}
+        --AND #{taxonomic_level_not_null}
         AND #{country_condition}
         AND #{child_taxa_condition}
         GROUP BY #{ancestors_list(taxonomic_level)}


### PR DESCRIPTION
## Description

⚠️ Please do not merge yet. I would like this to be tested properly first and to check that this should be the intended behaviour.

This is to fill gaps within taxonomic data.
For example, there are shipments related to species for which no `class`, `phylum` or even lower level groups are not reported. Those are mostly related to plants, but there are also animals for which taxonomic data is not fully reported.

In some cases also the `kingdom` is still missing.  In this case, data should be fixed at the database level but I've covered this here until that is resolved. 'Unknown' will show when no Kingdom is reported.

[Related codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/182)