### PR TITLE
feat: Replace letters with diactritics (e.g., ä ö ü É é) during geoen…

### DIFF
--- a/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
+++ b/app/assets/javascripts/species/mixins/geo_entity_auto_complete_lookup.js.coffee
@@ -6,14 +6,17 @@ Species.GeoEntityAutoCompleteLookup = Ember.Mixin.create
   selectedGeoEntitiesIds: []
 
   geoEntityQueryObserver: ( ->
-    re = new RegExp("(^|\\(| )"+@get('geoEntityQuery'),"i")
+    removeDiactritics = (string) -> string.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+    query = removeDiactritics(@get('geoEntityQuery'));
+
+    re = new RegExp("(^|\\(| )"+query,"i")
     @set 'autoCompleteCountries', @get('geoEntities.countries').filter (item, index, enumerable) =>
-      re.test item.get('name')
+      re.test removeDiactritics(item.get('name'));
 
-    re = new RegExp("^[0-9]- "+@get('geoEntityQuery'),"i")
-
+    re = new RegExp("^[0-9]- "+query,"i")
     @set 'autoCompleteRegions', @get('geoEntities.regions').filter (item, index, enumerable) =>
-      re.test item.get('name')
+      re.test removeDiactritics(item.get('name'));
   ).observes('geoEntityQuery')
 
   geoEntitiesObserver: ( ->


### PR DESCRIPTION
…tity filtering, so geoentities can be filtered using only english alphabet

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/127

not much to add beyond the title.
Country name changes mean we need to be able to search by english only letters, which would not match e.g "Türk" with "Turk".
This removes diacritics from characters when comparing them in the filter

NOTE: didn't see this https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/121, which might mean we are moving all searches to elastic search or something that can handle partial matching? so might make this ticket obsolete
