### PR TITLE
feat: add migration to include new taxa to timber grouping

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :stage, :staging
-set :branch, :develop
+set :branch, 'feat/113/do-not-add-spp-suffix-to-hybrids'
 
 server "sapi-staging.linode.unep-wcmc.org", user: "wcmc", roles: %w{app web db}
 

--- a/db/migrate/20230913132619_update_timber_taxa_on_trade_plus_group_view.rb
+++ b/db/migrate/20230913132619_update_timber_taxa_on_trade_plus_group_view.rb
@@ -1,0 +1,31 @@
+class UpdateTimberTaxaOnTradePlusGroupView < ActiveRecord::Migration
+  def up
+    execute "DROP MATERIALIZED VIEW IF EXISTS trade_plus_complete_mview"
+    execute "DROP VIEW IF EXISTS trade_plus_complete_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_final_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_view"
+    execute "DROP VIEW IF EXISTS trade_plus_group_view"
+    execute "DROP VIEW IF EXISTS trade_plus_shipments_view"
+    execute "CREATE VIEW trade_plus_shipments_view AS #{view_sql('20200206150700', 'trade_plus_shipments_view')}"
+    execute "CREATE VIEW trade_plus_group_view AS #{view_sql('20230913140200', 'trade_plus_group_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_view AS #{view_sql('20211005144857', 'trade_plus_formatted_data_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_final_view AS #{view_sql('20220119111417', 'trade_plus_formatted_data_final_view')}"
+    execute "CREATE VIEW trade_plus_complete_view AS #{view_sql('20200707183829', 'trade_plus_complete_view')}"
+    execute "CREATE MATERIALIZED VIEW trade_plus_complete_mview AS SELECT * FROM trade_plus_complete_view"
+  end
+
+  def down
+    execute "DROP MATERIALIZED VIEW IF EXISTS trade_plus_complete_mview"
+    execute "DROP VIEW IF EXISTS trade_plus_complete_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_final_view"
+    execute "DROP VIEW IF EXISTS trade_plus_formatted_data_view"
+    execute "DROP VIEW IF EXISTS trade_plus_group_view"
+    execute "DROP VIEW IF EXISTS trade_plus_shipments_view"
+    execute "CREATE VIEW trade_plus_shipments_view AS #{view_sql('20200206150700', 'trade_plus_shipments_view')}"
+    execute "CREATE VIEW trade_plus_group_view AS #{view_sql('20220223142356', 'trade_plus_group_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_view AS #{view_sql('20211005144857', 'trade_plus_formatted_data_view')}"
+    execute "CREATE VIEW trade_plus_formatted_data_final_view AS #{view_sql('20220119111417', 'trade_plus_formatted_data_final_view')}"
+    execute "CREATE VIEW trade_plus_complete_view AS #{view_sql('20200707183829', 'trade_plus_complete_view')}"
+    execute "CREATE MATERIALIZED VIEW trade_plus_complete_mview AS SELECT * FROM trade_plus_complete_view"
+  end
+end

--- a/db/views/trade_plus_group_view/20230913140200.sql
+++ b/db/views/trade_plus_group_view/20230913140200.sql
@@ -1,0 +1,56 @@
+
+SELECT
+    ts.*,
+    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammals'
+        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Birds'
+        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibians'
+        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Fish'
+        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Non-coral invertebrates'
+        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
+        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plants (timber)'
+        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plants (timber)'
+        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
+    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
+    THEN 'Plants (other than timber)'
+        END AS group_en,
+
+    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mamiferos'
+        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Aves'
+        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Anfibios'
+        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Pez'
+        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertebrados no coralinos'
+        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
+        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plantas (madera)'
+        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plantas (madera)'
+        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
+    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
+    THEN 'Plantas (otro que madera)'
+        END AS group_es,
+
+    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammifères'
+        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Oiseaux'
+        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibiens'
+        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Poissons'
+        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertébrés autres que les coraux'
+        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coraux'
+        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plantes (bois)'
+        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plantes (bois)'
+        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
+    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
+    THEN 'Plantes (autres que le bois)'
+        END AS group_fr,
+
+    -- mapping Taiwan trades to China trades, so that they appear as the same country on Tradeplus
+    CASE WHEN ts.importer_id = 218 THEN 160
+    ELSE ts.importer_id
+    END AS china_importer_id,
+    CASE WHEN ts.exporter_id = 218 THEN 160
+    ELSE ts.exporter_id
+    END AS china_exporter_id,
+    CASE WHEN ts.country_of_origin_id = 218 THEN 160
+    ELSE ts.country_of_origin_id
+    END AS china_origin_id
+FROM trade_plus_shipments_view ts

--- a/db/views/trade_plus_group_view/20230913140200.sql
+++ b/db/views/trade_plus_group_view/20230913140200.sql
@@ -1,56 +1,55 @@
+    SELECT
+      ts.*,
+      CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammals'
+			WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Birds'
+			WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+			WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibians'
+			WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Fish'
+			WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Non-coral invertebrates'
+			WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
+			WHEN ts.taxon_concept_genus_name IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus') THEN 'Plants (timber)'
+			WHEN ts.taxon_concept_full_name IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei') THEN 'Plants (timber)'
+			WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus')
+      OR ts.taxon_concept_full_name NOT IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei'))
+      THEN 'Plants (other than timber)'
+			END AS group_en,
 
-SELECT
-    ts.*,
-    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammals'
-        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Birds'
-        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
-        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibians'
-        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Fish'
-        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Non-coral invertebrates'
-        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
-        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plants (timber)'
-        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plants (timber)'
-        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
-    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
-    THEN 'Plants (other than timber)'
-        END AS group_en,
+      CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mamiferos'
+			WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Aves'
+			WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+			WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Anfibios'
+			WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Pez'
+			WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertebrados no coralinos'
+			WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
+			WHEN ts.taxon_concept_genus_name IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus') THEN 'Plantas (madera)'
+			WHEN ts.taxon_concept_full_name IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei') THEN 'Plantas (madera)'
+			WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus')
+      OR ts.taxon_concept_full_name NOT IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei'))
+      THEN 'Plantas (otro que madera)'
+			END AS group_es,
 
-    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mamiferos'
-        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Aves'
-        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
-        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Anfibios'
-        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Pez'
-        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertebrados no coralinos'
-        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coral'
-        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plantas (madera)'
-        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plantas (madera)'
-        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
-    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
-    THEN 'Plantas (otro que madera)'
-        END AS group_es,
+      CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammifères'
+			WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Oiseaux'
+			WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
+			WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibiens'
+			WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Poissons'
+			WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertébrés autres que les coraux'
+			WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coraux'
+			WHEN ts.taxon_concept_genus_name IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus') THEN 'Plantes (bois)'
+			WHEN ts.taxon_concept_full_name IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei') THEN 'Plantes (bois)'
+			WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies','Afzelia','Aquilaria','Cedrela','Dalbergia','Diospyros','Dipteryx','Gonystylus','Guaiacum','Guarea','Guibourtia','Gyrinops','Handroanthus','Khaya','Pericopsis','Platymiscium','Prunus','Pterocarpus','Podocarpus','Quercus','Roseodendron','Swietenia','Tabebuia','Taxus')
+      OR ts.taxon_concept_full_name NOT IN ('Abies guatemalensis','Aniba rosaeodora','Araucaria araucana','Bulnesia sarmientoi','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Dipteryx panamensis','Fitzroya cupressoides','Fraxinus mandshurica','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Paubrasilia echinata','Pilgerodendron uviferum','Pinus koraiensis','Pterygota excelsa','Tachigali versicolor','Tetracentron sinense','Widdringtonia whytei'))
+      THEN 'Plantes (autres que le bois)'
+			END AS group_fr,
 
-    CASE 			WHEN ts.taxon_concept_class_name IN ('Mammalia') THEN 'Mammifères'
-        WHEN ts.taxon_concept_class_name IN ('Aves') THEN 'Oiseaux'
-        WHEN ts.taxon_concept_class_name IN ('Reptilia') THEN 'Reptiles'
-        WHEN ts.taxon_concept_class_name IN ('Amphibia') THEN 'Amphibiens'
-        WHEN ts.taxon_concept_class_name IN ('Elasmobranchii','Actinopteri','Coelacanthi','Dipneusti','Actinopterygii') THEN 'Poissons'
-        WHEN ts.taxon_concept_class_name IN ('Holothuroidea','Arachnida','Insecta','Hirudinoidea','Bivalvia','Gastropoda','Cephalopoda') THEN 'Invertébrés autres que les coraux'
-        WHEN ts.taxon_concept_class_name IN ('Anthozoa','Hydrozoa') THEN 'Coraux'
-        WHEN ts.taxon_concept_genus_name IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei') THEN 'Plantes (bois)'
-        WHEN ts.taxon_concept_full_name IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor') THEN 'Plantes (bois)'
-        WHEN ts.taxon_concept_class_name IS NULL AND (ts.taxon_concept_genus_name NOT IN ('Abies', 'Afzelia', 'Aquilaria', 'Cedrela', 'Dalbergia', 'Diospyros', 'Dipteryx', 'Gonystylus', 'Guaiacum', 'Guarea', 'Guibourtia', 'Gyrinops', 'Handroanthus', 'Khaya', 'Pericopsis', 'Platymiscium', 'Prunus', 'Pterocarpus', 'Podocarpus', 'Quercus', 'Roseodendron', 'Swietenia', 'Tabebuia', 'Taxus', 'Abies guatemalensis', 'Aniba rosaeodora', 'Araucaria araucana', 'Bulnesia sarmientoi', 'Caryocar costaricense', 'Celtis aetnensis', 'Cynometra hemitomophylla', 'Dipteryx panamensis', 'Fitzroya cupressoides', 'Fraxinus mandshurica', 'Magnolia liliifera', 'Oreomunnea pterocarpa', 'Osyris lanceolata', 'Paubrasilia echinata', 'Pilgerodendron uviferum', 'Pinus koraiensis', 'Pterygota excelsa', 'Tachigali versicolor', 'Tetracentron sinense', 'Widdringtonia whytei')
-    OR ts.taxon_concept_full_name NOT IN ('Araucaria araucana','Fitzroya cupressoides','Abies guatemalensis','Pterocarpus santalinus','Pilgerodendron uviferum','Aniba rosaeodora','Caesalpinia echinata','Bulnesia sarmientoi','Dipteryx panamensis','Pinus koraiensis','Caryocar costaricense','Celtis aetnensis','Cynometra hemitomophylla','Magnolia liliifera','Oreomunnea pterocarpa','Osyris lanceolata','Pterygota excelsa','Tachigali versicolor'))
-    THEN 'Plantes (autres que le bois)'
-        END AS group_fr,
-
-    -- mapping Taiwan trades to China trades, so that they appear as the same country on Tradeplus
-    CASE WHEN ts.importer_id = 218 THEN 160
-    ELSE ts.importer_id
-    END AS china_importer_id,
-    CASE WHEN ts.exporter_id = 218 THEN 160
-    ELSE ts.exporter_id
-    END AS china_exporter_id,
-    CASE WHEN ts.country_of_origin_id = 218 THEN 160
-    ELSE ts.country_of_origin_id
-    END AS china_origin_id
-FROM trade_plus_shipments_view ts
+      -- mapping Taiwan trades to China trades, so that they appear as the same country on Tradeplus
+      CASE WHEN ts.importer_id = 218 THEN 160
+      ELSE ts.importer_id
+      END AS china_importer_id,
+      CASE WHEN ts.exporter_id = 218 THEN 160
+      ELSE ts.exporter_id
+      END AS china_exporter_id,
+      CASE WHEN ts.country_of_origin_id = 218 THEN 160
+      ELSE ts.country_of_origin_id
+      END AS china_origin_id
+    FROM trade_plus_shipments_view ts

--- a/lib/modules/trade/grouping/base.rb
+++ b/lib/modules/trade/grouping/base.rb
@@ -7,7 +7,7 @@ class Trade::Grouping::Base
 
   # Example usage
   # Group by year considering compliance types:
-  # Trade::Grouping::Compliance.new(['year, 'issue_type']})
+  # Trade::Grouping::Compliance.new(['year', 'issue_type'])
   # Group by importer and limit result to 5 records
   # Trade::Grouping::Compliance.new('importer', {limit: 5})
   def initialize(attributes, opts={})


### PR DESCRIPTION
adds new migration to update taxa in timber grouping for tradeview

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/210

testing:
```
rake db:migrate
rake db:migrate:rebuild
```