### PR TITLE
Fixes arising from changes to name_status

### DIFF
--- a/app/models/checklist/pdf/index_query.rb
+++ b/app/models/checklist/pdf/index_query.rb
@@ -9,7 +9,7 @@ class Checklist::Pdf::IndexQuery
     # we want common names and synonyms returned as separate records
     # and sorted alphabetically
     shared_columns = [:full_name, :rank_name, :family_name, :class_name,
-    :cites_accepted, :cites_listing,
+    :cites_accepted, :cites_listing, :name_status,
     :ann_symbol, :hash_ann_symbol]
     shared_columns << :english_names_ary if @english_common_names
     shared_columns << :spanish_names_ary if @spanish_common_names

--- a/app/models/trade/shipment_report_queries.rb
+++ b/app/models/trade/shipment_report_queries.rb
@@ -478,6 +478,7 @@ module Trade::ShipmentReportQueries
       appendix,
       taxon_concept_id,
       full_name_with_spp(ranks.name, taxon_concept_full_name, taxon_concept_name_status) AS taxon,
+      taxon_concept_name_status,
       importer_id,
       importers.iso_code2 AS importer,
       exporter_id,

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -18,6 +18,9 @@ CREATE OR REPLACE FUNCTION squish_null(TEXT) RETURNS TEXT
 COMMENT ON FUNCTION squish_null(TEXT) IS
   'Squishes whitespace characters in a string and returns null for empty string';
 
+-- This function previously had a different signature - ensure that the old version is gone
+DROP FUNCTION IF EXISTS full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255));
+
 CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255), name_status CHAR(1)) RETURNS VARCHAR(255)
   LANGUAGE sql IMMUTABLE
   AS $$
@@ -28,7 +31,7 @@ CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name 
     END;
   $$;
 
-COMMENT ON FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255)) IS
+COMMENT ON FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255), name_status CHAR(1)) IS
   'Returns full name with ssp where applicable depending on rank. This is not applied for higher than species level hybrids';
 
 DROP FUNCTION IF EXISTS ancestor_listing_auto_note(rank_name VARCHAR(255), full_name VARCHAR(255), change_type_name VARCHAR(255));
@@ -186,7 +189,7 @@ CREATE OR REPLACE FUNCTION create_trade_sandbox_view(
       CASE
         WHEN aru.point_of_view = ''E''
         THEN trading_partner
-        ELSE geo_entities.iso_code2 
+        ELSE geo_entities.iso_code2
       END AS importer,
       taxon_concepts.full_name AS accepted_taxon_name,
       taxon_concepts.data->''rank_name'' AS rank,

--- a/lib/tasks/db_migrate_plpgsql.rake
+++ b/lib/tasks/db_migrate_plpgsql.rake
@@ -2,14 +2,20 @@ namespace :db do
   namespace :migrate do
     desc "Run custom sql scripts"
     task :sql => :environment do
-      ['helpers', 'mviews', 'plpgsql'].each do |dir|
-        files = Dir.glob(Rails.root.join("db/#{dir}/*.sql"))
-        files.sort.each do |file|
-          puts file
-          ActiveRecord::Base.connection.execute(File.read(file))
+      ActiveRecord::Base.transaction do
+        connection = ActiveRecord::Base.connection
+
+        ['helpers', 'mviews', 'plpgsql'].each do |dir|
+          files = Dir.glob(Rails.root.join("db/#{dir}/*.sql"))
+
+          files.sort.each do |file|
+            puts "Executing #{file}"
+            connection.execute(File.read(file))
+          end
         end
       end
     end
+
     desc "Rebuild all computed values"
     task :rebuild => :migrate do
       Sapi.rebuild
@@ -23,9 +29,11 @@ namespace :db do
       Sapi::create_indexes
     end
   end
+
   task :migrate do
     Rake::Task['db:migrate:sql'].invoke
   end
+
   desc "Drop sandboxes in progress"
   task :drop_sandboxes => :environment do
     Trade::AnnualReportUpload.where(:is_done => false).each do |aru|
@@ -42,5 +50,4 @@ namespace :db do
     puts "Deleting annual report uploads & dropping sandboxes"
     Trade::AnnualReportUpload.all.each { |aru| aru.destroy }
   end
-
 end


### PR DESCRIPTION
Various minor issues arising from https://github.com/unepwcmc/SAPI/pull/943

- On staging, the cron job running `rake downloads:cache:update` was failing with error `missing attribute: name_status`. This was not failing on production.
- The function signature for `full_name_with_spp` changed; a simple `CREATE OR REPLACE FUNCTION` leaves the old one intact, as name and signature are both part of the uniqueness constraint. DBs created prior to this change needed the function signature removing and test dbs created after this change were not correctly being built because a comment on the function referenced the function with the old signature (which hadn't been created), and failed, meaning the rest of the file was not being executed.
- Many tests were failing due to a column being missing from a subquery that was referenced later in that query.