### PR TITLE
fix: add non-public document options for signed_in users to allow cor…

### DIFF
--- a/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
+++ b/app/assets/javascripts/species/controllers/elibrary_search_controller.js.coffee
@@ -33,7 +33,8 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
     allDocumentTypes = @get('controllers.events.documentTypes')
       .concat @get('controllers.events.interSessionalDocumentTypes')
       .concat @get('controllers.events.identificationDocumentTypes')
-    
+    if @get('isSignedIn')
+      allDocumentTypes = allDocumentTypes.concat(@get('controllers.events.interSessionalNonPublicDocumentTypes'))
     @set('selectedDocumentType', allDocumentTypes.findBy('id', filtersHash.document_type))
    
     general_subtype_type = @get_general_subtype_type(filtersHash)
@@ -71,10 +72,10 @@ Species.ElibrarySearchController = Ember.Controller.extend Species.Spinner,
       general_subtype: isGeneralSubType
     }
 
-  getDocTypeParam: -> 
+  getDocTypeParam: ->
     id = @get('selectedDocumentType.id')
 
-    if id != '__all__' then id else null 
+    if id != '__all__' then id else null
 
   filteredDocumentTypes: ( ->
     if @get('selectedEventType')


### PR DESCRIPTION
…rect parameter building

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/188

CommissionNote document types are only available to users that are signed in.
These were not being added to the list of options when a user is signed in
this prevented the document type being submitted when loading more options in the results pages
this meant the documents were not filtered correctly on load more

this ticket adds the CommssionNote document type to the list of options if a user is signed in, so the correct parameters are built

Testing:

1, sign in
2. on document search tab, select 'Commission Notes' in the 'Other documents' field
3. open the results tables for the results
4. click 'more'
5. the total number of documents at the top of each table should not change