### PR TITLE
fix: table link to external site not visible in table

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_cites_processes.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_cites_processes.handlebars
@@ -71,23 +71,23 @@
   {{#if historicCitesProcesses}}
     <div {{bind-attr class=":historic controller.citesProcessesExpanded::hidden"}}>
       <table summary="data table">
-            <thead>
-              <tr>
-                <th class="col2">&nbsp;</th>
-                <th class="col14">&nbsp;</th>
-                <th class="col2">&nbsp;</th>
-                <th class="col14">&nbsp;</th>
-                <th class="col2">&nbsp;</th>
-              </tr>
-            </thead>
+        <thead>
+          <tr>
+            <th class="col2">&nbsp;</th>
+            <th class="col14">&nbsp;</th>
+            <th class="col2">&nbsp;</th>
+            <th class="col14">&nbsp;</th>
+            <th class="col2">&nbsp;</th>
+          </tr>
+        </thead>
         <tbody {{bind-attr class="controller.citesProcessExpanded:historic_expanded"}}>
           {{#each process in historicCitesProcesses}}
             <tr>
               <td>
-               {{process.resolution}}
+                {{process.resolution}}
               </td>
               <td>
-               {{process.geo_entity.name}}
+                {{process.geo_entity.name}}
               </td>
               <td>
                 {{#if process.start_event_name}}
@@ -96,22 +96,26 @@
                   {{process.start_date}}
                 {{/if}}
               </td>
-             <td>
-              {{process.status}}
-             </td>
-             <td class="last">
-               {{#ifEquals process.resolution 'Significant trade'}}
-                 <a class="legal-links" href="{{unbound process.document}}" target="_blank">
-                   CITES RST Management System
-                 </a>
-               {{else}}
-                 {{process.notes}}
-                 <br /><br />
-                 <a class="legal-links" href="{{unbound process.document}}">
-                   {{process.document_title}}
-                 </a>
-               {{/ifEquals}}
-             </td>
+              <td>
+                {{process.status}}
+              </td>
+              <td class="last">
+                {{#ifEquals process.resolution 'Significant Trade'}}
+                  {{#if process.document}}
+                    <a class="legal-links" href="{{unbound process.document}}" target="_blank">
+                      CITES RST Management System
+                    </a>
+                  {{/if}}
+                {{else}}
+                  {{process.notes}}
+                  {{#if process.document}}
+                    <br /><br />
+                    <a class="legal-links" href="{{unbound process.document}}">
+                      {{process.document_title}}
+                    </a>
+                  {{/if}}
+                {{/ifEquals}}
+              </td>
             </tr>
           {{/each}}
         </tbody>

--- a/lib/modules/api_clients/rst_api.rb
+++ b/lib/modules/api_clients/rst_api.rb
@@ -8,7 +8,9 @@ module ApiClients::RstApi
     RETRIES = 3
 
     # @see https://api-cites-rst.leman.un-icc.cloud/api/#/case/CaseController_readCases
-    def get_cases(page = 1, per_page = 25)
+    # Pagination on the CITES API is buggy, and when requesting a smaller amount of records
+    # not all records are returned across the pages
+    def get_cases(page = 1, per_page = 250)
       RETRIES.times do |i|
         res = HTTParty.post("#{BASE_URI}/#{PUBLIC_CASES_ENDPOINT}?page=#{page}&limit=#{per_page}&sortBy=id&sortOrder=ASC&relationalData=yes", {})
         break res if res.created? # a POST returns 201 CREATED as successful status


### PR DESCRIPTION
For some reason the link in the RST table for non-active RSTs was not being rendered correctly, and so was missing,

Testing:

http://localhost:3000/species#/taxon_concepts/4997/legal

should see link next to record after clicking to see historic RST records