### PR TITLE
Allow to filter by multiple taxa in child_taxa query

### DIFF
--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -134,7 +134,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     WITH child_taxa AS (
       SELECT taxon_concept_id AS id
       FROM all_taxon_concepts_and_ancestors_mview
-      WHERE ancestor_taxon_concept_id = #{tc_id}
+      WHERE ancestor_taxon_concept_id IN (#{tc_id}) -- Multiple taxa can be selected
     )
     SQL
   end


### PR DESCRIPTION
## Description

Quick fix for component request returning null if two taxa are passed (either on country or taxon page).
Child taxa query wasn't taking into account the possibility of having multiple taxa selected.

[Codebase ticket](https://unep-wcmc.codebasehq.com/projects/trade/tickets/190)