### PR TITLE
fix: use ILIKE instead of LIKE in species search queries

### DIFF
--- a/app/models/species/taxon_concept_prefix_matcher.rb
+++ b/app/models/species/taxon_concept_prefix_matcher.rb
@@ -92,7 +92,7 @@ class Species::TaxonConceptPrefixMatcher
     if @taxon_concept_query
       @query = @query.where(
         ActiveRecord::Base.send(:sanitize_sql_array, [
-          "name_for_matching LIKE :sci_name_prefix",
+          "name_for_matching ILIKE :sci_name_prefix",
           :sci_name_prefix => "#{@taxon_concept_query}%"
         ])
       )


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/121

This is part of a quote, but I fixed it during debugging

Users are unable to search species with diacritics because we upcase the query term and search against upcased database records in an m view, and upcase doesn't work on diacritics.

The easiest way to fix this is to search using ILIKE instead of LIKE. I've tested this and it doesn't appear to make the search slower.

an alternative would be to include the diacritic gem and upcase the search string correctly and continue to use LIKE for searching

