### PR TITLE
fix: allow searching for countries with non-standard characters in tr…

### DIFF
--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -256,6 +256,35 @@ $(document).ready(function(){
     unLock('initSourcesObj');
   }
 
+  removeCasingAndDiacritics = function (value) {
+    return value.toString()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036F]/g, '')
+      .toLowerCase()
+  }
+
+  matchWithDiacritics = function (term, text) {
+    // If there are no search terms, return all of the data
+    if ($.trim(term) === '') {
+      return text;
+    }
+
+    // Do not display the item if there is no 'text' property
+    if (typeof text === 'undefined') {
+      return null;
+    }
+
+    var searchTerm = removeCasingAndDiacritics(term)
+    var optionText = removeCasingAndDiacritics(text)
+
+    if (optionText.indexOf(searchTerm) > -1) {
+      return text;
+    }
+
+    // Return `null` if the term should not be displayed
+    return null;
+  }
+
   initExpctyImpcty = function (data) {
   	var args = {
   	  	data: data.geo_entities,
@@ -272,7 +301,8 @@ $(document).ready(function(){
     $('#expcty').select2({
     	width: '75%',
     	allowClear: false,
-    	closeOnSelect: false
+    	closeOnSelect: false,
+      matcher: matchWithDiacritics
     }).on('change', function(e){
     	var selection = "";
     	if (e.val.length == 0) {
@@ -298,7 +328,8 @@ $(document).ready(function(){
     $('#impcty').select2({
     	width: '75%',
     	allowClear: false,
-    	closeOnSelect: false
+    	closeOnSelect: false,
+      matcher: matchWithDiacritics
     }).on('change', function(e){
     	selection = "";
     	if (e.val.length == 0) {


### PR DESCRIPTION
Allows searching for non-standard characters in the importer and exporter selects on the trade database page.

Frontend only solution. If the backend is updated then I think the selects can be configured with a url so that filtering happens in the backend.

https://select2.github.io/select2/

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/155