### PR TITLE
elibrary document migrate to ActiveStorage S3 part 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,10 @@ gem 'coffee-rails', '~> 5.0'
 # gem 'mini_racer', platforms: :ruby
 
 gem 'active_model_serializers', '0.8.4' # Deprecated
+gem "active_storage_validations", "~> 2.0"
+
+# Use redis for caching
+gem "redis", "~> 4.8"
 
 # Use PostgreSQL database
 gem 'pg', '~> 1.5', '>= 1.5.4'
@@ -226,4 +230,4 @@ gem 'handlebars-source', '1.0.12' # TODO: just a wrapwrapper. Any update will ch
 # the config: `passenger_preload_bundler on;`
 gem 'base64', '0.1.1'
 
-gem "redis", "~> 4.8"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,12 @@ GEM
       ember-data-source (>= 1.13, < 3.0)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
+    active_storage_validations (2.0.3)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     activejob (7.1.3.4)
       activesupport (= 7.1.3.4)
       globalid (>= 0.3.6)
@@ -620,6 +626,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (= 0.8.4)
+  active_storage_validations (~> 2.0)
   acts-as-taggable-on (~> 10.0)
   ahoy_matey (~> 5.0, >= 5.0.2)
   annotaterb (~> 4.10.2)

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -101,24 +101,18 @@ class Api::V1::DocumentsController < ApplicationController
 
   def show
     @document = Document.find(params[:id])
-    path_to_file = @document.filename.path unless @document.is_link?
 
     if access_denied? && !@document.is_public
       render_403
     elsif @document.is_link?
-      redirect_to @document.filename.model[:filename], allow_other_host: true
-    elsif !File.exist?(path_to_file)
+      redirect_to @document.elib_legacy_file_name, allow_other_host: true
+    elsif !@document.file.attached?
       render_404
     else
-      response.headers['Content-Length'] = File.size(path_to_file).to_s
-
-      send_file(
-        path_to_file,
-        filename: File.basename(path_to_file),
-        type: @document.filename.content_type,
-        disposition: 'inline',
-        url_based_filename: true
-      )
+      # Redirect to S3 URL, which only valid for 1 minute (override Rails 7.1 default, which was 5 minutes)
+      # WARNING: Don't use `rails_blob_url` for security reasons because it generates a permanent URL without requiring
+      # authentication.
+      redirect_to @document.file.url(disposition: 'attachment', expires_in: 1.minute), allow_other_host: true
     end
   end
 
@@ -131,15 +125,14 @@ class Api::V1::DocumentsController < ApplicationController
 
     Zip::OutputStream.open(t.path) do |zos|
       @documents.each do |document|
-        path_to_file = document.filename.path
-        filename = path_to_file.split('/').last
-
-        unless File.exist?(path_to_file)
+        unless document.file.attached?
           missing_files <<
-            "{\n  title: #{document.title},\n  filename: #{filename}\n}"
+            "{\n  title: #{document.title},\n  filename: #{document.filename}\n}"
         else
-          zos.put_next_entry(filename)
-          zos.print File.read(path_to_file)
+          zos.put_next_entry(document.file.filename)
+          ActiveStorage::Blob.service.download(document.file.blob.key) do |chunk|
+            zos.print(chunk)
+          end
         end
       end
 

--- a/app/controllers/checklist/documents_controller.rb
+++ b/app/controllers/checklist/documents_controller.rb
@@ -23,24 +23,18 @@ class Checklist::DocumentsController < ApplicationController
 
   def show
     @document = Document.find(params[:id])
-    path_to_file = @document.filename.path unless @document.is_link?
 
     if access_denied? && !@document.is_public
       render_403
     elsif @document.is_link?
-      redirect_to @document.filename.model[:filename], allow_other_host: true
-    elsif !File.exist?(path_to_file)
+      redirect_to @document.elib_legacy_file_name, allow_other_host: true
+    elsif !@document.file.attached?
       render_404
     else
-      response.headers['Content-Length'] = File.size(path_to_file).to_s
-
-      send_file(
-        path_to_file,
-        filename: File.basename(path_to_file),
-        type: @document.filename.content_type,
-        disposition: 'attachment',
-        url_based_filename: true
-      )
+      # Redirect to S3 URL, which only valid for 1 minute (override Rails 7.1 default, which was 5 minutes)
+      # WARNING: Don't use `rails_blob_url` for security reasons because it generates a permanent URL without requiring
+      # authentication.
+      redirect_to @document.file.url(disposition: 'attachment', expires_in: 1.minute), allow_other_host: true
     end
   end
 

--- a/app/serializers/checklist/document_serializer.rb
+++ b/app/serializers/checklist/document_serializer.rb
@@ -16,12 +16,4 @@ class Checklist::DocumentSerializer < ActiveModel::Serializer
   end
 
   delegate :taxon_concept_ids, to: :object
-
-  def is_link
-    object.document_type == 'Document::VirtualCollege' && !is_pdf?
-  end
-
-  def is_pdf?
-    (Document.find(object.primary_document_id).elib_legacy_file_name =~ /\.pdf/).present?
-  end
 end

--- a/app/serializers/species/document_serializer.rb
+++ b/app/serializers/species/document_serializer.rb
@@ -11,12 +11,4 @@ class Species::DocumentSerializer < ActiveModel::Serializer
   end
 
   delegate :document_language_versions, to: :object
-
-  def is_link
-    object.document_type == 'Document::VirtualCollege' && !is_pdf?
-  end
-
-  def is_pdf?
-    (Document.find(object.primary_document_id).elib_legacy_file_name =~ /\.pdf/).present?
-  end
 end

--- a/app/services/document_batch.rb
+++ b/app/services/document_batch.rb
@@ -39,11 +39,18 @@ private
     @documents = []
     if documents_attributes && files
       for idx in 0..(files.length - 1) do
-        document_params = {
-          type: documents_attributes[idx.to_s][:type],
-          filename: files[idx],
-          title: document_title(files[idx])
-        }
+        document_params =
+          if files[idx].respond_to?(:read) # Filter out invalid params for ActiveStorage.
+            {
+              type: documents_attributes[idx.to_s][:type],
+              file: files[idx],
+              title: document_title(files[idx])
+            }
+          else
+            {
+              type: documents_attributes[idx.to_s][:type],
+            }
+          end
         @documents.push(Document.new(common_attributes.merge(document_params)))
       end
     end
@@ -64,6 +71,6 @@ private
 
   def document_title(file)
     original_filename = file.is_a?(Hash) ? file[:filename].original_filename : file.original_filename
-    original_filename.sub(/.\w+$/, '')
+    File.basename(original_filename, File.extname(original_filename))
   end
 end

--- a/app/views/admin/document_batches/new.html.erb
+++ b/app/views/admin/document_batches/new.html.erb
@@ -47,7 +47,7 @@
   <div class="control-group">
     <label class="control-label">Documents</label>
     <div class="controls">
-      <%= file_field_tag "document_batch[files][]", multiple: true, id: 'file-upload' %>
+      <%= file_field_tag "document_batch[files][]", multiple: true, accept: Document::ACCEPTED_CONTENT_TYPES.join(','), id: 'file-upload' %>
       <div id="document-form-collection"></div>
     </div>
   </div>

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -198,10 +198,10 @@
   </div>
 
   <div class="control-group">
-    <%= f.label :filename, class: 'control-label' %>
+    <%= f.label :file, class: 'control-label' %>
     <div class="controls">
-      <%= @document.filename %>
-      <%= f.file_field :filename %>
+      <%= @document.file.filename %>
+      <%= f.file_field :file, accept: Document::ACCEPTED_CONTENT_TYPES.join(',') %>
     </div>
   </div>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   minio:
     container_name: sapi-minio
     image: minio/minio:latest
-    command: server /data --console-address ":9001"
+    command: server /data --address 0.0.0.0:9000 --console-address ":9001"
     ports:
       - "${SAPI_CONTAINER_S3_PORT:-9000}:9000"
       - "${SAPI_CONTAINER_S3_CONSOLE_PORT:-9001}:9001"

--- a/spec/controllers/api/documents_controller_spec.rb
+++ b/spec/controllers/api/documents_controller_spec.rb
@@ -107,13 +107,12 @@ describe Api::V1::DocumentsController do
   context 'download documents' do
     context 'single document selected' do
       it 'should return 404 if file is missing' do
-        expect(File).to receive(:exist?).and_return(false)
+        @document2.file.purge
         get :download_zip, params: { ids: @document2.id }
         expect(response).to have_http_status(404)
       end
       it 'should return zip file if file is found' do
         allow(controller).to receive(:render)
-        expect(File).to receive(:exist?).and_return(true)
         get :download_zip, params: { ids: @document2.id }
         expect(response.headers['Content-Type']).to eq 'application/zip'
       end
@@ -121,13 +120,14 @@ describe Api::V1::DocumentsController do
 
     context 'multiple documents selected' do
       it 'should return 404 if all files are missing' do
-        expect(File).to receive(:exist?).and_return(false, false)
+        @document.file.purge
+        @document2.file.purge
         get :download_zip, params: { ids: "#{@document.id},#{@document2.id}" }
         expect(response).to have_http_status(404)
       end
 
       it 'should return zip file if at least a file is found' do
-        expect(File).to receive(:exist?).and_return(false, true)
+        @document.file.purge
         get :download_zip, params: { ids: "#{@document.id},#{@document2.id}" }
         expect(response.headers['Content-Type']).to eq 'application/zip'
       end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :document do
     date { Date.today }
-    filename { Rack::Test::UploadedFile.new(Rails.root.join('spec/support/annual_report_upload_exporter.csv').to_s) }
+    file { Rack::Test::UploadedFile.new(Rails.root.join('spec/support/annual_report_upload_exporter.csv').to_s) }
     designation
     event
     type { 'Document' }


### PR DESCRIPTION
This is phase 2 PR, continues from PR #1018 

---
Related tickets:
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/369

**In this PR:**
1. Add file type validation in both the model and frontend, matching the original requirements from DocumentFileUploader.
2. Serve files via signed S3 URLs, valid for 1 minute.
3. Update the code to support file uploads using ActiveStorage.
4. Fix RSpec tests.
5. Fix `is_pdf?` logic to use the `content_type` column.