### PR TITLE
Aru single edit cancellation

### DIFF
--- a/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
@@ -139,7 +139,7 @@ Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPa
       )
 
     cancelChanges: () ->
-      @get('store').get('currentTransaction').rollback()
+      @get('store').get('defaultTransaction').rollback()
       @clearModifiedFlags()
 
     #### Single shipment related ####

--- a/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
@@ -155,6 +155,7 @@ Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPa
       shipment.setProperties({'_destroyed': true, '_modified': true})
 
     cancelShipmentEdit: (shipment) ->
+      @get('store').get('defaultTransaction').rollback()
       shipment.setProperties(shipment.get('data'))
       @set('currentShipment', null)
       $('.shipment-form-modal').modal('hide')

--- a/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
+++ b/app/assets/javascripts/trade/controllers/sandbox_shipments_controller.js.coffee
@@ -61,6 +61,8 @@ Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPa
 
   actions:
     closeError: ->
+      @get('store').get('defaultTransaction').rollback()
+      @clearModifiedFlags()
       @transitionToParentController()
 
     toggleUpdatesVisible: ->
@@ -155,7 +157,7 @@ Trade.SandboxShipmentsController = Ember.ArrayController.extend Trade.ShipmentPa
       shipment.setProperties({'_destroyed': true, '_modified': true})
 
     cancelShipmentEdit: (shipment) ->
-      @get('store').get('defaultTransaction').rollback()
       shipment.setProperties(shipment.get('data'))
+      shipment.set('_modified', false)
       @set('currentShipment', null)
       $('.shipment-form-modal').modal('hide')


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/39
https://unep-wcmc.codebasehq.com/projects/species-rails-4-upgrade/tickets/41

Rollback changes to all shipments in sandbox when closing the error - this will undo all unsaved changes to rows in the current sandbox.

Also remove modified flag if cancelling a change for a given row. 

Note if you edit a row and click update, don't save and then go back into the edit modal, do nothing and click cancel, it will undo the original update. This should be fine, but worth noting.