### PR TITLE
Begin to dockerise Species+

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,31 @@
-# .dockerignore
-.git*
-.git/**
-db/*.sql*
-log/*
-tmp/**
-Dockerfile
-Readme
-docker-compose.yml
-config/master.key
-.env*
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
+
+# Ignore git directory.
+/.git/
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all environment files (except templates).
+/.env*
+!/.env*.erb
+
+# Ignore all default key files.
+/config/master.key
+/config/credentials/*.key
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/.keep
+
+# Ignore storage (uploaded files in development and any SQLite databases).
+/storage/*
+!/storage/.keep
+/tmp/storage/*
+!/tmp/storage/.keep

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# .dockerignore
+.git*
+.git/**
+db/*.sql*
+log/*
+tmp/**
+Dockerfile
+Readme
+docker-compose.yml
+config/master.key

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ Dockerfile
 Readme
 docker-compose.yml
 config/master.key
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Dockerfile
+FROM ruby:2.3.1
+
+# The ruby:2.3.1 image is ancient, based of debian jessie which no longer
+# receives active security updates. Therefore we must declare the debian
+# archive as a source instead.
+RUN rm /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list.d/jessie.list
+RUN echo "deb http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list
+
+# Rails and SAPI has some additional dependencies, e.g. rake requires a JS
+# runtime, so attempt to get these from apt, where possible
+RUN apt-get update
+RUN apt-get install -y --force-yes libsodium-dev libgmp3-dev libssl-dev
+RUN apt-get install -y --force-yes libpq-dev
+RUN apt-get install -y --force-yes nodejs
+# rake requires a JS runtime, such as nodejs, so install it.
+# postgresql-9.5 postgresql-contrib-9.5
+# cannot find postgresql-contrib-9.5 - maybe postgres archive? Do we need it?
+
+
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN gem install bundler -v 1.17.3
+RUN bundle config without test production
+RUN bundle install
+
+EXPOSE 3100
+
+# docker build -t sapi:latest .
+# docker run --rm -it --mount type=bind,src=${PWD},dst=/usr/src/app sapi bundler exec rake db:migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,9 @@ RUN apt-get install -y --force-yes nodejs
 # postgresql-9.5 postgresql-contrib-9.5
 # cannot find postgresql-contrib-9.5 - maybe postgres archive? Do we need it?
 
-
 ADD . /usr/src/app
 WORKDIR /usr/src/app
 
 RUN gem install bundler -v 1.17.3
 RUN bundle config without test production
 RUN bundle install
-
-EXPOSE 3100
-
-# docker build -t sapi:latest .
-# docker run --rm -it --network host --mount type=bind,src=${PWD},dst=/usr/src/app sapi bundler exec rake db:migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN bundle install
 EXPOSE 3100
 
 # docker build -t sapi:latest .
-# docker run --rm -it --mount type=bind,src=${PWD},dst=/usr/src/app sapi bundler exec rake db:migrate
+# docker run --rm -it --network host --mount type=bind,src=${PWD},dst=/usr/src/app sapi bundler exec rake db:migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,22 @@ FROM ruby:2.3.1
 # The ruby:2.3.1 image is ancient, based of debian jessie which no longer
 # receives active security updates. Therefore we must declare the debian
 # archive as a source instead.
-RUN rm /etc/apt/sources.list
-RUN echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list.d/jessie.list
-RUN echo "deb http://archive.debian.org/debian jessie main" >> /etc/apt/sources.list.d/jessie.list
+RUN rm /etc/apt/sources.list && \
+  echo "deb http://archive.debian.org/debian-security jessie/updates main" \
+    >> /etc/apt/sources.list.d/jessie.list && \
+  echo "deb http://archive.debian.org/debian jessie main" \
+    >> /etc/apt/sources.list.d/jessie.list \
+;
 
 # Rails and SAPI has some additional dependencies, e.g. rake requires a JS
 # runtime, so attempt to get these from apt, where possible
-RUN apt-get update
-RUN apt-get install -y --force-yes libsodium-dev libgmp3-dev libssl-dev
-RUN apt-get install -y --force-yes libpq-dev
-RUN apt-get install -y --force-yes nodejs
-# rake requires a JS runtime, such as nodejs, so install it.
+RUN apt-get update && apt-get install -y --force-yes \
+  libsodium-dev libgmp3-dev libssl-dev \
+  libpq-dev \
+  nodejs \
+;
+
+# Woudl be nice to have:
 # postgresql-9.5 postgresql-contrib-9.5
 # cannot find postgresql-contrib-9.5 - maybe postgres archive? Do we need it?
 

--- a/app/assets/javascripts/cites_trade/application.js
+++ b/app/assets/javascripts/cites_trade/application.js
@@ -785,13 +785,16 @@ $(document).ready(function(){
     } else {
       $.cookie('cites_trade.csv_separator', csv_separator)
       query += '&filters[csv_separator]=' + csv_separator;
-      
-      ga('send', {
-        hitType: 'event',
-        eventCategory: 'Downloads: ' + report_type,
-        eventAction: 'Format: CSV',
-        eventLabel: csv_separator
-      });
+
+      // google analytics function only defined on production
+      if (typeof(ga) === 'function') {
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'Downloads: ' + report_type,
+          eventAction: 'Format: CSV',
+          eventLabel: csv_separator
+        });
+      }
       downloadResults( decodeURIComponent( query ) );
       return
     }
@@ -800,11 +803,14 @@ $(document).ready(function(){
   $('#button_report').click( function (e) {handleDownloadRequest(false) });
   $('#ignore_warning_button_report').click( function (e) {handleDownloadRequest(true) });
   $('[data-full-trade-db-download]').click( function (e) {
-    ga('send', {
-      hitType: 'event',
-      eventCategory: 'Downloads: Full trade database',
-      eventAction: 'Format: CSV',
-    });
+    // google analytics function only defined on production
+    if (typeof(ga) === 'function') {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: 'Downloads: Full trade database',
+        eventAction: 'Format: CSV',
+      });
+    }
   })
 
   //////////////////////////////

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,47 +1,29 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-development:
-  adapter: postgresql
-  database: sapi_development
-  pool: 5
-  username: postgres
-  password:
-  timeout: 5000
-  port: 5432
-  host: localhost
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
+default: &default
+  host: <%= ENV.fetch("SAPI_DATABASE_HOST", 'localhost') %>
   adapter: postgresql
-  database: sapi_test
-  pool: 5
-  username: postgres
-  password:
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("SAPI_RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("SAPI_DATABASE_USERNAME", 'postgres') %>
+  port: <%= ENV.fetch("SAPI_DATABASE_PORT", 5432) %>
+
+development:
+  <<: *default
+  database: sapi_development
   timeout: 5000
-  port: 5432
-  host: localhost
+
+test:
+  <<: *default
+  database: sapi_test
+  timeout: 5000
 
 staging:
-  adapter: postgresql
+  <<: *default
   database: sapi_development
-  pool: 10
-  username: postgres
-  password:
-  host: localhost
   port: 5432
-  template: template0
 
 production:
-  adapter: postgresql
+  <<: *default
   database: sapi_development
-  pool: 10
-  username: postgres
-  password:
-  host: localhost
-  port: 5432
-  template: template0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+# docker-compose.yml
+version: '3.8'
+
+networks:
+  species-plus:
+    driver: bridge
+
+services:
+  species-plus-db:
+    container_name: species-plus-db
+    image: postgres:10
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      timeout: 45s
+      interval: 10s
+      retries: 10
+    volumes:
+      - 'pgdata:/var/lib/postgresql/data'
+    ports:
+      - "5432:5432"
+    networks:
+      - species-plus
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+      POSTGRES_DB: "sapi_development"
+
+  sapi-rails:
+    container_name: sapi-rails
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    command: /bin/bash -l -c "rm -f ./tmp/pids/server.pid && bundle exec rails s -p 3100 -b '0.0.0.0'"
+    ports:
+      - '3100:3100'
+    networks:
+      - species-plus
+    stdin_open: true
+    tty: true
+    environment:
+      SAPI_DATABASE_HOST: species-plus-db
+    depends_on:
+      - species-plus-db
+
+volumes:
+  pgdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - 'pgdata:/var/lib/postgresql/data'
     ports:
-      - "5432:5432"
+      - "${SAPI_DATABASE_PORT:-5432}:5432"
     networks:
       - species-plus
     environment:
@@ -29,15 +29,16 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    command: /bin/bash -l -c "rm -f ./tmp/pids/server.pid && bundle exec rails s -p 3100 -b '0.0.0.0'"
+    command: /bin/bash -l -c "rm -f ./tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
-      - '3100:3100'
+      - '${SAPI_PORT:-3000}:3000'
     networks:
       - species-plus
     stdin_open: true
     tty: true
     environment:
       SAPI_DATABASE_HOST: species-plus-db
+      SAPI_DATABASE_PORT: "${SAPI_DATABASE_PORT:-5432}"
     depends_on:
       - species-plus-db
 


### PR DESCRIPTION
A PR to get the ball rolling so we can actually do something with Species+ on modern machines, where ruby 2.3.1/rails 4.0.2 won't work.

What works with this PR:

- Website runs on `docker compose up` (on first load it takes about 20s to display a page).
- You can specify the service port, e.g. `SAPI_PORT=3010 docker compose up` to avoid conflicting with ports defined in other applications.

What doesn't work right now:

- Download species list button (500 ENOENT on a file in `public/downloads/`)

To do (perhaps in a future PR):

- sidekiq/redis/mailcatcher like in [UNI](https://github.com/unepwcmc/urban-nature-index/blob/feat/pdf/docker-compose.yml)
- Not sure how to go about testing these yet