### PR TITLE
Fix checklist download params

### DIFF
--- a/app/controllers/checklist/downloads_controller.rb
+++ b/app/controllers/checklist/downloads_controller.rb
@@ -64,12 +64,12 @@ class Checklist::DownloadsController < ApplicationController
   end
 
   def download_index
-    @doc = download_module::Index.new(checklist_params)
+    @doc = download_module::Index.new(**checklist_params)
     send_download
   end
 
   def download_history
-    @doc = download_module::History.new(checklist_params)
+    @doc = download_module::History.new(**checklist_params)
     send_download
   end
 
@@ -112,7 +112,8 @@ private
 
   def checklist_params
     Checklist::ChecklistParams.sanitize(
-      params
+      # defer param permitting to Checklist::ChecklistParams
+      params.permit(params.keys).to_h
     )
   end
 end

--- a/app/services/checklist/checklist_params.rb
+++ b/app/services/checklist/checklist_params.rb
@@ -1,41 +1,56 @@
-# Constructs a normalised list of parameters, with non-recognised params
+# Constructs a normalised hash of parameters, with non-recognised params
 # removed.
-#
+
 class Checklist::ChecklistParams < Hash
   include SearchParamSanitiser
 
-  def initialize(params)
+  def initialize(original_params)
+    get_param =
+      Proc.new do |*accessors|
+        got = nil
+
+        accessors.each do |accessor|
+          if original_params.has_key?(accessor)
+            got = original_params[accessor]
+            break
+          end
+        end
+
+        got
+      end
+
     sanitized_params = {
       # possible output layouts are:
       # taxonomic (hierarchic, taxonomic order)
       # alphabetical (flat, alphabetical order)
       output_layout: whitelist_param(
-        sanitise_symbol(params[:output_layout]),
+        sanitise_symbol(original_params[:output_layout]),
         [ :taxonomic, :alphabetical, :appendix ],
         :alphabetical
       ),
-      level_of_listing: sanitise_boolean(params[:level_of_listing], false),
+      level_of_listing: sanitise_boolean(original_params[:level_of_listing], false),
       # filtering options
-      scientific_name: sanitise_upcase_string(params[:scientific_name]),
-      countries: sanitise_integer_array(params[:country_ids]),
-      cites_regions: sanitise_integer_array(params[:cites_region_ids]),
-      cites_appendices: sanitise_string_array(params[:cites_appendices]),
+      scientific_name: sanitise_upcase_string(original_params[:scientific_name]),
+      countries: sanitise_integer_array(get_param.(:countries, :country_ids)),
+      cites_regions: sanitise_integer_array(get_param.(:cites_regions, :cites_region_ids)),
+      cites_appendices: sanitise_string_array(original_params[:cites_appendices]),
       # optional data
-      english_common_names: sanitise_boolean(params[:show_english], false),
-      spanish_common_names: sanitise_boolean(params[:show_spanish], false),
-      french_common_names: sanitise_boolean(params[:show_french], false),
-      synonyms: sanitise_boolean(params[:show_synonyms], false),
-      authors: sanitise_boolean(params[:show_author], false),
-      intro: sanitise_boolean(params[:intro], false),
-      page: sanitise_positive_integer(params[:page], 1),
-      per_page: sanitise_positive_integer(params[:per_page], 20)
+      english_common_names: sanitise_boolean(get_param.(:english_common_names, :show_english), false),
+      spanish_common_names: sanitise_boolean(get_param.(:spanish_common_names, :show_spanish), false),
+      french_common_names: sanitise_boolean(get_param.(:french_common_names, :show_french), false),
+      synonyms: sanitise_boolean(get_param.(:synonyms, :show_synonyms), false),
+      authors: sanitise_boolean(get_param.(:authors, :show_author), false),
+      intro: sanitise_boolean(original_params[:intro], false),
+      page: sanitise_positive_integer(original_params[:page], 1),
+      per_page: sanitise_positive_integer(original_params[:per_page], 20)
     }
 
     super(sanitized_params)
+
     self.merge!(sanitized_params)
   end
 
-  def self.sanitize(params)
-    new(params)
+  def self.sanitize(original_params)
+    new(original_params)
   end
 end

--- a/lib/modules/search_param_sanitiser.rb
+++ b/lib/modules/search_param_sanitiser.rb
@@ -15,7 +15,9 @@ module SearchParamSanitiser
   end
 
   def sanitise_boolean(b, default = nil)
-    (b && ActiveRecord::Type::Boolean.new.cast(b)) || default
+    cast_b = ActiveRecord::Type::Boolean.new.cast(b)
+
+    cast_b.nil? ? default : cast_b
   end
 
   def sanitise_positive_integer(i, default = nil)

--- a/spec/services/checklist/checklist_spec.rb
+++ b/spec/services/checklist/checklist_spec.rb
@@ -1,5 +1,75 @@
 require 'spec_helper'
 
+describe Checklist::ChecklistParams do
+  default_sanitized = {
+    authors: false,
+    cites_appendices: [],
+    cites_regions: [],
+    countries: [],
+    english_common_names: false,
+    french_common_names: false,
+    intro: false,
+    level_of_listing: false,
+    output_layout: :alphabetical,
+    page: 1,
+    per_page: 20,
+    scientific_name: nil,
+    spanish_common_names: false,
+    synonyms: false
+  }
+
+  describe :sanitize do
+    context 'when params empty' do
+      specify do
+        expect(
+          Checklist::ChecklistParams.sanitize({})
+        ).to match(
+          default_sanitized
+        )
+      end
+    end
+
+    context 'when show_author = true' do
+      specify do
+        expect(
+          Checklist::ChecklistParams.sanitize({ show_author: true })
+        ).to match(
+          default_sanitized.merge({ authors: true })
+        )
+      end
+    end
+
+    context 'when authors = true' do
+      specify do
+        expect(
+          Checklist::ChecklistParams.sanitize({ authors: true })
+        ).to match(
+          default_sanitized.merge({ authors: true })
+        )
+      end
+    end
+
+    context 'Fully repeatable' do
+      specify do
+        first_iteration =
+          Checklist::ChecklistParams.sanitize(
+            authors: true,
+            show_spanish: true,
+            country_ids: [ 123, 234, 345 ]
+          )
+
+        expect(
+          Checklist::ChecklistParams.sanitize(
+            first_iteration
+          )
+        ).to match(
+          first_iteration
+        )
+      end
+    end
+  end
+end
+
 describe Checklist::Checklist do
   describe :summarise_filters do
     context 'when params empty' do


### PR DESCRIPTION
Relates to https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/336

Fixes issues where e.g. the `show_author` param was being ignored.