### PR TITLE
feat: add EU option to importer/exporter WIP

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -1,15 +1,8 @@
-//TODO: align with backend
-const EU_OPTION = {
-  geo_entity_type: 'REGION',
-  id: 1001,
-  iso_code2: 'EU',
-  name: 'European Union'
-}
-
 $(document).ready(function(){
 
   var ajaxFail, initExpctyImpcty, initTerms, initSources, initPurposes,
     countries = {}, units = {}, terms = {}, purposes = {}, sources = {},
+    euId = '',
     selected_taxa = '',
     is_search_page = $('#form_expert').length > 0,
     is_download_page = $('#net_gross_options').length > 0,
@@ -112,13 +105,6 @@ $(document).ready(function(){
 
   function getParamsFromInputs(){
     var values = parseInputs($('#form_expert :input'));
-
-    // TODO: add required logic here
-    ['exporters_ids', 'importers_ids'].forEach(function (key) {
-      if (isEuInArray(values[key])) {
-        console.log('Getting params: ' + key + ' contains EU.')
-      }
-    })
 
     return $.param({'filters': values});
   }
@@ -248,6 +234,10 @@ $(document).ready(function(){
   initCountriesObj = function (data) {
     _.each(data.geo_entities, function (country) {
       countries[country.id] = country;
+
+      if (country.iso_code2 == 'EU') {
+        euId = country.id.toString()
+      }
     });
     unLock('initCountriesObj');
   }
@@ -274,8 +264,6 @@ $(document).ready(function(){
   }
 
   initExpctyImpcty = function (data) {
-    data.geo_entities.push(EU_OPTION)
-    // TODO: Sort if required
   	var args = {
   	  	data: data.geo_entities,
   	  	condition: function (item) {return item.iso_code2},
@@ -513,7 +501,7 @@ $(document).ready(function(){
   }
 
   function isEuInArray (array) {
-    return array.indexOf(EU_OPTION.id.toString()) >= 0
+    return array.indexOf(euId) >= 0
   }
 
   $('#side .ui-button, #form .ui-button').hover(function() {

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -1,3 +1,11 @@
+//TODO: align with backend
+const EU_OPTION = {
+  geo_entity_type: 'REGION',
+  id: 1001,
+  iso_code2: 'EU',
+  name: 'European Union'
+}
+
 $(document).ready(function(){
 
   var ajaxFail, initExpctyImpcty, initTerms, initSources, initPurposes,
@@ -104,6 +112,14 @@ $(document).ready(function(){
 
   function getParamsFromInputs(){
     var values = parseInputs($('#form_expert :input'));
+
+    // TODO: add required logic here
+    ['exporters_ids', 'importers_ids'].forEach(function (key) {
+      if (values[key].indexOf(EU_OPTION.id.toString()) > 0) {
+        console.log('Getting params: ' + key + ' contains EU.')
+      }
+    })
+
     return $.param({'filters': values});
   }
 
@@ -257,6 +273,8 @@ $(document).ready(function(){
   }
 
   initExpctyImpcty = function (data) {
+    data.geo_entities.push(EU_OPTION)
+    // TODO: Sort if required
   	var args = {
   	  	data: data.geo_entities,
   	  	condition: function (item) {return item.iso_code2},

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -490,12 +490,18 @@ $(document).ready(function(){
     ['imp', 'exp'].forEach(function (type) {
       const disclaimerEl = $('#eu_disclaimer_' + type)
 
-      hasEuDisclaimer(type) ? disclaimerEl.show() : disclaimerEl.hide()
+      if (disclaimerEl.length) {
+        hasEuDisclaimer(type) ? disclaimerEl.show() : disclaimerEl.hide()
+      }
     })
   }
 
   function hasEuDisclaimer (type) {
     const selections = $('#'+ type + 'cty').val()
+
+    if (!selections) {
+      return false
+    }
 
     return isEuInArray(selections)
   }

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -115,7 +115,7 @@ $(document).ready(function(){
 
     // TODO: add required logic here
     ['exporters_ids', 'importers_ids'].forEach(function (key) {
-      if (values[key].indexOf(EU_OPTION.id.toString()) > 0) {
+      if (isEuInArray(values[key])) {
         console.log('Getting params: ' + key + ' contains EU.')
       }
     })
@@ -199,6 +199,7 @@ $(document).ready(function(){
   $('#reset_search').click(function() {
   	resetSelects();
   	show_values_selection();
+    setEuDisclaimerVisibility();
     // Removing the table results on reset
     $("#query_results_table").find('thead,tbody').remove();
     $('#query_results').find('p.info').text('');
@@ -306,6 +307,7 @@ $(document).ready(function(){
     		selection = getText(new_array);
     	}
     	$('#expcty_out').text(selection);
+      setEuDisclaimerVisibility();
     });
 
     populateSelect(_.extend(args, {
@@ -333,6 +335,7 @@ $(document).ready(function(){
     		selection = getText(new_array);
     	}
     	$('#impcty_out').text(selection);
+      setEuDisclaimerVisibility();
     });
   };
 
@@ -495,6 +498,24 @@ $(document).ready(function(){
   	$('#genus_all_id').val();
   };
 
+  function setEuDisclaimerVisibility () {
+    ['imp', 'exp'].forEach(function (type) {
+      const disclaimerEl = $('#eu_disclaimer_' + type)
+
+      hasEuDisclaimer(type) ? disclaimerEl.show() : disclaimerEl.hide()
+    })
+  }
+
+  function hasEuDisclaimer (type) {
+    const selections = $('#'+ type + 'cty').val()
+
+    return isEuInArray(selections)
+  }
+
+  function isEuInArray (array) {
+    return array.indexOf(EU_OPTION.id.toString()) >= 0
+  }
+
   $('#side .ui-button, #form .ui-button').hover(function() {
   	$(this).toggleClass('ui-state-hover');
   });
@@ -629,6 +650,7 @@ $(document).ready(function(){
   }
 
   show_values_selection();
+  setEuDisclaimerVisibility();
 
   $('#qryFrom, #qryTo').on('change',function() {
   	var y_from = $('#qryFrom').val();

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -20,14 +20,6 @@ $(document).ready(function(){
   	$.jGrowl(text);
   };
 
-  function growlMeSticky(text){
-  	$.jGrowl(text, {sticky: true});
-  };
-
-  function notyNormal(message){
-  	noty({layout: 'topRight', text: message, timeout: 4000});
-  };
-
   function notySticky(message){
   	noty({ layout: 'top',
    			   type: 'information',
@@ -75,17 +67,6 @@ $(document).ready(function(){
 	  //prevent form support on input and select enter
 	  $('input,select').keypress(function(event) { return event.keyCode != 13; });
   };
-
-  function fixTaxonId (arr) {
-    return _.map(arr, function (obj) {
-      if (obj.name === 'taxon_concepts_ids[]') {
-        return {name: 'taxon_concepts_ids[]', value: selected_taxa};
-      } else {
-        return obj;
-      }
-    });
-  }
-
 
   function parseInputs ($inputs) {
     var values = {};
@@ -204,17 +185,6 @@ $(document).ready(function(){
   		bgColor: '#E6EDD7',
   		hoverColor: '#D2EF9A'
   });
-
-
-  function getSelectionTextNew(source) {
-  	var values = [];
-
-  	$('#ms-' + source).find('div.ms-selection ul.ms-list  li').each(function() {
-      values.push($(this).text());
-    });
-
-  	return values.join(',')
-  }
 
   function getSelectionText(source) {
   	myValues = new Array();
@@ -470,11 +440,6 @@ $(document).ready(function(){
   function show_values_selection() {
   	var year_from = $('#qryFrom').val();
   	var year_to = $('#qryTo').val();
-  	var exp_cty = $('#expctyms2side__dx').text();
-  	var imp_cty = $('#impctyms2side__dx').text();
-  	var sources = $('#sourcesms2side__dx').text();
-  	var purposes = $('#purposesms2side__dx').text();
-  	var terms = $('#termsms2side__dx').text();
 
   	$('#year_from > span').text(year_from);
     $('#year_to > span').text(year_to);
@@ -541,18 +506,6 @@ $(document).ready(function(){
       };
     // 'red collared' should highlight 'red-collared'
     return taxonDisplayName.replace(new RegExp("(" + term + '|' + termWithHyphens+ ")", "gi"), transform);
-  }
-
-  function parseTaxonData (data, term, showSpp) {
-    var d = data.auto_complete_taxon_concepts;
-  	return _.map(d, function (element, index) {
-      var displayName = getTaxonDisplayName(element, showSpp)
-  	  return {
-        'value': element.id,
-        'label': displayName,
-        'drop_label': getTaxonLabel(displayName, term)
-      };
-  	});
   }
 
   function parseTaxonCascadeData(data, term, showSpp) {

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -599,12 +599,29 @@ $(document).ready(function(){
   show_values_selection();
   setEuDisclaimerVisibility();
 
-  $('#qryFrom, #qryTo').on('change',function() {
-  	var y_from = $('#qryFrom').val();
-  	var y_to = $('#qryTo').val();
-    $('#year_from > span').text(y_from);
-    $('#year_to > span').text(y_to);
+  $('#qryFrom, #qryTo').on('change', function(e) {
+    year_range = handleYearRangeChange(e.target.id)
+
+    $('#year_from > span').text(year_range[0])
+    $('#year_to > span').text(year_range[1])
   });
+
+  function handleYearRangeChange (id) {
+    var y_from = $('#qryFrom').val()
+  	var y_to = $('#qryTo').val()
+
+    if (y_from > y_to) {
+      if (id === 'qryFrom') {
+        y_to = y_from
+        $('#qryTo').val(y_to)
+      } else {
+        y_from = y_to
+        $('#qryFrom').val(y_from)
+      }
+    }
+
+    return [y_from, y_to]
+  }
 
   //Put functions to be executed here
   initialiseControls();

--- a/app/assets/stylesheets/cites_trade/citestrade.css
+++ b/app/assets/stylesheets/cites_trade/citestrade.css
@@ -21,6 +21,10 @@ font-weight:700;
 padding: 3px 3px;
 }
 
+.select_notes {
+  margin-top: 10px;
+}
+
 .banner {
   background-color: #ac9e89;
   width: 95%;

--- a/app/models/geo_entity_type.rb
+++ b/app/models/geo_entity_type.rb
@@ -20,7 +20,7 @@ class GeoEntityType < ActiveRecord::Base
     "1" => [CITES_REGION], # CITES Checklist
     "2" => [COUNTRY, TERRITORY], # CITES Checklist
     "3" => [CITES_REGION, COUNTRY, TERRITORY], # Species+
-    "4" => [COUNTRY, TERRITORY, TRADE_ENTITY], # CITES Trade
+    "4" => [COUNTRY, REGION, TERRITORY, TRADE_ENTITY], # CITES Trade
     "5" => [COUNTRY, TERRITORY] # E-library
   }
   CURRENT_ONLY_SETS = ['3']

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -89,7 +89,7 @@
               <option selected value="all_exp"> <%= t('all_countries') %> </option>
             </select>
           </div>
-          <div id="eu_disclaimer_exp">
+          <div id="eu_disclaimer_exp" class="select_notes">
             <%= t('eu_disclaimer') %>
           </div>
         </div>
@@ -102,7 +102,7 @@
               <option selected value="all_imp"> <%= t('all_countries') %> </option>
             </select>
           </div>
-          <div id="eu_disclaimer_imp">
+          <div id="eu_disclaimer_imp" class="select_notes">
             <%= t('eu_disclaimer') %>
           </div>
         </div>

--- a/app/views/cites_trade/home/index.html.erb
+++ b/app/views/cites_trade/home/index.html.erb
@@ -89,6 +89,9 @@
               <option selected value="all_exp"> <%= t('all_countries') %> </option>
             </select>
           </div>
+          <div id="eu_disclaimer_exp">
+            <%= t('eu_disclaimer') %>
+          </div>
         </div>
         <div id="tabs-imp">
           <div class="label_style"> <%= t('import_text') %>:
@@ -98,6 +101,9 @@
             <select id="impcty" class="multi_countries" multiple="multiple"  name="importers_ids[]">
               <option selected value="all_imp"> <%= t('all_countries') %> </option>
             </select>
+          </div>
+          <div id="eu_disclaimer_imp">
+            <%= t('eu_disclaimer') %>
           </div>
         </div>
         <div id="tabs-source">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
   taxon_search: "Search for species or higher taxon"
   genus_title: "Search for genus:"
 
+  eu_disclaimer: 'This is the EU disclaimer text explaining how the EU selection works.'
+
   all_countries: "All Countries"
   all_sources: "All Sources"
   all_purposes: "All Purposes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
   taxon_search: "Search for species or higher taxon"
   genus_title: "Search for genus:"
 
-  eu_disclaimer: 'This is the EU disclaimer text explaining how the EU selection works.'
+  eu_disclaimer: "Selection of 'European Union' will include trade data involving countries that were EU Member States at the time of trade (i.e. the year range of the query). Where the year range includes a country’s year of accession to/exit from the European Union, all trade relevant to the search query reported for that country and year will be included within the search results even if the accession/exit date was partway through that year."
 
   all_countries: "All Countries"
   all_sources: "All Sources"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -31,6 +31,8 @@ es:
   taxon_search: "Buscar por especie o grupo taxonómico"
   genus_title: "Seleccione un género:"
 
+  eu_disclaimer: "Selection of 'European Union' will include trade data involving countries that were EU Member States at the time of trade (i.e. the year range of the query). Where the year range includes a country’s year of accession to/exit from the European Union, all trade relevant to the search query reported for that country and year will be included within the search results even if the accession/exit date was partway through that year."
+
   all_countries: "Todos los Países"
   all_sources: "Todos los Orígenes"
   all_purposes: "Todos los Objetivos"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,6 +31,8 @@ fr:
   taxon_search: "Recherche par espèce ou taxon supérieur"
   genus_title: "Sélectionnez un genre"
 
+  eu_disclaimer: "Selection of 'European Union' will include trade data involving countries that were EU Member States at the time of trade (i.e. the year range of the query). Where the year range includes a country’s year of accession to/exit from the European Union, all trade relevant to the search query reported for that country and year will be included within the search results even if the accession/exit date was partway through that year."
+
   all_countries: "Tous les Pays"
   all_sources: "Toutes les Sources"
   all_purposes: "Tous les Buts"


### PR DESCRIPTION
Very basic starting point.

1. Adds EU option to the importer and exporter selects. The option is configured with these details, but all can be changed:
```
{
  geo_entity_type: 'REGION',
  id: 1001,
  iso_code2: 'EU',
  name: 'European Union'
}
```
2. Check the params before sending backend request to determine whether EU is selected. If so, console log (which can be replaced with whatever functionality is required for the backend)
3. Add very simple (unstyled) disclaimer text to show when EU is selected in importer and exporter tabs.

![Screenshot 2022-10-13 at 09 44 30](https://user-images.githubusercontent.com/39922722/195548333-508af8dc-af61-4058-9065-e41e29520b7f.png)
