### PR TITLE
SAT trade component aggregated over time query

### DIFF
--- a/app/controllers/admin/api_usage_controller.rb
+++ b/app/controllers/admin/api_usage_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ApiUsageController < Admin::AdminController
   def index
     @recent_requests = ApiRequest.recent_requests
-    @users_by_activity = ApiRequest.top_5_most_active_users
+    @users_by_activity = ApiRequest.top_50_most_active_users
   end
 
   def show

--- a/app/controllers/api/v1/eu_decisions_controller.rb
+++ b/app/controllers/api/v1/eu_decisions_controller.rb
@@ -1,0 +1,69 @@
+class Api::V1::EuDecisionsController < ApplicationController
+
+  # makes params available to the ActiveModel::Serializers
+  serialization_scope :view_context
+
+  def index
+    @eu_decisions = eu_decision_search(sanitized_params)
+    render :json => @eu_decisions,
+    :each_serializer => CaptiveBreeding::EuDecisionSerializer
+  end
+
+  private
+
+  def permitted_params
+    params.permit(taxon_concept_ids: [], geo_entity_ids: [])
+  end
+
+  def eu_decision_search(params)
+    list = EuDecision.from('api_eu_decisions_view eu_decisions').
+      select(eu_decision_select_attrs).
+      joins('LEFT JOIN eu_suspensions_applicability_view v ON eu_decisions.id = v.id').
+      order(<<-SQL
+            geo_entity_en->>'name' ASC,
+            start_date DESC
+        SQL
+      )
+
+    list = list.where("eu_decisions.taxon_concept_id IN (?)", params['taxon_concept_ids']) if params['taxon_concept_ids'].present?
+    list = list.where("eu_decisions.geo_entity_id IN (?)", params['geo_entity_ids']) if params['geo_entity_ids'].present?
+
+    list.all
+  end
+
+  def eu_decision_select_attrs
+    string = %{
+            eu_decisions.notes,
+            eu_decisions.start_date,
+            v.original_start_date_formatted,
+            eu_decisions.is_current,
+            eu_decisions.geo_entity_id,
+            eu_decisions.start_event_id,
+            eu_decisions.term_id,
+            eu_decisions.source_id,
+            eu_decisions.eu_decision_type_id,
+            eu_decisions.term_id,
+            eu_decisions.source_id,
+            eu_decisions.nomenclature_note_en,
+            eu_decisions.nomenclature_note_fr,
+            eu_decisions.nomenclature_note_es,
+            eu_decision_type,
+            srg_history,
+            start_event,
+            end_event,
+            geo_entity_en,
+            taxon_concept,
+            term_en,
+            source_en
+          }
+    current_user ? "#{string},\n private_url" : string
+  end
+
+  def sanitized_params
+    filters = permitted_params.inject({}) do |h, (k,v)|
+      h[k] = v.reject(&:empty?).map!(&:to_i)
+      h
+    end
+    filters
+  end
+end

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -75,6 +75,17 @@ class Api::V1::ShipmentsController < ApplicationController
     render json: @over_time_data
   end
 
+  # TODO refactor to merge this method and the over_time one above together
+  def aggregated_over_time_query
+    # TODO Remember to implement permitted parameters here
+    query = @grouping_class.new(sanitized_attributes, params)
+    @aggregated_over_time_data = Rails.cache.fetch(['aggregated_over_time_data', params], expires_in: 1.week) do
+      query.aggregated_over_time_data
+    end
+
+    render json: @aggregated_over_time_data
+  end
+
   def download_data
     @download_data = Rails.cache.fetch(['download_data', params], expires_in: 1.week) do
                        Trade::DownloadDataRetriever.dashboard_download(download_params).to_a

--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -30,7 +30,7 @@ class ApiRequest < ActiveRecord::Base
   RESPONSE_STATUSES = [200, 400, 401, 404, 422, 500]
   CONTROLLERS = ['taxon_concepts', 'distributions', 'cites_legislation', 'eu_legislation', 'references']
 
-  def self.top_5_most_active_users
+  def self.top_50_most_active_users
     subquery = self.recent.select(
       [
         :user_id,

--- a/app/models/api_request.rb
+++ b/app/models/api_request.rb
@@ -21,8 +21,9 @@ class ApiRequest < ActiveRecord::Base
   belongs_to :user
 
   RECENT_DAYS = 90
+  RECENT_MONTHS = 6
 
-  scope :recent, -> { where('created_at > ?', RECENT_DAYS.days.ago) }
+  scope :recent, -> { where('created_at > ?', RECENT_MONTHS.months.ago) }
   scope :by_response_status, -> { group(:response_status) }
   scope :by_controller, -> { group(:controller) }
 
@@ -40,7 +41,7 @@ class ApiRequest < ActiveRecord::Base
     ).group(:user_id).
       where('user_id IS NOT NULL')
     self.from("(#{subquery.to_sql}) api_requests").
-      order('cnt DESC').limit(5)
+      order('cnt DESC').limit(50)
   end
 
   def self.recent_requests(user = nil)

--- a/app/serializers/captive_breeding/eu_decision_serializer.rb
+++ b/app/serializers/captive_breeding/eu_decision_serializer.rb
@@ -1,0 +1,45 @@
+class CaptiveBreeding::EuDecisionSerializer < ActiveModel::Serializer
+  attributes :taxon_concept, :notes, { :start_date_formatted => :start_date },
+    :is_current, :nomenclature_note_en, :nomenclature_note_fr,
+    :nomenclature_note_es,
+    :eu_decision_type,
+    :srg_history,
+    :geo_entity,
+    :start_event,
+    :source,
+    :term,
+    { :original_start_date_formatted => :original_start_date },
+    :private_url
+
+  def taxon_concept
+    object['taxon_concept']
+  end
+
+  def eu_decision_type
+    object['eu_decision_type']
+  end
+
+  def srg_history
+    object['srg_history']
+  end
+
+  def geo_entity
+    { 'id'=> object['geo_entity_id'] }.merge(object['geo_entity_en'])
+  end
+
+  def start_event
+    object['start_event']
+  end
+
+  def source
+    object['source_en']
+  end
+
+  def term
+    object['term_en']
+  end
+
+  def private_url
+    scope.current_user ? object['private_url'] : nil
+  end
+end

--- a/app/views/admin/api_usage/index.html.erb
+++ b/app/views/admin/api_usage/index.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="page-header">
-      <h4>Last <%= ApiRequest::RECENT_DAYS %> Days Requests by Response Status</h4>
+      <h4>Last <%= ApiRequest::RECENT_MONTHS %> Months Requests by Response Status</h4>
     </div>
 
     <%= line_chart sanitise_hash_for_line_graph(@recent_requests),

--- a/app/views/admin/api_usage/index.html.erb
+++ b/app/views/admin/api_usage/index.html.erb
@@ -37,7 +37,7 @@
 <div class="row">
   <div class="span12">
     <div class="page-header">
-      <h4>Top 5 Most Active Users in the last <%= ApiRequest::RECENT_DAYS %> days</h4>
+      <h4>Top 50 Most Active Users in the last <%= ApiRequest::RECENT_MONTHS %> months</h4>
     </div>
     <table class="table">
       <thead>

--- a/app/views/admin/api_usage/show.html.erb
+++ b/app/views/admin/api_usage/show.html.erb
@@ -11,23 +11,23 @@
 
     <table class="table table-striped">
       <tr>
-        <td><span class="text-info">Email:</span></td> 
+        <td><span class="text-info">Email:</span></td>
         <td><%= @user.email %></td>
       </tr>
       <tr>
-        <td><span class="text-info">Organisation:</span></td> 
+        <td><span class="text-info">Organisation:</span></td>
         <td><%= @user.try(:organisation) %></td>
       </tr>
       <tr>
-        <td><span class="text-info">Country:</span></td> 
+        <td><span class="text-info">Country:</span></td>
         <td><%= @user.try(:geo_entity).try(:name_en) %></td>
       </tr>
       <tr>
-        <td><span class="text-info">Role:</span></td> 
+        <td><span class="text-info">Role:</span></td>
         <td><%= @user.role %></td>
       </tr>
       <tr>
-        <td><span class="text-info">Total Successful Requests:</span></td> 
+        <td><span class="text-info">Total Successful Requests:</span></td>
         <td><%= number_with_delimiter @user.api_requests.where(response_status: 200).count, delimiter: ',' %></td>
       </tr>
       <tr>
@@ -35,7 +35,7 @@
         <td><%= number_with_delimiter @user.api_requests.where(response_status: 500).count, delimiter: ',' %></td>
       </tr>
       <tr>
-        <td><span class="text-info">Date Joined:</span></td> 
+        <td><span class="text-info">Date Joined:</span></td>
         <td><%= @user.created_at.to_s(:long) %></td>
       </tr>
     </table>
@@ -45,7 +45,7 @@
 <div class="row">
   <div class="span12">
     <div class="page-header">
-      <h4>Last <%= ApiRequest::RECENT_DAYS %> Days Requests by Response Status</h4>
+      <h4>Last <%= ApiRequest::RECENT_MONTHS %> Months Requests by Response Status</h4>
     </div>
 
     <%= line_chart sanitise_hash_for_line_graph(@recent_requests),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ SAPI::Application.routes.draw do
       get '/shipments/chart' => 'shipments#chart_query'
       get '/shipments/grouped' => 'shipments#grouped_query'
       get '/shipments/over_time' => 'shipments#over_time_query'
+      get '/shipments/aggregated_over_time' => 'shipments#aggregated_over_time_query'
       get '/shipments/country' => 'shipments#country_query'
       get '/shipments/search' => 'shipments#search_query'
       get '/shipments/download' => 'shipments#download_data'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ SAPI::Application.routes.draw do
       resources :sources, :only => [:index]
       resources :purposes, :only => [:index]
       resources :trade_plus_filters, only: :index
+      resources :eu_decisions, only: :index
       resources :documents do
         collection do
           get 'download_zip'

--- a/lib/modules/trade/trade_plus_filters.rb
+++ b/lib/modules/trade/trade_plus_filters.rb
@@ -36,7 +36,7 @@ class Trade::TradePlusFilters
         SELECT id,name_#{locale},iso_code2
         FROM geo_entities
         WHERE geo_entity_type_id IN (1,4,7) --(1,4,7) this is to include both countries, territories and trade entities
-        AND id NOT IN (218,221,277,278) --this is to exclude TW(included into CH), Sudan prior secession and North and South Atlantic stock
+        AND id NOT IN (218,221,277,278,279) --this is to exclude TW(included into CH), Sudan prior secession, North and South Atlantic stock and All stocks
 
       )
       SELECT 'countries' AS attribute_name, json_build_object('id', id, 'name', name_#{locale}, 'iso2', iso_code2)::jsonb AS data

--- a/spec/models/api_request_spec.rb
+++ b/spec/models/api_request_spec.rb
@@ -47,9 +47,9 @@ describe ApiRequest do
     )
   end
 
-  describe :top_5_most_active_users do
+  describe :top_50_most_active_users do
     subject {
-      ApiRequest.top_5_most_active_users
+      ApiRequest.top_50_most_active_users
     }
     specify {
       expect(subject.first.user_id).to eq(api_user.id)


### PR DESCRIPTION
<!-- Complete as far as useful; remove any unused sections/details -->

## Changes

<!-- Table or list. Types: feature, refactor, fix etc (see https://github.com/commitizen/conventional-commit-types/blob/master/index.json). Consider starting description with a verb for clarity if type alone doesn't convey the specific kind of change made -->

| Feat | add endpoint to retrieve aggregated over time data for the "Reported by" tab of the SAT trade component |

### Comments

<!-- E.g. issues that need addressing; PRs to merge first -->

For now, I have implemented this as a new endpoint, ideally, I could have refactored the preexisting endpoint used by Tradeview to also return the aggregated results based on a boolean parameter. This would have required more time to make sure I don't break the preexisting endpoint so I left a couple of TODO comments for future improvement.

This PR also includes this [other one](https://github.com/unepwcmc/SAPI/pull/854), which I merged into this to keep it on staging in case is needed

## Testing

### Steps

<!-- Both for setup and testing user experience -->
I have created this postman collection
[SAT.postman_collection.zip](https://github.com/unepwcmc/SAPI/files/9010604/SAT.postman_collection.zip)
 (they are pointing to localhost, they will need to be edited to point to staging and you might need to add the auth token which I included in the [SAT relative PR](https://github.com/unepwcmc/sustainability-assessment-tool/pull/30).

It contains 3 endpoints:

- the `over_time` one can be used to retrieve data for the source and term tab(see design), by changing the `group_by` param accordingly.
- the `aggregated_over_time` can be used for the Reported by tab(see design); 2 separate calls will be needed to retrieve the reported by exporter and reported by importer data (achieved by changing the `reported_by` param in the query)
- the `trade filters` one is needed to retrieve all the filter options we will need to show on the dropdowns (sources, terms, purposes, units). This is quite a heavy call and it is returning more info than we need for SAT, but for consistency and future-proofing I have left the endpoint as it is.

### Expectations

<!-- E.g. "Form looks like design"; "Form completion redirects to..." -->

- over_time endpoint example response
[over_time_response.json.zip](https://github.com/unepwcmc/SAPI/files/9010755/over_time_response.json.zip)

- aggregated_over_time endpoint example response
[aggregated_over_time_response.json.zip](https://github.com/unepwcmc/SAPI/files/9010756/aggregated_over_time_response.json.zip)

- trade filters example response
[trade_filters.json.zip](https://github.com/unepwcmc/SAPI/files/9010758/trade_filters.json.zip)


## Links

<!-- Convert to lists if multiple features/pages and/or Codebase tickets -->

**Design:** [trade component](https://xd.adobe.com/view/7e4cebbc-a0ce-44c7-9383-789739ce3bea-2b1f/screen/3a6ad1ac-5f40-4f0f-b76e-4fab0f065ac7/specs/)

**Codebase:** [Ticket 81](https://unep-wcmc.codebasehq.com/projects/sustainability-assessment-tool/tickets/81)