### PR TITLE
feat: use orginal filename to generate document tite rather than the …

### DIFF
--- a/app/models/document_batch.rb
+++ b/app/models/document_batch.rb
@@ -40,7 +40,8 @@ class DocumentBatch
       for idx in 0..(files.length - 1) do
         document_params = {
           type: documents_attributes[idx.to_s][:type],
-          filename: files[idx]
+          filename: files[idx],
+          title:  document_title(files[idx])
         }
         @documents.push(Document.new(common_attributes.merge(document_params)))
       end
@@ -56,4 +57,8 @@ class DocumentBatch
     }
   end
 
+  def document_title(file)
+    original_filename = file.is_a?(Hash) ? file[:filename].original_filename :  file.original_filename
+    original_filename.sub(/.\w+$/, '')
+  end
 end


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/206

the file uploader sanitizes the filename, this is used to set the document title, which then needs to be corrected

this PR uses the original_filename before it is sanitized to set the document.

Testing:
upload some files with brackets in the filename. the Document title should match the original filename
the filename will still be modified