### PR TITLE
Add TeX dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --force-yes \
   libsodium-dev libgmp3-dev libssl-dev \
   libpq-dev postgresql-client \
   nodejs \
+  texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra \
 ;
 # NB: Postgres client from Debian is 9.4 - not sure if this is acceptable
 


### PR DESCRIPTION
The task `rake downloads:cache:update` depends on pdflatex, which is not currently installed on the image. However:

- These are pretty heavy
- I'm still getting issues with tex not recognising unicode characters - I'm not sure how to solve these.
