### PR TITLE
feat: Change stying of 'New' text, add link to CITES Trade View to li…

### DIFF
--- a/app/assets/stylesheets/cites_trade/citestrade.css
+++ b/app/assets/stylesheets/cites_trade/citestrade.css
@@ -63,5 +63,5 @@ padding: 3px 3px;
 }
 
 .new {
-  text-transform: uppercase;
+  color: #9C1452;
 }

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -190,7 +190,7 @@
     <strong><%= t('download') %>:</strong>
     <a href="/cites_trade_guidelines/<%= I18n.locale %>-CITES_Trade_Database_Guide.pdf"><%= t('db_guide') %></a>
     <% if I18n.locale == :en %>
-      <i class="new"><%= t('new') %></i>
+      <strong class="new">*<%= t('new') %>*</strong>
     <% end %>
   </p>
   <% unless I18n.locale == :en %>

--- a/app/views/layouts/cites_trade.html.erb
+++ b/app/views/layouts/cites_trade.html.erb
@@ -68,6 +68,7 @@
   <a href="http://www.cites.org">CITES</a> |
   <a href="http://www.unep-wcmc.org">UNEP-WCMC</a> |
   <a href="https://www.speciesplus.net">Species+</a> |
+  <a href="https://tradeview.cites.org/<%= I18n.locale.to_s %>">CITES Wildlife TradeView</a> |
   <a href="mailto:species@unep-wcmc.org" target="_blank"> Contact Us </a>
   </font>
   </div>


### PR DESCRIPTION
…nks list

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/128

changes styling of adds links that point to different language pages of CITES Trade View

Testing:
go to http://localhost:3000/en/cites_trade
see maroon New
click CITES Wildlife Tradeview link, so to english landing page

go to http://localhost:3000/es/cites_trade
click CITES Wildlife Tradeview link, so to spanish landing page

go to http://localhost:3000/fr/cites_trade
click CITES Wildlife Tradeview link, so to french landing page