### PR TITLE
fix: add line height to authors part of species pages

### DIFF
--- a/app/assets/javascripts/species/templates/taxon_concept.handlebars
+++ b/app/assets/javascripts/species/templates/taxon_concept.handlebars
@@ -8,7 +8,7 @@
   {{/if}}
   <div class="heading-holder">
     <h1>{{fullName}}</h1>
-    <h2>{{authorYear}}</h2>
+    <h2 class="authors">{{authorYear}}</h2>
     <ul class="list">
       <li>
         <a {{action 'openSearchPage' phylumName}} class="hover-pointer">

--- a/app/assets/stylesheets/species/all.scss
+++ b/app/assets/stylesheets/species/all.scss
@@ -809,6 +809,9 @@ body.inner #footer .holder{
   word-spacing: -3px;
   text-align: left;
 }
+.heading-holder .authors {
+  line-height: 30px;
+}
 .heading-holder .species-name {
   word-spacing: 0;
 }


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/192

Adds a line height to authors, so if text wraps onto a new line, it doesn't overlap the line above

Testing:
http://localhost:3000/species#/taxon_concepts/100473/legal - text should not overlap
other species should look ok too