### PR TITLE
Suppress extinct species in checklist

### DIFF
--- a/app/serializers/checklist/taxon_concept_serializer.rb
+++ b/app/serializers/checklist/taxon_concept_serializer.rb
@@ -67,8 +67,16 @@ class Checklist::TaxonConceptSerializer < ActiveModel::Serializer
       ["extinct"], :exclude => true
     )
 
-    non_extinct_distributions.map do |distribution|
-      distribution.geo_entity_id
+    # We can't just return the ids, we need to retain the order of the original
+    # array, which is sorted on English name.
+    country_id_not_extinct = (
+      non_extinct_distributions.map do |distribution|
+        [ distribution.geo_entity_id, true ]
+      end
+    ).to_h
+
+    object.countries_ids.select do |country_id|
+      country_id_not_extinct[country_id]
     end
   end
 end

--- a/app/serializers/checklist/taxon_concept_serializer.rb
+++ b/app/serializers/checklist/taxon_concept_serializer.rb
@@ -55,4 +55,18 @@ class Checklist::TaxonConceptSerializer < ActiveModel::Serializer
     object.is_a? Checklist::HigherTaxaItem
   end
 
+  # Override the matview here to instead query the db for non-extinct distributions
+  def countries_ids
+    if object.countries_ids.length == 0
+      return object.countries_ids
+    end
+
+    non_extinct_distributions = object.taxon_concept.distributions.reject do |distribution|
+      distribution.tags.length == 1 && distribution.tags[0].name == 'extinct'
+    end
+
+    non_extinct_distributions.map do |distribution|
+      distribution.geo_entity_id
+    end
+  end
 end

--- a/app/serializers/checklist/taxon_concept_serializer.rb
+++ b/app/serializers/checklist/taxon_concept_serializer.rb
@@ -61,9 +61,11 @@ class Checklist::TaxonConceptSerializer < ActiveModel::Serializer
       return object.countries_ids
     end
 
-    non_extinct_distributions = object.taxon_concept.distributions.reject do |distribution|
-      distribution.tags.length == 1 && distribution.tags[0].name == 'extinct'
-    end
+    non_extinct_distributions = Distribution.where(
+      taxon_concept_id: object.id
+    ).tagged_with(
+      ["extinct"], :exclude => true
+    )
 
     non_extinct_distributions.map do |distribution|
       distribution.geo_entity_id


### PR DESCRIPTION
This PR changes the behaviour of the CITES Checklist Taxon Concept route. Instead of returning all countries where there is geographic distribution information, this route will now exclude those where the information is that the species is extinct, per [issue 215 on Codebase](https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/215)

STR:

```
/checklist/taxon_concepts?locale=en&output_layout=alphabetical&level_of_listing=0&show_synonyms=1&show_author=1&show_english=1&show_spanish=1&show_french=1&scientific_name=Acinonyx+jubatus%00&page=1&per_page=20
```

- Observed: countries_ids has >50 items including 203, Afghanistan
- Expected: Fewer entries, not includng 203

