### PR TITLE
feat: Add unaccent extension to Postgres, use it to filter geoentity …

### DIFF
--- a/app/controllers/api/v1/geo_entities_controller.rb
+++ b/app/controllers/api/v1/geo_entities_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::GeoEntitiesController < ApplicationController
 
   def index
     @geo_entities = GeoEntitySearch.new(
-      params.slice(:geo_entity_types_set, :locale)
+      params.slice(:geo_entity_types_set, :locale, :query_string)
     ).cached_results
     render :json => @geo_entities,
       :each_serializer => Species::GeoEntitySerializer,

--- a/app/models/geo_entity_search.rb
+++ b/app/models/geo_entity_search.rb
@@ -30,6 +30,8 @@ class GeoEntitySearch
       geo_entity_types_set: @geo_entity_types_set,
       locale: @locale
     }
+    @query_string = options[:query_string]
+    @options.merge!(query_string: @query_string) if @query_string.present?
   end
 
   def initialize_query
@@ -44,6 +46,9 @@ class GeoEntitySearch
     unless geo_entity_types.empty?
       @query = @query.
         where('geo_entity_types.name' => geo_entity_types)
+    end
+    if @query_string.present?
+      @query = @query.where("unaccent(name_#{@locale}) ILIKE unaccent(:q)", q: "%#{@query_string}%")
     end
   end
 end

--- a/db/migrate/20230620110017_setup_unaccent.rb
+++ b/db/migrate/20230620110017_setup_unaccent.rb
@@ -1,0 +1,17 @@
+class SetupUnaccent < ActiveRecord::Migration
+  def self.up
+    if Rails.env.staging? or Rails.env.production?
+      puts "Please add extension by hand: CREATE EXTENSION unaccent"
+    else
+      execute "CREATE EXTENSION IF NOT EXISTS unaccent"
+    end
+  end
+
+  def self.down
+    if Rails.env.staging? or Rails.env.production?
+      puts "Please drop extension by hand: DROP EXTENSION unaccent"
+    else
+      execute "DROP EXTENSION unaccent"
+    end
+  end
+end


### PR DESCRIPTION
…by name

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/127

Adds Postgres extension `unaccent`
uses it to filter by query_string if one is submitted

testing:
`rake db:migrate`
in console:
```
GeoEntity.find_by(name_en: 'Turkey').update(name: 'Türkiye')
params = { geo_entity_types_set: nil, locale: nil, query_string: 'turkiye' }

@geo_entities = GeoEntitySearch.new(
  params.slice(:geo_entity_types_set, :locale, :query_string)
).results
```