### PR TITLE
Feat/447 checklist listings order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Fixes an issue where the serialisation of the autocomplete results for new
   taxon concepts is broken until they go through the cascade.
 
+**CITES Checklist**
+
+* Fixes an issue where the serialisation of listing changes in the History
+  downloads for the CITES Checklist were in an unintuitive order.
+
 ### 1.21.1
 
 **CITES Trade DB**

--- a/app/models/m_taxon_concept.rb
+++ b/app/models/m_taxon_concept.rb
@@ -126,17 +126,23 @@ class MTaxonConcept < ApplicationRecord
       where(
         show_in_downloads: true
       ).order(
-        Arel.sql(
-          <<-SQL.squish
+        # This order is used for the CITES Checklist History downloads,
+        # particularly the PDF and is intentionally different from the order
+        # used in the display of the timelines on the checklist website. The
+        # checklist display is intended to identify the most important change,
+        # and put it last (on top) whereas here we want a more human-readable
+        # order.
+        Arel.sql <<-SQL.squish
           effective_at,
+          species_listing_name,
           CASE
-          WHEN change_type_name = 'ADDITION' THEN 0
-          WHEN change_type_name = 'RESERVATION' THEN 1
+          WHEN change_type_name = 'DELETION' THEN 0
+          WHEN change_type_name = 'ADDITION' THEN 1
           WHEN change_type_name = 'RESERVATION_WITHDRAWAL' THEN 2
-          WHEN change_type_name = 'DELETION' THEN 3
-          END
+          WHEN change_type_name = 'RESERVATION' THEN 3
+          END,
+          party_iso_code
         SQL
-        )
       )
     },
     foreign_key: :taxon_concept_id,

--- a/app/services/checklist/higher_taxa_injector.rb
+++ b/app/services/checklist/higher_taxa_injector.rb
@@ -14,36 +14,45 @@ class Checklist::HigherTaxaInjector
     @ranks = [ 'PHYLUM', 'CLASS', 'ORDER', 'FAMILY', 'SUBFAMILY', 'GENUS', 'SPECIES' ]
     @header_ranks = options[:header_ranks] || [ 'PHYLUM', 'CLASS', 'ORDER', 'FAMILY' ]
     @taxon_concepts = taxon_concepts
+
     # fetch all higher taxa first
     higher_taxa_ids = @taxon_concepts.map do |tc|
       [ tc.phylum_id, tc.class_id, tc.order_id, tc.family_id ]
     end.flatten.uniq
+
     @higher_taxa =
       MTaxonConcept.where(id: higher_taxa_ids).index_by { |tc| tc.id }
   end
 
   def run
     res = []
+
     @taxon_concepts.each_with_index do |tc, i|
       prev_item = (i > 0 ? @taxon_concepts[i - 1] : nil)
       res +=
         higher_taxa_headers(prev_item, tc).map do |ht|
           Checklist::HigherTaxaItem.new(ht)
         end
+
       res << tc
     end
     res
   end
 
   def run_summary
-    @expand_headers = false # use this only for collapsed headers
-    # such as the Checklist or Species+ website
+    # use @expand_headers only for collapsed headers, such as the Checklist or
+    # Species+ website
+    @expand_headers = false
+
     res = []
+
     current_higher_taxon = nil
     current_higher_taxon_children_ids = []
+
     @taxon_concepts.each_with_index do |tc, i|
       prev_item = (i > 0 ? @taxon_concepts[i - 1] : nil)
       higher_taxon = higher_taxa_headers(prev_item, tc).first
+
       if higher_taxon
         res.push(
           {
@@ -54,8 +63,10 @@ class Checklist::HigherTaxaInjector
         current_higher_taxon = higher_taxon
         current_higher_taxon_children_ids = []
       end
+
       current_higher_taxon_children_ids << tc.id
     end
+
     # push the last one
     res.push(
       {
@@ -77,30 +88,37 @@ class Checklist::HigherTaxaInjector
 
         for rank in @header_ranks.reverse
           rank_id_attr = "#{rank.downcase}_id"
+
           curr_item.send(rank_id_attr)
+
           if prev_item.send(rank_id_attr) == curr_item.send(rank_id_attr)
             break
           else
             tmp << rank
           end
         end
+
         tmp.reverse
       end
 
     ranks = [ ranks.last ].compact unless @expand_headers
 
     res = []
+
     @last_ancestor_ids = @header_ranks.map { |rank| curr_item.send("#{rank.downcase}_id") }
+
     ranks.each_with_index do |rank, idx|
       higher_taxon_id = curr_item.send("#{rank.downcase}_id")
 
       unless prev_item && prev_item.send("#{rank.downcase}_id") == higher_taxon_id && !@expand_headers
         higher_taxon = @higher_taxa[higher_taxon_id]
+
         if higher_taxon && !(@skip_ancestor_ids && @skip_ancestor_ids.include?(higher_taxon.id))
           res << higher_taxon
         end
       end
     end
+
     res
   end
 end

--- a/app/services/checklist/higher_taxa_item.rb
+++ b/app/services/checklist/higher_taxa_item.rb
@@ -13,6 +13,7 @@ class Checklist::HigherTaxaItem
         [ 'PHYLUM', 'CLASS', 'ORDER', 'FAMILY', 'SUBFAMILY' ]
       end
     current_idx = taxa.index(rank_name) || 0
+
     0.upto(current_idx).map do |i|
       taxa[i]
     end

--- a/app/services/checklist/pdf/history_content.rb
+++ b/app/services/checklist/pdf/history_content.rb
@@ -1,10 +1,15 @@
 module Checklist::Pdf::HistoryContent
   def content(tex)
     fetcher = Checklist::HistoryFetcher.new(@animalia_rel)
+
     kingdom(tex, fetcher, 'FAUNA')
+
     fetcher = Checklist::HistoryFetcher.new(@plantae_rel)
+
     kingdom(tex, fetcher, 'FLORA')
+
     ak = Checklist::Pdf::HistoryAnnotationsKey.new
+
     tex << ak.annotations_key
   end
 
@@ -15,8 +20,8 @@ module Checklist::Pdf::HistoryContent
     @skip_ancestor_ids = nil
 
     tex << "\\cpart{#{kingdom_name}}\n"
-    begin
 
+    begin
       injector = Checklist::HigherTaxaInjector.new(
         kingdom,
         {
@@ -25,90 +30,100 @@ module Checklist::Pdf::HistoryContent
           header_ranks: (kingdom_name == 'FLORA' ? [ 'FAMILY' ] : nil)
         }
       )
+
       kingdom = injector.run
       @skip_ancestor_ids = injector.last_ancestor_ids
 
       listed_taxa_ary = []
+
       kingdom.each do |tc|
         if tc.kind_of? Checklist::HigherTaxaItem
           unless listed_taxa_ary.empty?
             listed_taxa(tex, listed_taxa_ary, kingdom_name)
+
             listed_taxa_ary = []
           end
+
           tex << higher_taxon_name(tc)
         else
           listed_taxa_ary << tc
         end
       end
+
       unless listed_taxa_ary.empty?
         listed_taxa(tex, listed_taxa_ary, kingdom_name)
+
         listed_taxa_ary = []
       end
+
       kingdom = fetcher.next
     end while !kingdom.empty?
   end
 
   def listed_taxa(tex, listed_taxa_ary, kingdom_name = 'FAUNA')
     tex << "\\listingtable#{kingdom_name.downcase}{"
+
     rows = []
+
     listed_taxa_ary.each do |tc|
       listed_taxon_name = listed_taxon_name(tc)
       is_tc_row = true # it is the first row per taxon concept
+
       tc.historic_cites_listing_changes_for_downloads.each do |lc|
         is_lc_row = true # it is the first row per listing change
         ann = annotation_for_language(lc, I18n.locale)
         row = []
+
         # tc fields
         row << (is_tc_row ? listed_taxon_name : '')
         is_tc_row = false
+
         # lc fields
         row << (is_lc_row ? listing_with_change_type(lc) : '')
         row << (is_lc_row && lc.party_iso_code ? lc.party_iso_code.upcase : '')
         row << (is_lc_row ? lc.effective_at_formatted : '')
+
         if kingdom_name == 'FLORA'
           row << (is_lc_row ? "#{LatexToPdf.escape_latex(lc.full_hash_ann_symbol)}" : '')
         end
+
         is_lc_row = false
         # ann fields
         row << ann
         rows << row.join(' & ')
       end
     end
+
     tex << rows.join("\\\\\n")
     tex << '}'
   end
 
   def listing_with_change_type(listing_change)
-    appendix =
-      if listing_change.change_type_name == ChangeType::DELETION
-        nil
-      else
-        listing_change.species_listing_name
-      end
-    change_type =
-      if listing_change.change_type_name == ChangeType::RESERVATION
-        '/r'
-      elsif listing_change.change_type_name == ChangeType::RESERVATION_WITHDRAWAL
-        '/w'
-      elsif listing_change.change_type_name == ChangeType::DELETION
-        'Del'
-      else
-        nil
-      end
-    "#{appendix}#{change_type}"
+    if listing_change.change_type_name == ChangeType::RESERVATION
+      "#{listing_change.species_listing_name}/r"
+    elsif listing_change.change_type_name == ChangeType::RESERVATION_WITHDRAWAL
+      "#{listing_change.species_listing_name}/w"
+    elsif listing_change.change_type_name == ChangeType::DELETION
+      "#{listing_change.species_listing_name}/del"
+    else
+      listing_change.species_listing_name
+    end
   end
 
   def annotation_for_language(listing_change, lng)
     short_note = LatexToPdf.html2latex(
       listing_change.send("short_note_#{lng}")
     )
+
     nomenclature_note = LatexToPdf.html2latex(
       listing_change.send("nomenclature_note_#{lng}")
     )
+
     if listing_change.display_in_footnote
       full_note = listing_change.send("full_note_#{lng}")
       full_note && full_note.gsub!(/[\n\r]/, ' ')
       full_note = LatexToPdf.html2latex(full_note)
+
       "#{short_note}\n\n#{nomenclature_note}\\footnote{#{full_note}}"
     else
       "#{short_note}\n\n#{nomenclature_note}"
@@ -122,15 +137,19 @@ module Checklist::Pdf::HistoryContent
       else
         taxon_concept.full_name
       end
+
     if [ 'SPECIES', 'SUBSPECIES', 'GENUS' ].include? taxon_concept.rank_name
       res = "\\emph{#{res}}"
     end
+
     res += " #{taxon_concept.spp}" if taxon_concept.spp
+
     res
   end
 
   def higher_taxon_name(taxon_concept)
     common_names = common_names_with_lng_initials(taxon_concept)
+
     if taxon_concept.rank_name == 'PHYLUM' && taxon_concept.kingdom_name == 'Animalia'
       "\\csection{#{taxon_concept.full_name.upcase}}\n"
     elsif taxon_concept.rank_name == 'CLASS' && taxon_concept.kingdom_name == 'Animalia'

--- a/app/services/checklist/pdf/index_query.rb
+++ b/app/services/checklist/pdf/index_query.rb
@@ -32,25 +32,26 @@ class Checklist::Pdf::IndexQuery
         english: "REGEXP_REPLACE(UNNEST(english_names_ary), '(.+) (.+)', '\\2, \\1')",
         spanish: 'UNNEST(spanish_names_ary)',
         french: 'UNNEST(french_names_ary)',
-        synonym: if @authors
-                   <<-SQL.squish
-            UNNEST(ARRAY(SELECT synonym ||
-            CASE
-            WHEN author_year IS NOT NULL
-            THEN ' ' || author_year
-            ELSE ''
-            END
-            FROM (
-              (SELECT synonym, ROW_NUMBER() OVER() AS id FROM (SELECT * FROM UNNEST(synonyms_ary) AS synonym) q) synonyms
-              LEFT JOIN
-              (SELECT author_year, ROW_NUMBER() OVER() AS id FROM (SELECT * FROM UNNEST(synonyms_author_years_ary) AS author_year) q) author_years
-              ON synonyms.id = author_years.id
-            )
-            ))
+        synonym:
+          if @authors
+            <<-SQL.squish
+              UNNEST(ARRAY(SELECT synonym ||
+              CASE
+              WHEN author_year IS NOT NULL
+              THEN ' ' || author_year
+              ELSE ''
+              END
+              FROM (
+                (SELECT synonym, ROW_NUMBER() OVER() AS id FROM (SELECT * FROM UNNEST(synonyms_ary) AS synonym) q) synonyms
+                LEFT JOIN
+                (SELECT author_year, ROW_NUMBER() OVER() AS id FROM (SELECT * FROM UNNEST(synonyms_author_years_ary) AS author_year) q) author_years
+                ON synonyms.id = author_years.id
+              )
+              ))
             SQL
-                 else
-                   'UNNEST(synonyms_ary)'
-                 end
+          else
+            'UNNEST(synonyms_ary)'
+          end
       },
       lng: {
         english: "'E'",
@@ -65,6 +66,7 @@ class Checklist::Pdf::IndexQuery
           (distinct_columns_values[dc][name_type] || 'null') + " AS #{dc}"
         end + shared_columns
       ).join(',') + ' FROM taxon_concept_matches'
+
       instance_variable_set("@#{name_type}_select_clause", select_clause)
     end
   end
@@ -75,19 +77,20 @@ class Checklist::Pdf::IndexQuery
         #{@rel.to_sql}
       )
     SQL
+
     inner_query << @basic_select_clause
     inner_query << " UNION #{@english_select_clause}" if @english_common_names
     inner_query << " UNION #{@spanish_select_clause}" if @spanish_common_names
     inner_query << " UNION #{@french_select_clause}" if @french_common_names
     inner_query << " UNION #{@synonym_select_clause}" if @synonyms
 
-    outer_query = <<-SQL.squish
-    WITH name_matches AS (
-      #{inner_query}
-    )
-    SELECT * FROM name_matches WHERE sort_name IS NOT NULL
-    ORDER BY UPPER(sort_name) COLLATE "en_US"
-    LIMIT #{limit} OFFSET #{offset}
+    <<-SQL.squish
+      WITH name_matches AS (
+        #{inner_query}
+      )
+      SELECT * FROM name_matches WHERE sort_name IS NOT NULL
+      ORDER BY UPPER(sort_name) COLLATE "en_US"
+      LIMIT #{limit} OFFSET #{offset}
     SQL
   end
 end

--- a/public/latex/history.tex
+++ b/public/latex/history.tex
@@ -78,7 +78,7 @@
 }
 
 \newcommand{\listingtableflora}[1]{
-  \begin{longtable}[t]{>{\raggedright\arraybackslash}p{4.4cm}p{0.4cm}p{0.4cm}p{1.4cm}p{1.4cm}>{\raggedright\arraybackslash}p{8cm}}
+  \begin{longtable}[t]{>{\raggedright\arraybackslash}p{4.25cm}p{0.5cm}p{0.5cm}p{1.5cm}p{1.75cm}>{\raggedright\arraybackslash}p{7.5cm}}
   #1
   \end{longtable}
 }


### PR DESCRIPTION
I've made a few changes:

- Listings are now ordered by
    - `effective_at`
    - `species_listing_name`, i.e. appendix
    - `change_type_name` (deletion, addition, withdrawal, reservation)
    - `party_iso_code`, i.e. the 2-letter country code of AppIII listings
- To avoid confusion where there are multiple appendices in force, deletions are no longer listed simply as `Del` but as `III/del`.
- I've adjusted the spacing on the columns on the flora table slightly to account for the above.

https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/447