### PR TITLE
fix edge popup issue

### DIFF
--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_field_component.js.coffee
@@ -5,10 +5,6 @@ Species.TaxonConceptSearchFieldComponent = Em.TextField.extend
 
   targetObject: Em.computed.alias('parentView')
 
-  focusOut: (event) ->
-    @.$().attr('placeholder', @get('placeholder'))
-    @get('targetObject').hideDropdown() if !@get('targetObject.mousedOver')
-
   keyUp: (event) ->
     Ember.run.cancel(@currentTimeout)
     if event.keyCode == 13

--- a/app/assets/javascripts/species/views/search_form/taxon_concept_search_view.js.coffee
+++ b/app/assets/javascripts/species/views/search_form/taxon_concept_search_view.js.coffee
@@ -16,6 +16,11 @@ Species.TaxonConceptSearchView = Em.View.extend
   showDropdown: () ->
     $('.search fieldset').addClass('parent-focus parent-active')
 
+  didInsertElement: () ->
+    window.addEventListener('click', () =>
+      @hideDropdown() unless @get('mousedOver')
+    )
+
   actions:
     handleTaxonConceptSearchSelection: (autoCompleteTaxonConcept) ->
       @hideDropdown()


### PR DESCRIPTION
Old situtation:

Pop-up only closed on blur from the search input (provided you aren't clicking on the pop-up). If you click on the popup the focus is lost from the search, but popup is not closed. Clicking outside the popup now doesn't do anything because the search isn't losing focus (blur event).

Now:

Listens for all clicks and if the click is not on the popup or search input then the popup closes.

https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/73