### PR TITLE
fix: disable clear_show_tc_serializer_cache method on production. del…

### DIFF
--- a/app/models/change_observer.rb
+++ b/app/models/change_observer.rb
@@ -48,7 +48,13 @@ class ChangeObserver < ActiveRecord::Observer
   end
 
   def clear_show_tc_serializer_cache
-    Rails.cache.delete_matched('*ShowTaxonConceptSerializer*')
+    ##
+    # Disabling because we use memcache on production, but memcache doesn't implement this method.
+    # For now, changes to records that appear in serializers will not change until the caches are expired,
+    # which is 24 hours. Possible solution:
+    # https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/114
+
+    Rails.cache.delete_matched('*ShowTaxonConceptSerializer*') unless Rails.env.production?
   end
 
   def bump_dependents_timestamp(taxon_concept, updated_by_id)


### PR DESCRIPTION
…ete_matched is not implemented on memcache, so preventing admins from changing site data. This disables it, which means it will work, but changes won't be reflected in serialized search results until the cache expires (24 hours). possible solution https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/114

tha dalli delete matched gem didn't work, so just disabling this for now