### PR TITLE
fix: add term code to data and fix term capitalisation

### DIFF
--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -344,7 +344,11 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
       next if attribute == 'year' || attribute.nil?
       name = attribute.include?('id') ? 'id' : attribute.include?('iso') ? 'iso2' : attribute.include?('code') ? 'code' : 'name'
       @sanitised_column_names << name
-      attribute = "INITCAP(#{attribute})" if attribute == 'term_en'
+
+      if attribute == "term_#{@locale}"
+        attribute = "UPPER(SUBSTRING(#{attribute} from 1 for 1)) || LOWER(SUBSTRING(#{attribute} from 2))"
+      end
+
       "#{attribute} AS #{name}"
     end.compact.uniq.join(',')
   end

--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -71,6 +71,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
     importer_iso: 'importer_iso',
     exporter_iso: 'exporter_iso',
     term_id: 'term_id',
+    term_code: 'term_code',
     unit_id: 'unit_id',
     purpose_id: 'purpose_id',
     source_id: 'source_id',
@@ -140,7 +141,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
 
   def self.localize_grouping_attributes
     {
-      terms: ["term_#{@locale}", 'term_id'],
+      terms: ["term_#{@locale}", 'term_id', 'term_code'],
       sources: ["source_#{@locale}", 'source_id', 'source_code'],
       exporting: ["exporter_#{@locale}", 'exporter_iso'],
       importing: ["importer_#{@locale}", 'importer_iso'],
@@ -343,7 +344,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
       next if attribute == 'year' || attribute.nil?
       name = attribute.include?('id') ? 'id' : attribute.include?('iso') ? 'iso2' : attribute.include?('code') ? 'code' : 'name'
       @sanitised_column_names << name
-      attribute = "INITCAP(#{attribute})" if attribute == 'term'
+      attribute = "INITCAP(#{attribute})" if attribute == 'term_en'
       "#{attribute} AS #{name}"
     end.compact.uniq.join(',')
   end


### PR DESCRIPTION
This adds the term code to trade_over_time endpoint, so that the code can be shown in the frontend of SAT in the legend items.

Also I think fixes the issue of the first letter of the terms not being capitalised.

Linked PR: https://github.com/unepwcmc/sustainability-assessment-tool/pull/56

NOTE: TdV needs this PR on prod before this goes to prod: https://github.com/unepwcmc/tradeplus/pull/93