### PR TITLE
feat: allow EuOpinions to have neither start_event_id ot document_id

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -173,7 +173,6 @@
                     Intersessional decision
                    {{/unless}}
                   {{/if}}
-                  {{/if}}
                   {{#if decision.private_url}}
                     <a class="legal-links" href="{{unbound decision.private_url}}">
                       {{decision.start_event.name}}

--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -69,6 +69,10 @@
                 <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                   Intersessional decision
                 </a>
+              {{else}}
+               {{#unless decision.start_event.name }}
+                Intersessional decision
+               {{/unless}}
               {{/if}}
               {{#if decision.private_url}}
                 <a class="legal-links" href="{{unbound decision.private_url}}">
@@ -164,6 +168,10 @@
                     <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                       Intersessional decision
                     </a>
+                  {{else}}
+                   {{#unless decision.start_event.name }}
+                    Intersessional decision
+                   {{/unless}}
                   {{/if}}
                   {{#if decision.private_url}}
                     <a class="legal-links" href="{{unbound decision.private_url}}">

--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -66,7 +66,7 @@
           <td class="last">
             {{#if isSignedIn }}
               {{#if decision.intersessional_decision_id}}
-                <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
+                <a class="legal-links" href="https://sapi.sapi-staging.linode.unep-wcmc.org/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                   Intersessional decision
                 </a>
               {{else}}
@@ -165,13 +165,14 @@
               <td class="last">
                 {{#if isSignedIn }}
                   {{#if decision.intersessional_decision_id}}
-                    <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
+                    <a class="legal-links" href="https://sapi.sapi-staging.linode.unep-wcmc.org/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                       Intersessional decision
                     </a>
                   {{else}}
                    {{#unless decision.start_event.name }}
                     Intersessional decision
                    {{/unless}}
+                  {{/if}}
                   {{/if}}
                   {{#if decision.private_url}}
                     <a class="legal-links" href="{{unbound decision.private_url}}">

--- a/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept/_eu_decisions.handlebars
@@ -66,7 +66,7 @@
           <td class="last">
             {{#if isSignedIn }}
               {{#if decision.intersessional_decision_id}}
-                <a class="legal-links" href="https://sapi.sapi-staging.linode.unep-wcmc.org/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
+                <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                   Intersessional decision
                 </a>
               {{else}}
@@ -165,7 +165,7 @@
               <td class="last">
                 {{#if isSignedIn }}
                   {{#if decision.intersessional_decision_id}}
-                    <a class="legal-links" href="https://sapi.sapi-staging.linode.unep-wcmc.org/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
+                    <a class="legal-links" href="https://speciesplus.net/api/v1/documents/{{unbound decision.intersessional_decision_id}}">
                       Intersessional decision
                     </a>
                   {{else}}

--- a/app/models/eu_opinion.rb
+++ b/app/models/eu_opinion.rb
@@ -35,7 +35,7 @@ class EuOpinion < EuDecision
   validate :event_or_document_presence
 
   def event_or_document_presence
-    return if start_event_id.nil? ^ document_id.nil?
-    errors.add(:base, "Select at least an Event or a Document, but not both")
+    return unless start_event_id.present? && document_id.present?
+    errors.add(:base, "Select at an Event, a Document or neither, but not both")
   end
 end


### PR DESCRIPTION
previous validation: either start_event_id OR document_id, but not both or neither
new validation: not both

Looks like these get used in eu_decisions_view and api_eu_decisions view, where they work without error.

deployed to staging and will see if there are any errors caused during rebuilding