### PR TITLE
chore: add gems to support next gen keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :development do
   gem 'git_pretty_accept'
   gem 'rubocop', '~> 0.40.0', require: false
   gem 'letter_opener'
-  gem 'bcrypt_pbkdf'
+  gem 'bcrypt_pbkdf', '~> 1.0.0'
   gem 'ed25519'
   # @TODO: bring back when ruby updated to > 2.6 # gem 'net-ssh', '7.0.0.beta1' # openssl 3.0 compatibility @see https://stackoverflow.com/q/72068406/1090438
 end
@@ -164,3 +164,7 @@ gem 'sitemap_generator'
 
 gem 'appsignal'
 gem 'test-unit', '~> 3.1' # annoyingly, rails console won't start without it in staging / production
+
+# support new gen ssh keys
+gem 'rbnacl', '~> 3.2'
+gem 'rbnacl-libsodium'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       ember-source (>= 1.0, < 3.1)
       execjs (>= 1.2, < 3)
     bcrypt (3.1.12)
-    bcrypt_pbkdf (1.1.0)
+    bcrypt_pbkdf (1.0.1)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -193,6 +193,7 @@ GEM
     factory_girl_rails (4.2.1)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
+    ffi (1.15.5)
     font-awesome-rails (4.5.0.1)
       railties (>= 3.2, < 5.1)
     foreigner (1.5.0)
@@ -352,6 +353,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.0.4)
+    rbnacl (3.4.0)
+      ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     redis (3.3.0)
     redis-actionpack (4.0.1)
       actionpack (~> 4)
@@ -514,7 +519,7 @@ DEPENDENCIES
   annotate (>= 2.5.0)
   appsignal
   aws-sdk (~> 2)
-  bcrypt_pbkdf
+  bcrypt_pbkdf (~> 1.0.0)
   better_errors (~> 1.1.0)
   binding_of_caller (>= 0.7.2)
   bootstrap-sass (~> 2.3.2.2)
@@ -584,6 +589,8 @@ DEPENDENCIES
   rails-observers
   rails-secrets (~> 1.0.2)
   rake (~> 10.0.3)
+  rbnacl (~> 3.2)
+  rbnacl-libsodium
   redis-rails (~> 4.0.0)
   request_store (~> 1.1)
   rest-client


### PR DESCRIPTION
add gems supporting newer ssh keys for capistrano deployment.