### PR TITLE
Fix JSONB expected value in the ARU

### DIFF
--- a/app/models/trade/inclusion_validation_rule.rb
+++ b/app/models/trade/inclusion_validation_rule.rb
@@ -130,7 +130,7 @@ class Trade::InclusionValidationRule < Trade::ValidationRule
       column_names.map do |column_name|
         column_value = mr.send(column_name)
         if column_value.nil?
-          [ column_name, column_value ]
+          [ column_name, "" ]
         else
           [ column_name, column_value.to_s ]
         end


### PR DESCRIPTION
Some column values in the csv can be empty. This fix puts those values in the JSONB field as empty strings rather than nil.

After fixing one of the errors, the `refresh_errors_if_needed` method will go through all the errors again and check the one resolved to remove them from the list.

Running down the list of errors, the code searches for the matching_criteria JSONB field to find the existing errors; that is where the mismatch was happening, with the record in the db having nil and the matching value expecting an empty string, so trying to create a new error_record rather than update the preexisting one.

Happy to have a chat if any of the above is not clear