### PR TITLE
fix: paginate results of query generated by DocumentSearch in documen…

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -78,8 +78,17 @@ class Admin::DocumentsController < Admin::StandardAuthorizationController
   protected
 
   def collection
+    # Super hacky. Pagination has been disabled in the DocumentSearch class
+    # for some reason related to the API documents endpoint and a 'new cascading feature'.
+    # As a result ~8000 records are returned in the results part of the Kaminari::PaginatableArray,
+    # triggering > 15000 database calls in the view.
+    # Here I am using the pagination initialized on the search class to paginate the results,
+    # so for both the web and API actions, pagination is broken in the search class and
+    # retrofitted in the controllers.
+    # TO DO: figure out if the cascading feature has been completed, and if so move the
+    # pagination back into the search class and out of the controllers.
     @documents = Kaminari::PaginatableArray.new(
-      @search.cached_results,
+      @search.cached_results.limit(@search.per_page).offset(@search.offset),
       limit: @search.per_page,
       offset: @search.offset,
       total_count: @search.cached_total_cnt

--- a/app/models/document_search.rb
+++ b/app/models/document_search.rb
@@ -1,4 +1,7 @@
 class DocumentSearch
+  # NOTE!!! This class returns an unpaginated result. Not sure if pagination can be restored
+  # and it is currently being done on the unpaginated query results in the API and web
+  # documents #index endpoints.
   include CacheIterator
   include SearchCache # this provides #cached_results and #cached_total_cnt
   attr_reader :page, :per_page, :offset, :event_type, :events_ids,


### PR DESCRIPTION
…ts controller. Pagination has been disabled in the DocumentSearch class and is being done in the documents API controller. I'm not sure if I can reinstate the pagination in DocumentSearch without breaking the api endpoint, so i'm adding pagination to the web documents controller instead.

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/183