### PR TITLE
feat: Add index to optimise LIKE search, and allow matches anywhere i…

### DIFF
--- a/app/models/trade/permit_matcher.rb
+++ b/app/models/trade/permit_matcher.rb
@@ -27,7 +27,7 @@ class Trade::PermitMatcher
     @query = Trade::Permit.order(:number)
     if @permit_query
       @query = @query.where([
-        "UPPER(number) LIKE :number", :number => "#{@permit_query}%"
+        "UPPER(number) LIKE :number", :number => "%#{@permit_query}%"
       ])
     end
   end

--- a/db/migrate/20230915113624_add_trigram_index_to_trade_permit_numbers.rb
+++ b/db/migrate/20230915113624_add_trigram_index_to_trade_permit_numbers.rb
@@ -1,0 +1,20 @@
+class AddTrigramIndexToTradePermitNumbers < ActiveRecord::Migration
+  def up
+    # Index to optimise LIKE queries
+    if Rails.env.staging? or Rails.env.production?
+      puts "Please add extension by hand: CREATE EXTENSION pg_trgm"
+    else
+      execute "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+    end
+    execute 'CREATE INDEX trade_permits_number_trigm_idx ON trade_permits USING gin (upper(number) gin_trgm_ops)'
+  end
+
+  def down
+    execute 'DROP INDEX trade_permits_number_trigm_idx'
+    if Rails.env.staging? or Rails.env.production?
+      puts "Please drop extension by hand: DROP EXTENSION pg_trgm"
+    else
+      execute "DROP EXTENSION pg_trgm"
+    end
+  end
+end


### PR DESCRIPTION
 Add index to optimise LIKE search, and allow matches anywhere in trade_permit 'number' string, instead of just the start

Testing:
`rake db:migrate` to add index
on `http://localhost:3000/trade` search for permits. response should be fast, and filtering should return partial matches from middle of trade permit number

Deployment to prod:
you need to install the pg_trgm extension on production before deploying
