### PR TITLE
Fix plants grouping

### DIFF
--- a/db/migrate/20210115103657_fix_trade_plus_plants_grouping_in_group_view.rb
+++ b/db/migrate/20210115103657_fix_trade_plus_plants_grouping_in_group_view.rb
@@ -1,0 +1,31 @@
+class FixTradePlusPlantsGroupingInGroupView < ActiveRecord::Migration
+  def up
+    execute "DROP MATERIALIZED VIEW IF EXISTS trade_plus_complete_mview"
+    execute "DROP VIEW IF EXISTS trade_plus_complete_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_final_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_view"
+    execute "DROP VIEW IF EXISTS trade_plus_group_view"
+    execute "DROP VIEW IF EXISTS trade_plus_shipments_view"
+    execute "CREATE VIEW trade_plus_shipments_view AS #{view_sql('20200206150700', 'trade_plus_shipments_view')}"
+    execute "CREATE VIEW trade_plus_group_view AS #{view_sql('20210115103657', 'trade_plus_group_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_view AS #{view_sql('2020070718281', 'trade_plus_formatted_data_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_final_view AS #{view_sql('2020070814429', 'trade_plus_formatted_data_final_view')}"
+    execute "CREATE VIEW trade_plus_complete_view AS #{view_sql('20200707183829', 'trade_plus_complete_view')}"
+    execute "CREATE MATERIALIZED VIEW trade_plus_complete_mview AS SELECT * FROM trade_plus_complete_view"
+  end
+
+  def down
+    execute "DROP MATERIALIZED VIEW IF EXISTS trade_plus_complete_mview"
+    execute "DROP VIEW IF EXISTS trade_plus_complete_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_final_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_view"
+    execute "DROP VIEW IF EXISTS trade_plus_group_view"
+    execute "DROP VIEW IF EXISTS trade_plus_shipments_view"
+    execute "CREATE VIEW trade_plus_shipments_view AS #{view_sql('20200206150700', 'trade_plus_shipments_view')}"
+    execute "CREATE VIEW trade_plus_group_view AS #{view_sql('20191030154249', 'trade_plus_group_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_view AS #{view_sql('20191209215129', 'trade_plus_formatted_data_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_final_view AS #{view_sql('2020070814429', 'trade_plus_formatted_data_final_view')}"
+    execute "CREATE VIEW trade_plus_complete_view AS #{view_sql('20191209215129', 'trade_plus_complete_view')}"
+    execute "CREATE MATERIALIZED VIEW trade_plus_complete_mview AS SELECT * FROM trade_plus_complete_view"
+  end
+end

--- a/db/views/trade_plus_group_view/20210115103657.sql
+++ b/db/views/trade_plus_group_view/20210115103657.sql
@@ -1,0 +1,18 @@
+SELECT
+  ts.*,
+  CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammals'
+  WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Birds'
+  WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+  WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibians'
+  WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Fish'
+  WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Non-coral invertebrates'
+  WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
+  WHEN ts.taxon_concept_genus_name IN ('Aquilaria','Pericopsis','Cedrela','Guaiacum','Swietenia','Dalbergia','Prunus','Gonystylus','Diospyros','Abies','Guarea','Guibourtia','Gyrinops','Platymiscium','Pterocarpus','Taxus') THEN 'Timber'
+  WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Timber'
+  WHEN ts.taxon_concept_class_name IS NULL
+    AND ts.taxon_concept_kingdom_name = 'Plantae'
+    AND ts.taxon_concept_genus_name NOT IN ('Aquilaria','Pericopsis','Cedrela','Guaiacum','Swietenia','Dalbergia','Prunus','Gonystylus','Diospyros','Abies','Guarea','Guibourtia','Gyrinops','Platymiscium','Pterocarpus','Taxus')
+    AND ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor')
+  THEN 'Plants'
+  END AS group
+FROM trade_plus_shipments_view ts

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -64,7 +64,15 @@ module Trade::TradePlusFilters
     json_values << ",'iso2',#{attributes[2]}" if attributes.grep(/iso/).present?
     json_values << ",'code',#{attributes[2]}" if attributes.grep(/code/).present?
     group_by_attrs = attributes.uniq.join(',')
-    "SELECT '#{as}' AS attribute_name, json_build_object(#{json_values})::jsonb AS data FROM #{table_name} #{group_by(group_by_attrs)}"
+
+    # Exclude possible null values for taxonomic groups
+    condition = "WHERE #{attributes[0]} IS NOT NULL" if attributes[0] == 'group_name'
+    <<-SQL
+      SELECT '#{as}' AS attribute_name, json_build_object(#{json_values})::jsonb AS data
+      FROM #{table_name}
+      #{condition}
+      #{group_by(group_by_attrs)}
+    SQL
   end
 
   private


### PR DESCRIPTION
## Description

Update trade_plus_group_view so to group empty class shipments as 'Plants' only if kingdom is 'Plantae'.

Currently you can't select only those kind of shipments, ~~so it has to be agreed whether~~ so it has been agreed that: 

1. leaving things as they are so only being able to fetch those alongside other shipments by not selecting anything in the taxonomic group dropdown

~~2. or adding another item in the taxonomig group list so that is possible to filter by EMPTY taxonomic group.~~

[Related codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/182)