### PR TITLE
Fix failing NomenclatureChange::ReassignmentCopyProcessor tests

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -54,11 +54,4 @@ class Distribution < ApplicationRecord
       self[column].present? || self[column] = nil
     end
   end
-
-  # `ignored_attributes` is used by ComparisonAttributes when identifying
-  # duplicate records. Attributes in this list won't be considered when
-  # determining if the record is a duplicate.
-  def self.ignored_attributes
-    super() + [:tag_list]
-  end
 end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -54,4 +54,11 @@ class Distribution < ApplicationRecord
       self[column].present? || self[column] = nil
     end
   end
+
+  # `ignored_attributes` is used by ComparisonAttributes when identifying
+  # duplicate records. Attributes in this list won't be considered when
+  # determining if the record is a duplicate.
+  def self.ignored_attributes
+    super() + [:tag_list]
+  end
 end

--- a/config/initializers/active_record_comparison_attributes.rb
+++ b/config/initializers/active_record_comparison_attributes.rb
@@ -6,7 +6,14 @@ module ComparisonAttributes
 
   module ClassMethods
     def ignored_attributes
-      [:id, :created_at, :updated_at, :created_by_id, :updated_by_id, :original_id]
+      attr_to_ignore = [:id, :created_at, :updated_at, :created_by_id, :updated_by_id, :original_id]
+      # When upgrade `acts_as_taggable` gem from version 5 to 8.1, we found that
+      #  `attributes` now return `xxx_list` as well. Put them in ignore list.
+      # `ignored_attributes` is used by ComparisonAttributes when identifying
+      # duplicate records. Attributes in this list won't be considered when
+      # determining if the record is a duplicate.
+      attr_to_ignore += tag_types.map{|t| "#{t.to_s.singularize}_list" } if taggable?
+      attr_to_ignore
     end
 
     def text_attributes

--- a/config/initializers/active_record_comparison_attributes.rb
+++ b/config/initializers/active_record_comparison_attributes.rb
@@ -59,3 +59,9 @@ module ComparisonAttributes
 end
 
 ApplicationRecord.send :include, ComparisonAttributes
+
+# Since Rails 5, our base class has changed and is no longer ActiveRecord::Base,
+# but is now ApplicationRecord. However ActsAsTaggableOn still has
+# ActiveRecord::Base as a base class, therefore it needs to be done separately.
+# It's possible that more ActsAsTaggableOn:: classes need this treatment.
+ActsAsTaggableOn::Tagging.send :include, ComparisonAttributes


### PR DESCRIPTION
Two fixes for broken tests associated with tagging module ActsAsTaggableOn