### PR TITLE
fix: add UNR source code to data

### DIFF
--- a/lib/modules/trade/grouping/trade_plus_static.rb
+++ b/lib/modules/trade/grouping/trade_plus_static.rb
@@ -29,7 +29,7 @@ class Trade::Grouping::TradePlusStatic < Trade::Grouping::Base
 
   def sanitise_response_over_time_query(response)
     response.map do |value|
-      value['id'], value['name'] = 'unreported', I18n.t('tradeplus.unreported') if value['id'].nil?
+      value['id'], value['name'], value['code'] = 'unreported', I18n.t('tradeplus.unreported'), 'UNR' if value['id'].nil?
     end
     response.sort_by { |i| i['name'] }
     response.partition { |value| value['id'] != 'unreported' }.reduce(:+)


### PR DESCRIPTION
Affects TradeView and SAT - fix is intended for SAT. See codebase ticket for TdV considerations.

Adds UNR code to source data to match the filters (which have UNR code next to the unreported source)

https://unep-wcmc.codebasehq.com/projects/sustainability-assessment-tool/tickets/112