### PR TITLE
fix: update links on erb version of dropdown, to match updated versio…

### DIFF
--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -56,7 +56,8 @@
               <li><a href="http://api.speciesplus.net">Species+ / CITES Checklist API</a></li>
               <li><a href="http://captivebreeding.unep-wcmc.org">EU Captive breeding database</a></li>
               <li><a href="/eu_legislation">EU Wildlife Trade Legislation</a></li>
-              <li><a href="http://euanalysis.unep-wcmc.org/">EU analysis</a></li>
+              <li><a href="https://ec.europa.eu/environment/cites/reports_en.htm">EU analysis</a></li>
+              <li><a href="https://tradeview.cites.org/">CITES Wildlife TradeView</a></li>
             </ul>
           </div>
           </li>


### PR DESCRIPTION
…n in handlebars template

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/98

Links in drop down in handlebars template were updated months ago, but there is another version of the drop down in an erb that wasn't updated.

Drop down can be viewed at `localhost:3000/eu_legislation`