### PR TITLE
upgrade sprockets to 2.12.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'redis-rails', '~> 4.0.0'
 
 gem 'whenever', :require => false
 
-gem 'sprockets', '~> 2.12.5'
+gem 'sprockets', '~> 2.12.5' # upgrading to 3 breaks handlebars/tilt
 gem 'ember-rails', '~> 0.14.1'
 gem 'ember-source', '~> 1.6.0'
 gem 'ember-data-source', '0.14'

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'redis-rails', '~> 4.0.0'
 
 gem 'whenever', :require => false
 
-gem 'sprockets', '~> 2.8.0'
+gem 'sprockets', '~> 2.12.5'
 gem 'ember-rails', '~> 0.14.1'
 gem 'ember-source', '~> 1.6.0'
 gem 'ember-data-source', '0.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
     mime-types (1.25.1)
     mini_portile2 (2.4.0)
     minitest (4.7.5)
-    multi_json (1.13.1)
+    multi_json (1.15.0)
     nested-hstore (0.0.5)
       activerecord
       activerecord-postgres-hstore
@@ -444,7 +444,7 @@ GEM
       temple (~> 0.5.5)
       tilt (~> 1.3.3)
     slop (3.4.3)
-    sprockets (2.8.3)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -598,7 +598,7 @@ DEPENDENCIES
   sitemap_generator
   slackistrano
   slim
-  sprockets (~> 2.8.0)
+  sprockets (~> 2.12.5)
   susy (~> 2.2.14)
   test-unit (~> 3.1)
   timecop
@@ -610,3 +610,6 @@ DEPENDENCIES
   wicked (~> 1.3.3)
   wkhtmltopdf-binary (~> 0.9.9)
   yajl-ruby
+
+BUNDLED WITH
+   1.17.3


### PR DESCRIPTION
Can't go to 3 -> handlebars/ember/tilt breaks. 2.12.5 is required by security alert.

https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/32