### PR TITLE
pass param instead of using promise for transition

### DIFF
--- a/app/assets/javascripts/shared-mixins/custom_transition.js.coffee
+++ b/app/assets/javascripts/shared-mixins/custom_transition.js.coffee
@@ -99,3 +99,29 @@ isNotUndefinedOrNull = (x) ->
             urlParam = paramConfig.urlParam
       
       return urlParam
+
+    getParameterByName: (name, url = window.location.href) ->
+      name = name.replace(/[\[\]]/g, '\\$&')
+      regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+      results = regex.exec(url)
+      if !results
+        return null
+      if !results[2]
+        return ''
+      decodeURIComponent results[2].replace(/\+/g, ' ')
+
+    removeParam: (key, sourceURL) ->
+      rtn = sourceURL.split('?')[0]
+      param = undefined
+      params_arr = []
+      queryString = if sourceURL.indexOf('?') != -1 then sourceURL.split('?')[1] else ''
+      if queryString != ''
+        params_arr = queryString.split('&')
+        i = params_arr.length - 1
+        while i >= 0
+          param = params_arr[i].split('=')[0]
+          if param == key
+            params_arr.splice i, 1
+          i -= 1
+        rtn = rtn + '?' + params_arr.join('&')
+      rtn

--- a/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/search_results_controller.js.coffee
@@ -133,34 +133,31 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
             )
       )
 
-    deleteBatch: ->
+    deleteBatchTransition: ->
       @userCanEdit( =>
-        @customTransitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
-        .then(
-          # resolve
-          (() =>
-            if confirm("This will delete #{@get('total')} shipments. Are you sure?")
-              $.ajax(
-                url: '/trade/shipments/destroy_batch'
-                type: 'POST'
-                data:
-                  filters: @get('controllers.search.searchParams')
-              )
-              .done( (data) =>
-                @flashSuccess(message: "Successfully deleted #{data.rows} shipments.")
-                @send("dataChanged")
-              )
-              .fail( (xhr) =>
-                @flashError(message: 'Error occurred when deleting shipments.')
-                console.log "bad luck: ", xhr.responseText
-              )
-              .always( () =>
-                @set('currentShipment', null)
-                $('.batch-form-modal').modal('hide')
-              )
-          )
-        )
+        @customTransitionToRoute('search.results', {queryParams: $.extend({}, @get('controllers.search.searchParams'), {mode: 'delete'})})
       )
+    
+    deleteBatch: ->
+      if confirm("This will delete #{@get('total')} shipments. Are you sure?")
+        $.ajax(
+          url: '/trade/shipments/destroy_batch'
+          type: 'POST'
+          data:
+            filters: @get('controllers.search.searchParams')
+        )
+        .done( (data) =>
+          @flashSuccess(message: "Successfully deleted #{data.rows} shipments.")
+          @send("dataChanged")
+        )
+        .fail( (xhr) =>
+          @flashError(message: 'Error occurred when deleting shipments.')
+          console.log "bad luck: ", xhr.responseText
+        )
+        .always( () =>
+          @set('currentShipment', null)
+          $('.batch-form-modal').modal('hide')
+        )
 
     editShipment: (shipment) ->
       transaction = @get('transaction')
@@ -168,16 +165,13 @@ Trade.SearchResultsController = Ember.ArrayController.extend Trade.QueryParams, 
       @set('currentShipment', shipment)
       $('.shipment-form-modal').modal('show')
 
-    editBatch: ->
-      @customTransitionToRoute('search.results', {queryParams: @get('controllers.search.searchParams')})
-      .then(
-        # resolve
-        (() =>
-          @get('batchUpdateParams').reset()
-          @set('currentShipment', @get('batchUpdateParams'))
-          $('.batch-form-modal').modal('show')
-        )
-      )
+    editBatchTransition: ->
+      @customTransitionToRoute('search.results', {queryParams: $.extend({}, @get('controllers.search.searchParams'), {mode: 'edit'})})
+    
+    editBatch: -> 
+      @get('batchUpdateParams').reset()
+      @set('currentShipment', @get('batchUpdateParams'))
+      $('.batch-form-modal').modal('show')
 
     updateBatch: ->
       updates = @get('batchUpdateParams').export()

--- a/app/assets/javascripts/trade/routes/search_results_route.js.coffee
+++ b/app/assets/javascripts/trade/routes/search_results_route.js.coffee
@@ -1,4 +1,5 @@
 Trade.SearchResultsRoute = Trade.BeforeRoute.extend Trade.LoadingModal,
+  Trade.CustomTransition
 
   queryParams: {
     taxon_concepts_ids: { refreshModel: true },
@@ -32,6 +33,18 @@ Trade.SearchResultsRoute = Trade.BeforeRoute.extend Trade.LoadingModal,
 
   afterModel: () ->
     @hideLoadingModal()
+    searchResultsController = @controllerFor('search_results')
+    mode = @getParameterByName('mode')
+
+    if mode == 'edit'
+      searchResultsController.send('editBatch')
+    else if mode == 'delete'
+      searchResultsController.send('deleteBatch')
+
+    # So you can open the edit/delete modal again
+    if mode
+      window.history.replaceState({}, 'Search', @removeParam('mode', window.location.href))
+    
 
   actions:
     dataChanged: () ->

--- a/app/assets/javascripts/trade/routes/search_results_route.js.coffee
+++ b/app/assets/javascripts/trade/routes/search_results_route.js.coffee
@@ -48,6 +48,6 @@ Trade.SearchResultsRoute = Trade.BeforeRoute.extend Trade.LoadingModal,
 
   actions:
     dataChanged: () ->
-      @refresh()
+      @customTransitionToRoute('search')
     queryParamsDidChange: (changed, totalPresent, removed) ->
       @refresh()

--- a/app/assets/javascripts/trade/templates/search/results.handlebars
+++ b/app/assets/javascripts/trade/templates/search/results.handlebars
@@ -13,10 +13,10 @@
       <button {{action 'newShipment'}} class="pull-right btn clearfix">
         Add shipment
       </button>
-      <button {{action 'editBatch'}} class="pull-right btn clearfix">
+      <button {{action 'editBatchTransition'}} class="pull-right btn clearfix">
         <i class="icon-pencil"></i>
       </button>
-      <button {{action 'deleteBatch'}} class="pull-right btn clearfix">
+      <button {{action 'deleteBatchTransition'}} class="pull-right btn clearfix">
         <i class="icon-trash"></i>
       </button>
     </div>


### PR DESCRIPTION
Ember seemed to wrap a transition in a promise (or something like this), so that logic could be executed after the transition. Transitions are now real page changes rather than a single page app hybrid...

A parameter is passed to the search results endpoint indicating edit or delete which then triggers the same behaviour as after the promise resolved before.

Note there are bugs around the search results not always matching the selected options and also the selected options do not load from the url, so are out of sync with the results because of this sometimes too. These bugs are on the live site.

To play it safe, data is always reloaded before editing or updating such that it matches the current selected options.

https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/81