### PR TITLE
fix: account for species csv generation where no appendix is submitte…

### DIFF
--- a/lib/modules/trade/download_data_retriever.rb
+++ b/lib/modules/trade/download_data_retriever.rb
@@ -48,13 +48,22 @@ module Trade::DownloadDataRetriever
         SQL
       when 'species'
         appendix = params[:appendix]
-        <<-SQL
-               SELECT #{ATTRIBUTES.join(',')}
-               FROM non_compliant_shipments_view
-               WHERE year = #{year}
-               AND taxon_concept_id IN (#{id})
-               AND appendix = '#{appendix}'
-        SQL
+        if appendix.present?
+          <<-SQL
+                SELECT #{ATTRIBUTES.join(',')}
+                FROM non_compliant_shipments_view
+                WHERE year = #{year}
+                AND taxon_concept_id IN (#{id})
+                AND appendix = '#{appendix}'
+          SQL
+        else
+          <<-SQL
+                SELECT #{ATTRIBUTES.join(',')}
+                FROM non_compliant_shipments_view
+                WHERE year = #{year}
+                AND taxon_concept_id IN (#{id})
+          SQL
+        end
       when 'commodity'
         <<-SQL
                SELECT #{ATTRIBUTES.join(',')}

--- a/lib/modules/trade/grouping/base.rb
+++ b/lib/modules/trade/grouping/base.rb
@@ -35,6 +35,20 @@ class Trade::Grouping::Base
     raise NotImplementedError
   end
 
+  def read_taxonomy_conversion
+    conversion = {}
+    taxonomy = CSV.read(TAXONOMIC_GROUPING, {headers: true})
+    taxonomy.each do |csv|
+      conversion[csv['group']] ||= []
+      data = {
+        taxon_name: csv['taxon_name'],
+        rank: csv['taxonomic_level']
+      }
+      conversion[csv['group']] << data
+    end
+    conversion
+  end
+
   protected
 
   def shipments_table
@@ -79,20 +93,6 @@ class Trade::Grouping::Base
   end
 
   private
-
-  def read_taxonomy_conversion
-    conversion = {}
-    taxonomy = CSV.read(TAXONOMIC_GROUPING, {headers: true})
-    taxonomy.each do |csv|
-      conversion[csv['group']] ||= []
-      data = {
-        taxon_name: csv['taxon_name'],
-        rank: csv['taxonomic_level']
-      }
-      conversion[csv['group']] << data
-    end
-    conversion
-  end
 
   def sanitise_group(group)
     return nil unless group

--- a/lib/modules/trade/grouping/compliance.rb
+++ b/lib/modules/trade/grouping/compliance.rb
@@ -270,7 +270,11 @@ class Trade::Grouping::Compliance < Trade::Grouping::Base
   end
 
   def group_query
-    columns = @attributes.compact.uniq.join(',')
+    columns = if @attributes
+      @attributes.compact.uniq.join(',')
+    else
+      attributes.values.join(',')
+    end
     <<-SQL
       SELECT #{columns}, COUNT(*) AS cnt, 100.0*COUNT(*)/(SUM(COUNT(*)) OVER (PARTITION BY year)) AS percent
       FROM non_compliant_shipments_view


### PR DESCRIPTION
…d, and move private method to public so class calling it has access to it. This allows downloads to be generated for species lists by year and by taxonomy from the cites compliance tool

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/67
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/69

Fixes to allow the file generation links in compliance tool to work.

defaults to returning all columns and all appendices if no params are submitted


Testing:
have compliance tool and SAPI running locally (comment out authenticate controller filter in `app/controllers/api/v1/shipments_controller.rb`)
download all button should work on species tab
![image](https://github.com/unepwcmc/SAPI/assets/15033504/fbee3761-adba-447b-8f4e-c803ba5fce3e)

download issues by taxonomy on dashboard should work
![image](https://github.com/unepwcmc/SAPI/assets/15033504/4a5ad38c-8e96-42e1-8bbe-b5c9a0a220dd)
