### PR TITLE
Changes to Part 1 of ticket to migrate e-Library documents to active storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ FROM ruby:3.2.5
 
 # Rails and SAPI has some additional dependencies, e.g. rake requires a JS
 # runtime, so attempt to get these from apt, where possible
+# socat is just for binding ports within docker, not needed for the application
 RUN apt-get update && apt-get install -y --force-yes \
   libsodium-dev libgmp3-dev libssl-dev \
   libpq-dev postgresql-client \
   nodejs \
+  socat \
   texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra \
   ;
 # NB: Postgres client from Debian is 9.4 - not sure if this is acceptable

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/agenda_items.rb
+++ b/app/models/document/agenda_items.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/commission_notes.rb
+++ b/app/models/document/commission_notes.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/detailed_summary_of_conclusions.rb
+++ b/app/models/document/detailed_summary_of_conclusions.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/id_manual.rb
+++ b/app/models/document/id_manual.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/list_of_participants.rb
+++ b/app/models/document/list_of_participants.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/meeting_agenda.rb
+++ b/app/models/document/meeting_agenda.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/ndf_consultation.rb
+++ b/app/models/document/ndf_consultation.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/non_detriment_findings.rb
+++ b/app/models/document/non_detriment_findings.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/proposal.rb
+++ b/app/models/document/proposal.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/range_state_consultation_letter.rb
+++ b/app/models/document/range_state_consultation_letter.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/review_of_significant_trade.rb
+++ b/app/models/document/review_of_significant_trade.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/search_result.rb
+++ b/app/models/document/search_result.rb
@@ -12,7 +12,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/short_summary_of_conclusions.rb
+++ b/app/models/document/short_summary_of_conclusions.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/unep_wcmc_report.rb
+++ b/app/models/document/unep_wcmc_report.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/app/models/document/virtual_college.rb
+++ b/app/models/document/virtual_college.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -31,4 +31,17 @@ mkdir -p {./,spec/}public/downloads/taxon_concepts_names
 #   ./bin/rails db:prepare
 # fi
 
-exec "${@}"
+# Bind 'minio:9000' to 'localhost:9000' so that we can correctly generate
+# signed S3 urls.
+# We use the approach documented in:
+# https://docs.docker.com/engine/containers/multi-service_container/
+/usr/bin/socat TCP-LISTEN:9000,fork,reuseaddr TCP:minio:9000 &
+
+# This is the main rails/sidekiq command
+exec "${@}" &
+
+# Wait for any process to exit
+wait -n
+
+# Exit with status of process that exited first
+exit $?

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -21,7 +21,7 @@ amazon: &amazon
 
 local_s3:
   <<: [*amazon]
-  endpoint: 'http://host.docker.internal:<%= ENV.fetch("SAPI_CONTAINER_S3_PORT", 9000) %>'
+  endpoint: 'http://localhost:<%= ENV.fetch("SAPI_CONTAINER_S3_PORT", 9000) %>'
   force_path_style: true
 
 # Remember not to checkin your GCS keyfile to a repository

--- a/db/migrate/20250513134147_document_filename_column_deprecated.rb
+++ b/db/migrate/20250513134147_document_filename_column_deprecated.rb
@@ -1,5 +1,22 @@
+##
+# Make the filename column nullable on Document; after this, uploads will go
+# into S3 storage rather than being kept on the disk of the web server.
+#
+# Note that the rollback 'down' migration is DESTRUCTIVE - all documents created
+# since the change will be deleted, as they can no longer be represented in the
+# previous schema.
+
 class DocumentFilenameColumnDeprecated < ActiveRecord::Migration[7.1]
   def change
-    change_column_null :documents, :filename, true
+    reversible do |dir|
+      dir.up do
+        change_column_null :documents, :filename, true
+      end
+
+      dir.down do
+        Document.where(filename: nil).destroy_all
+        change_column_null :documents, :filename, false
+      end
+    end
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -6,7 +6,7 @@
 #  date                         :date             not null
 #  discussion_sort_index        :integer
 #  elib_legacy_file_name        :text
-#  filename                     :text             not null
+#  filename                     :text
 #  general_subtype              :boolean
 #  is_public                    :boolean          default(FALSE), not null
 #  sort_index                   :integer


### PR DESCRIPTION
- Commits automatically-generated changes to annotations so comments reflect schema change.
- Make it possible to run the down migration for DocumentFilenameColumnDeprecated (note that this is destructive) - it's useful to be able to do this in development.
- Use `socat` to map minio:9000 to rails container's localhost:9000 so as to avoid needing a hack on the host machine to map `host.docker.internal` to `localhost`