### PR TITLE
move ARU CSV files to /private

### DIFF
--- a/app/uploaders/trade/csv_source_file_uploader.rb
+++ b/app/uploaders/trade/csv_source_file_uploader.rb
@@ -16,7 +16,11 @@ class Trade::CsvSourceFileUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    "#{Rails.root.join("private/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}")}"
+  end
+
+  def cache_dir
+    "#{Rails.root.join("tmp/private/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}")}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:


### PR DESCRIPTION
This config should work, need to test on staging.

For the original path in file system, I would say it safe to remove them.
- public/uploads/trade/annual_report_upload
- public/uploads/tmp