### PR TITLE
Fix synonym authorship on CITES Checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 1.22.0
+
+**CITES Checklist**
+
+* Fixed an issue where the authorship of synonyms was occasionally displaying
+  incorrectly. This happened when there were multiple synonyms and one or more
+  had no authorship information.
+
+**Species+ Admin Interface**
+
+* Fixed a security issue where admins could in theory cause arbitrary SQL to
+  be executed with sufficiently well-crafted taxon names.
+
 ### 1.21.2
 
 **Species+**

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -48,20 +48,20 @@ AS $ancestor_listing_auto_note$
       SELECT
         UPPER(
           COALESCE(
-            ranks.%I$1,
+            ranks.%1$I,
             ranks.display_name_en,
             ranks.name
           )
         ) || ' ' || COALESCE(
-          change_types.%I$1,
+          change_types.%1$I,
           change_types.display_name_en,
           change_types.name
         ) || ' ' || full_name_with_spp(
-          ranks.name, %L$2, %L$3
+          ranks.name, %2$L, %3$L
         )
         FROM ranks, change_types
-        WHERE ranks.id = %L$4
-        AND change_types.id = %L$5
+        WHERE ranks.id = %4$L
+        AND change_types.id = %5$L
       $execute$,
       'display_name_' || locale,
       taxon_concept.full_name,
@@ -116,7 +116,7 @@ AS $drop_trade_sandboxes$
         AND table_name != 'trade_sandbox_template'
         AND table_type != 'VIEW'
     LOOP
-      EXECUTE format('DROP TABLE %I$1 CASCADE', current_table_name);
+      EXECUTE format('DROP TABLE %1$I CASCADE', current_table_name);
     END LOOP;
 
     RETURN;
@@ -138,7 +138,7 @@ LANGUAGE plpgsql AS $drop_trade_sandbox_views$
       WHERE table_name LIKE 'trade_sandbox%_view'
         AND table_type = 'VIEW'
     LOOP
-      EXECUTE format('DROP VIEW IF EXISTS %I$1 CASCADE', current_view_name);
+      EXECUTE format('DROP VIEW IF EXISTS %1$I CASCADE', current_view_name);
     END LOOP;
 
     RETURN;
@@ -193,7 +193,7 @@ AS $create_trade_sandbox_view$
   BEGIN
     EXECUTE format(
       $format$
-        CREATE VIEW %I$1 AS
+        CREATE VIEW %1$I AS
         SELECT aru.point_of_view,
           CASE
             WHEN aru.point_of_view = 'E'
@@ -208,9 +208,9 @@ AS $create_trade_sandbox_view$
           taxon_concepts.full_name AS accepted_taxon_name,
           taxon_concepts.data->'rank_name' AS rank,
           taxon_concepts.rank_id,
-          %I$2.*
-        FROM %I$2
-        JOIN trade_annual_report_uploads aru ON aru.id = %L$3
+          %2$I.*
+        FROM %2$I
+        JOIN trade_annual_report_uploads aru ON aru.id = %3$L
         JOIN geo_entities ON geo_entities.id = aru.trading_country_id
         LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id;
       $format$,
@@ -234,7 +234,7 @@ AS $drop_eu_lc_mviews$
       WHERE table_name LIKE 'eu_%_listing_changes_mview'
         AND table_type != 'VIEW'
     LOOP
-      EXECUTE format('DROP TABLE %I$1 CASCADE', current_table_name);
+      EXECUTE format('DROP TABLE %1$I CASCADE', current_table_name);
     END LOOP;
 
     RETURN;

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -1,163 +1,184 @@
-CREATE OR REPLACE FUNCTION array_intersect(anyarray, anyarray)
-  RETURNS anyarray
-  language SQL
-AS $FUNCTION$
-    SELECT ARRAY(
-        SELECT UNNEST($1)
-        INTERSECT
-        SELECT UNNEST($2)
-    );
-$FUNCTION$;
+CREATE OR REPLACE FUNCTION array_intersect(
+  anyarray, anyarray
+) RETURNS anyarray LANGUAGE SQL
+AS $array_intersect$
+  SELECT ARRAY(
+    SELECT UNNEST($1)
+    INTERSECT
+    SELECT UNNEST($2)
+  );
+$array_intersect$;
 
 -- This function previously had a different signature - ensure that the old version is gone
 DROP FUNCTION IF EXISTS full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255));
 
-CREATE OR REPLACE FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255), name_status CHAR(1)) RETURNS VARCHAR(255)
-  LANGUAGE sql IMMUTABLE
-  AS $$
-    SELECT CASE
-      WHEN $1 IN ('ORDER', 'FAMILY', 'SUBFAMILY', 'GENUS') AND $3 != 'H'
-      THEN $2 || ' spp.'
-      ELSE $2
-    END;
-  $$;
+CREATE OR REPLACE FUNCTION full_name_with_spp(
+  rank_name   VARCHAR(255),
+  full_name   VARCHAR(255),
+  name_status CHAR(1)
+) RETURNS VARCHAR(255) LANGUAGE sql IMMUTABLE
+AS $full_name_with_spp$
+  SELECT CASE
+    WHEN $1 IN ('ORDER', 'FAMILY', 'SUBFAMILY', 'GENUS') AND $3 != 'H'
+    THEN $2 || ' spp.'
+    ELSE $2
+  END;
+$full_name_with_spp$;
 
 COMMENT ON FUNCTION full_name_with_spp(rank_name VARCHAR(255), full_name VARCHAR(255), name_status CHAR(1)) IS
   'Returns full name with ssp where applicable depending on rank. This is not applied for higher than species level hybrids';
 
 DROP FUNCTION IF EXISTS ancestor_listing_auto_note(rank_name VARCHAR(255), full_name VARCHAR(255), change_type_name VARCHAR(255));
 
-CREATE OR REPLACE FUNCTION ancestor_listing_auto_note(taxon_concept taxon_concepts, listing_change listing_changes, locale CHAR(2))
-RETURNS TEXT
-  LANGUAGE plpgsql STRICT
-  AS $$
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note(
+  taxon_concept public.taxon_concepts,
+  listing_change public.listing_changes,
+  locale CHAR(2)
+) RETURNS TEXT LANGUAGE plpgsql STRICT
+AS $ancestor_listing_auto_note$
   DECLARE
     result TEXT;
   BEGIN
     IF NOT ARRAY[LOWER(locale)] && ARRAY['en', 'es', 'fr'] THEN
       locale := 'en';
     END IF;
-    EXECUTE 'SELECT
-      UPPER(COALESCE(
-        ranks.display_name_' || locale || ',
-        ranks.display_name_en,
-        ranks.name
-      )) || '' '' ||
-      COALESCE(
-        change_types.display_name_' || locale || ',
-        change_types.display_name_en,
-        change_types.name
-      ) || '' '' ||
-      full_name_with_spp(ranks.name, ''' || taxon_concept.full_name || ''', ''' || taxon_concept.name_status || ''')
-      FROM ranks, change_types
-      WHERE ranks.id = ' || taxon_concept.rank_id || '
-      AND change_types.id = ' || listing_change.change_type_id
-    INTO result;
+
+    EXECUTE format(
+      $execute$
+      SELECT
+        UPPER(
+          COALESCE(
+            ranks.%I$1,
+            ranks.display_name_en,
+            ranks.name
+          )
+        ) || ' ' || COALESCE(
+          change_types.%I$1,
+          change_types.display_name_en,
+          change_types.name
+        ) || ' ' || full_name_with_spp(
+          ranks.name, %L$2, %L$3
+        )
+        FROM ranks, change_types
+        WHERE ranks.id = %L$4
+        AND change_types.id = %L$5
+      $execute$,
+      'display_name_' || locale,
+      taxon_concept.full_name,
+      taxon_concept.name_status,
+      taxon_concept.rank_id,
+      listing_change.change_type_id
+    ) INTO result;
+
     RETURN result;
   END;
-  $$;
+  $ancestor_listing_auto_note$;
 
-CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_en(taxon_concepts, listing_changes)
-RETURNS TEXT
-  LANGUAGE sql IMMUTABLE
-  AS $$
-    SELECT * FROM ancestor_listing_auto_note($1, $2, 'en');
-  $$;
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_en(
+  taxon_concepts, listing_changes
+) RETURNS TEXT LANGUAGE sql IMMUTABLE
+AS $ancestor_listing_auto_note_en$
+  SELECT * FROM ancestor_listing_auto_note($1, $2, 'en');
+$ancestor_listing_auto_note_en$;
 
 COMMENT ON FUNCTION ancestor_listing_auto_note_en(taxon_concepts, listing_changes) IS
   'Returns English auto note (used for inherited listing changes).';
 
-CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_es(taxon_concepts, listing_changes)
-RETURNS TEXT
-  LANGUAGE sql IMMUTABLE
-  AS $$
-    SELECT * FROM ancestor_listing_auto_note($1, $2, 'es');
-  $$;
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_es(
+  taxon_concepts, listing_changes
+) RETURNS TEXT LANGUAGE sql IMMUTABLE
+AS $ancestor_listing_auto_note_es$
+  SELECT * FROM ancestor_listing_auto_note($1, $2, 'es');
+$ancestor_listing_auto_note_es$;
 
 COMMENT ON FUNCTION ancestor_listing_auto_note_es(taxon_concepts, listing_changes) IS
   'Returns Spanish auto note (used for inherited listing changes).';
 
-CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_fr(taxon_concepts, listing_changes)
-RETURNS TEXT
-  LANGUAGE sql IMMUTABLE
-  AS $$
-    SELECT * FROM ancestor_listing_auto_note($1, $2, 'fr');
-  $$;
+CREATE OR REPLACE FUNCTION ancestor_listing_auto_note_fr(
+  taxon_concepts, listing_changes
+) RETURNS TEXT LANGUAGE sql IMMUTABLE
+AS $ancestor_listing_auto_note_fr$
+  SELECT * FROM ancestor_listing_auto_note($1, $2, 'fr');
+$ancestor_listing_auto_note_fr$;
 
 COMMENT ON FUNCTION ancestor_listing_auto_note_fr(taxon_concepts, listing_changes) IS
   'Returns French auto note (used for inherited listing changes).';
 
-
-CREATE OR REPLACE FUNCTION drop_trade_sandboxes() RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION drop_trade_sandboxes() RETURNS void LANGUAGE plpgsql
+AS $drop_trade_sandboxes$
   DECLARE
     current_table_name TEXT;
   BEGIN
-    FOR current_table_name IN SELECT table_name FROM information_schema.tables
-    WHERE table_name LIKE 'trade_sandbox%'
-      AND table_name != 'trade_sandbox_template'
-      AND table_type != 'VIEW'
+    FOR current_table_name IN
+    SELECT table_name
+      FROM information_schema.tables
+      WHERE table_name LIKE 'trade_sandbox%'
+        AND table_name != 'trade_sandbox_template'
+        AND table_type != 'VIEW'
     LOOP
-      EXECUTE 'DROP TABLE ' || current_table_name || ' CASCADE';
+      EXECUTE format('DROP TABLE %I$1 CASCADE', current_table_name);
     END LOOP;
+
     RETURN;
   END;
-  $$;
+$drop_trade_sandboxes$;
 
-COMMENT ON FUNCTION drop_trade_sandboxes() IS '
+COMMENT ON FUNCTION drop_trade_sandboxes() IS $comment$
 Drops all trade_sandbox_n tables. Used in specs only, you need to know what
-you''re doing. If you''re looking to drop all sandboxes in the live system,
-use the rake db:drop_sandboxes task instead.';
+you're doing. If you're looking to drop all sandboxes in the live system,
+use the rake db:drop_sandboxes task instead.$comment$;
 
 CREATE OR REPLACE FUNCTION drop_trade_sandbox_views() RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+LANGUAGE plpgsql AS $drop_trade_sandbox_views$
   DECLARE
     current_view_name TEXT;
   BEGIN
-    FOR current_view_name IN SELECT table_name FROM information_schema.tables
-    WHERE table_name LIKE 'trade_sandbox%_view'
-      AND table_type = 'VIEW'
+    FOR current_view_name IN
+      SELECT table_name FROM information_schema.tables
+      WHERE table_name LIKE 'trade_sandbox%_view'
+        AND table_type = 'VIEW'
     LOOP
-      EXECUTE 'DROP VIEW IF EXISTS ' || current_view_name || ' CASCADE';
+      EXECUTE format('DROP VIEW IF EXISTS %I$1 CASCADE', current_view_name);
     END LOOP;
+
     RETURN;
   END;
-  $$;
+$drop_trade_sandbox_views$;
 
-CREATE OR REPLACE FUNCTION create_trade_sandbox_views() RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION create_trade_sandbox_views() RETURNS void LANGUAGE plpgsql
+AS $create_trade_sandbox_views$
   DECLARE
     current_table_name TEXT;
     aru_id INT;
   BEGIN
-    FOR current_table_name IN SELECT table_name FROM information_schema.tables
-    WHERE table_name LIKE 'trade_sandbox%'
-      AND table_name != 'trade_sandbox_template'
-      AND table_type != 'VIEW'
+    FOR current_table_name IN
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_name LIKE 'trade_sandbox%'
+        AND table_name != 'trade_sandbox_template'
+        AND table_type != 'VIEW'
     LOOP
       aru_id := SUBSTRING(current_table_name, E'trade_sandbox_(\\d+)')::INT;
+
       IF aru_id IS NULL THEN
-  RAISE WARNING 'Unable to determine annual report upload id from %', current_table_name;
+        RAISE WARNING 'Unable to determine annual report upload id from %', current_table_name;
       ELSE
-  PERFORM create_trade_sandbox_view(current_table_name, aru_id);
+        PERFORM create_trade_sandbox_view(current_table_name, aru_id);
       END IF;
     END LOOP;
-    RETURN;
-  END;
-  $$;
 
-CREATE OR REPLACE FUNCTION refresh_trade_sandbox_views() RETURNS void
-  LANGUAGE plpgsql
-  AS $$
-  BEGIN
-    PERFORM drop_trade_sandbox_views();
-    PERFORM create_trade_sandbox_views();
     RETURN;
   END;
-  $$;
+$create_trade_sandbox_views$;
+
+CREATE OR REPLACE FUNCTION refresh_trade_sandbox_views() RETURNS void LANGUAGE plpgsql
+AS $refresh_trade_sandbox_views$
+  BEGIN
+    PERFORM public.drop_trade_sandbox_views();
+    PERFORM public.create_trade_sandbox_views();
+    RETURN;
+  END;
+$refresh_trade_sandbox_views$;
 
 COMMENT ON FUNCTION refresh_trade_sandbox_views() IS '
 Drops all trade_sandbox_n_view views and creates them again. Useful when the
@@ -165,60 +186,72 @@ view definition has changed and has to be applied to existing views.';
 
 
 CREATE OR REPLACE FUNCTION create_trade_sandbox_view(
-  target_table_name TEXT, idx INT
-  ) RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+  target_table_name TEXT,
+  idx               INT
+) RETURNS void LANGUAGE plpgsql
+AS $create_trade_sandbox_view$
   BEGIN
-    execute 'CREATE VIEW ' || target_table_name || '_view AS
-      SELECT aru.point_of_view,
-      CASE
-        WHEN aru.point_of_view = ''E''
-        THEN geo_entities.iso_code2
-        ELSE trading_partner
-      END AS exporter,
-      CASE
-        WHEN aru.point_of_view = ''E''
-        THEN trading_partner
-        ELSE geo_entities.iso_code2
-      END AS importer,
-      taxon_concepts.full_name AS accepted_taxon_name,
-      taxon_concepts.data->''rank_name'' AS rank,
-      taxon_concepts.rank_id,
-      ' || target_table_name || '.*
-      FROM ' || target_table_name || '
-      JOIN trade_annual_report_uploads aru ON aru.id = ' || idx || '
-      JOIN geo_entities ON geo_entities.id = aru.trading_country_id
-      LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id';
+    EXECUTE format(
+      $format$
+        CREATE VIEW %I$1 AS
+        SELECT aru.point_of_view,
+          CASE
+            WHEN aru.point_of_view = 'E'
+            THEN geo_entities.iso_code2
+            ELSE trading_partner
+          END AS exporter,
+          CASE
+            WHEN aru.point_of_view = 'E'
+            THEN trading_partner
+            ELSE geo_entities.iso_code2
+          END AS importer,
+          taxon_concepts.full_name AS accepted_taxon_name,
+          taxon_concepts.data->'rank_name' AS rank,
+          taxon_concepts.rank_id,
+          %I$2.*
+        FROM %I$2
+        JOIN trade_annual_report_uploads aru ON aru.id = %L$3
+        JOIN geo_entities ON geo_entities.id = aru.trading_country_id
+        LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id;
+      $format$,
+      target_table_name || _view,
+      target_table_name,
+      idx
+    );
+
     RETURN;
   END;
-  $$;
+$create_trade_sandbox_view$;
 
-CREATE OR REPLACE FUNCTION drop_eu_lc_mviews() RETURNS void
-  LANGUAGE plpgsql
-  AS $$
+CREATE OR REPLACE FUNCTION drop_eu_lc_mviews() RETURNS void LANGUAGE plpgsql
+AS $drop_eu_lc_mviews$
   DECLARE
     current_table_name TEXT;
   BEGIN
-    FOR current_table_name IN SELECT table_name FROM information_schema.tables
-    WHERE table_name LIKE 'eu_%_listing_changes_mview'
-      AND table_type != 'VIEW'
+    FOR current_table_name IN
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_name LIKE 'eu_%_listing_changes_mview'
+        AND table_type != 'VIEW'
     LOOP
-      EXECUTE 'DROP TABLE ' || current_table_name || ' CASCADE';
+      EXECUTE format('DROP TABLE %I$1 CASCADE', current_table_name);
     END LOOP;
+
     RETURN;
   END;
-  $$;
+$drop_eu_lc_mviews$;
 
-CREATE OR REPLACE FUNCTION listing_changes_mview_name(prefix TEXT, designation TEXT, events_ids INT[])
-  RETURNS TEXT
-  LANGUAGE SQL IMMUTABLE
-  AS $$
-    SELECT CASE WHEN $1 IS NULL THEN '' ELSE $1 || '_' END ||
-    $2 ||
-    CASE
-      WHEN $3 IS NOT NULL
-      THEN '_' || ARRAY_TO_STRING($3, '_')
-      ELSE ''
-    END || '_listing_changes_mview';
-  $$;
+CREATE OR REPLACE FUNCTION listing_changes_mview_name(
+  prefix      TEXT,
+  designation TEXT,
+  events_ids  INT[]
+) RETURNS TEXT LANGUAGE SQL IMMUTABLE
+AS $listing_changes_mview_name$
+  SELECT CASE WHEN $1 IS NULL THEN '' ELSE $1 || '_' END ||
+  $2 ||
+  CASE
+    WHEN $3 IS NOT NULL
+    THEN '_' || ARRAY_TO_STRING($3, '_')
+    ELSE ''
+  END || '_listing_changes_mview';
+$listing_changes_mview_name$;

--- a/db/helpers/000_helpers.sql
+++ b/db/helpers/000_helpers.sql
@@ -214,7 +214,7 @@ AS $create_trade_sandbox_view$
         JOIN geo_entities ON geo_entities.id = aru.trading_country_id
         LEFT JOIN taxon_concepts ON taxon_concept_id = taxon_concepts.id;
       $format$,
-      target_table_name || _view,
+      target_table_name || '_view',
       target_table_name,
       idx
     );

--- a/db/migrate/20260608165100_update_taxon_concepts_view.rb
+++ b/db/migrate/20260608165100_update_taxon_concepts_view.rb
@@ -1,0 +1,11 @@
+class UpdateTaxonConceptsView < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      execute "CREATE OR REPLACE VIEW taxon_concepts_view AS #{view_sql('20260608165100', 'taxon_concepts_view')}"
+    end
+  end
+
+  def down
+    execute "CREATE OR REPLACE VIEW taxon_concepts_view AS #{view_sql('20160630084345', 'taxon_concepts_view')}"
+  end
+end

--- a/db/views/taxon_concepts_view/20260608165100.sql
+++ b/db/views/taxon_concepts_view/20260608165100.sql
@@ -1,0 +1,282 @@
+SELECT
+  taxon_concepts.id,
+  taxon_concepts.parent_id,
+  taxon_concepts.taxonomy_id,
+  CASE
+    WHEN taxonomies.name = 'CITES_EU' THEN TRUE
+    ELSE FALSE
+  END AS taxonomy_is_cites_eu,
+  full_name::VARCHAR(255),
+  name_status::VARCHAR(255),
+  rank_id,
+  ranks.name::VARCHAR(255) AS rank_name,
+  ranks.display_name_en::VARCHAR(255) AS rank_display_name_en,
+  ranks.display_name_es::VARCHAR(255) AS rank_display_name_es,
+  ranks.display_name_fr::VARCHAR(255) AS rank_display_name_fr,
+  (data->'spp')::BOOLEAN AS spp,
+  (data->'cites_accepted')::BOOLEAN AS cites_accepted,
+  CASE
+    WHEN data->'kingdom_name' = 'Animalia' THEN 0
+    ELSE 1
+  END AS kingdom_position,
+  taxon_concepts.taxonomic_position::VARCHAR(255),
+  (data->'kingdom_name')::VARCHAR(255) AS kingdom_name,
+  (data->'phylum_name')::VARCHAR(255) AS phylum_name,
+  (data->'class_name')::VARCHAR(255) AS class_name,
+  (data->'order_name')::VARCHAR(255) AS order_name,
+  (data->'family_name')::VARCHAR(255) AS family_name,
+  (data->'subfamily_name')::VARCHAR(255) AS subfamily_name,
+  (data->'genus_name')::VARCHAR(255) AS genus_name,
+  (LOWER(data->'species_name'))::VARCHAR(255) AS species_name,
+  (LOWER(data->'subspecies_name'))::VARCHAR(255) AS subspecies_name,
+  (data->'kingdom_id')::INTEGER AS kingdom_id,
+  (data->'phylum_id')::INTEGER AS phylum_id,
+  (data->'class_id')::INTEGER AS class_id,
+  (data->'order_id')::INTEGER AS order_id,
+  (data->'family_id')::INTEGER AS family_id,
+  (data->'subfamily_id')::INTEGER AS subfamily_id,
+  (data->'genus_id')::INTEGER AS genus_id,
+  (data->'species_id')::INTEGER AS species_id,
+  (data->'subspecies_id')::INTEGER AS subspecies_id,
+  CASE
+    WHEN listing->'cites_I' = 'I' THEN TRUE
+    ELSE FALSE
+  END AS cites_I,
+  CASE
+    WHEN listing->'cites_II' = 'II' THEN TRUE
+    ELSE FALSE
+  END AS cites_II,
+  CASE
+    WHEN listing->'cites_III' = 'III' THEN TRUE
+    ELSE FALSE
+  END AS cites_III,
+  CASE
+    WHEN listing->'cites_status' = 'LISTED' AND listing->'cites_level_of_listing' = 't'
+    THEN TRUE
+    WHEN listing->'cites_status' = 'LISTED'
+    THEN FALSE
+    ELSE NULL
+  END AS cites_listed,
+  (listing->'cites_listed_descendants')::BOOLEAN AS cites_listed_descendants,
+  (listing->'cites_show')::BOOLEAN AS cites_show,
+  (listing->'cites_status')::VARCHAR(255) AS cites_status,
+  (listing->'cites_listing_original')::VARCHAR(255) AS cites_listing_original, --used in CSV downloads
+  (listing->'cites_listing')::VARCHAR(255) AS cites_listing,
+  (listing->'cites_listing_updated_at')::TIMESTAMP AS cites_listing_updated_at,
+  (listing->'ann_symbol')::VARCHAR(255) AS ann_symbol,
+  (listing->'hash_ann_symbol')::VARCHAR(255) AS hash_ann_symbol,
+  (listing->'hash_ann_parent_symbol')::VARCHAR(255) AS hash_ann_parent_symbol,
+  CASE
+    WHEN listing->'eu_status' = 'LISTED' AND listing->'eu_level_of_listing' = 't'
+    THEN TRUE
+    WHEN listing->'eu_status' = 'LISTED'
+    THEN FALSE
+    ELSE NULL
+  END AS eu_listed,
+  (listing->'eu_show')::BOOLEAN AS eu_show,
+  (listing->'eu_status')::VARCHAR(255) AS eu_status,
+  (listing->'eu_listing_original')::VARCHAR(255) AS eu_listing_original,
+  (listing->'eu_listing')::VARCHAR(255) AS eu_listing,
+  (listing->'eu_listing_updated_at')::TIMESTAMP AS eu_listing_updated_at,
+  CASE
+    WHEN listing->'cms_status' = 'LISTED' AND listing->'cms_level_of_listing' = 't'
+    THEN TRUE
+    WHEN listing->'cms_status' = 'LISTED'
+    THEN FALSE
+    ELSE NULL
+  END AS cms_listed,
+  (listing->'cms_show')::BOOLEAN AS cms_show,
+  (listing->'cms_status')::VARCHAR(255) AS cms_status,
+  (listing->'cms_listing_original')::VARCHAR(255) AS cms_listing_original,
+  (listing->'cms_listing')::VARCHAR(255) AS cms_listing,
+  (listing->'cms_listing_updated_at')::TIMESTAMP AS cms_listing_updated_at,
+  (listing->'species_listings_ids')::INT[] AS species_listings_ids,
+  (listing->'species_listings_ids_aggregated')::INT[] AS species_listings_ids_aggregated,
+  author_year::VARCHAR(255),
+  taxon_concepts.created_at,
+  taxon_concepts.updated_at,
+  taxon_concepts.dependents_updated_at,
+  common_names.*,
+  synonyms.*,
+  countries_ids_ary,
+  all_distribution_iso_codes_ary,
+  all_distribution_ary_en,
+  native_distribution_ary_en,
+  introduced_distribution_ary_en,
+  introduced_uncertain_distribution_ary_en,
+  reintroduced_distribution_ary_en,
+  extinct_distribution_ary_en,
+  extinct_uncertain_distribution_ary_en,
+  uncertain_distribution_ary_en,
+  all_distribution_ary_es,
+  native_distribution_ary_es,
+  introduced_distribution_ary_es,
+  introduced_uncertain_distribution_ary_es,
+  reintroduced_distribution_ary_es,
+  extinct_distribution_ary_es,
+  extinct_uncertain_distribution_ary_es,
+  uncertain_distribution_ary_es,
+  all_distribution_ary_fr,
+  native_distribution_ary_fr,
+  introduced_distribution_ary_fr,
+  introduced_uncertain_distribution_ary_fr,
+  reintroduced_distribution_ary_fr,
+  extinct_distribution_ary_fr,
+  extinct_uncertain_distribution_ary_fr,
+  uncertain_distribution_ary_fr,
+  CASE
+    WHEN
+    name_status = 'A'
+    AND (
+      ranks.name = 'SPECIES'
+      OR (
+        ranks.name = 'SUBSPECIES'
+        AND (
+          taxonomies.name = 'CITES_EU'
+          AND (
+            (listing->'cites_historically_listed')::BOOLEAN
+            OR (listing->'eu_historically_listed')::BOOLEAN
+          )
+          OR
+          taxonomies.name = 'CMS'
+          AND (listing->'cms_historically_listed')::BOOLEAN
+        )
+      )
+    )
+    THEN TRUE
+    ELSE FALSE
+  END AS show_in_species_plus
+FROM taxon_concepts
+JOIN ranks ON ranks.id = rank_id
+JOIN taxonomies ON taxonomies.id = taxon_concepts.taxonomy_id
+LEFT JOIN (
+  SELECT *
+  FROM
+  CROSSTAB(
+    $crosstab_values$
+      SELECT
+        taxon_commons.taxon_concept_id AS taxon_concept_id_com,
+        languages.iso_code1 AS lng,
+        ARRAY_AGG_NOTNULL(common_names.name ORDER BY common_names.name) AS common_names_ary
+      FROM "taxon_commons"
+      INNER JOIN "common_names"
+        ON "common_names"."id" = "taxon_commons"."common_name_id"
+      INNER JOIN "languages"
+        ON "languages"."id" = "common_names"."language_id"
+        AND UPPER(languages.iso_code1) IN ('EN', 'FR', 'ES')
+      GROUP BY
+        taxon_commons.taxon_concept_id,
+        languages.iso_code1
+      ORDER BY 1, 2
+    $crosstab_values$,
+    $crosstab_columns$
+      SELECT DISTINCT languages.iso_code1
+      FROM languages
+      WHERE UPPER(languages.iso_code1) IN ('EN', 'FR', 'ES')
+      ORDER BY 1
+    $crosstab_columns$
+  ) AS ct(
+    taxon_concept_id_com INTEGER,
+    english_names_ary VARCHAR[],
+    spanish_names_ary VARCHAR[],
+    french_names_ary VARCHAR[]
+  )
+) common_names ON taxon_concepts.id = common_names.taxon_concept_id_com
+LEFT JOIN (
+  SELECT
+    taxon_relationships.taxon_concept_id AS taxon_concept_id_syn,
+    array_agg(synonym_tc.full_name   ORDER BY synonym_tc.full_name) FILTER (WHERE synonym_tc.id IS NOT NULL) AS synonyms_ary,
+    array_agg(synonym_tc.author_year ORDER BY synonym_tc.full_name) FILTER (WHERE synonym_tc.id IS NOT NULL) AS synonyms_author_years_ary
+  FROM taxon_relationships
+  JOIN "taxon_relationship_types"
+    ON "taxon_relationship_types"."id" = "taxon_relationships"."taxon_relationship_type_id"
+    AND "taxon_relationship_types"."name" = 'HAS_SYNONYM'
+  JOIN taxon_concepts AS synonym_tc
+    ON synonym_tc.id = taxon_relationships.other_taxon_concept_id
+  GROUP BY taxon_relationships.taxon_concept_id
+) synonyms ON taxon_concepts.id = synonyms.taxon_concept_id_syn
+LEFT JOIN (
+  SELECT distributions.taxon_concept_id AS taxon_concept_id_cnt,
+  array_agg(geo_entities.id        ORDER BY geo_entities.name_en) AS countries_ids_ary,
+  array_agg(geo_entities.iso_code2 ORDER BY geo_entities.name_en) AS all_distribution_iso_codes_ary,
+  array_agg(geo_entities.name_en   ORDER BY geo_entities.name_en) AS all_distribution_ary_en,
+  array_agg(geo_entities.name_es   ORDER BY geo_entities.name_es) AS all_distribution_ary_es,
+  array_agg(geo_entities.name_fr   ORDER BY geo_entities.name_fr) AS all_distribution_ary_fr
+  FROM distributions
+  JOIN geo_entities
+    ON distributions.geo_entity_id = geo_entities.id
+  JOIN "geo_entity_types"
+    ON "geo_entity_types"."id" = "geo_entities"."geo_entity_type_id"
+  AND (geo_entity_types.name = 'COUNTRY' OR geo_entity_types.name = 'TERRITORY')
+  GROUP BY distributions.taxon_concept_id
+) countries_ids ON taxon_concepts.id = countries_ids.taxon_concept_id_cnt
+LEFT JOIN (
+  SELECT *
+  FROM CROSSTAB(
+    $crosstab_values$
+      SELECT distributions.taxon_concept_id,
+        CASE WHEN tags.name IS NULL THEN 'NATIVE' ELSE UPPER(tags.name) END || '_' || lng AS tag,
+        array_agg(geo_entities.name ORDER BY geo_entities.name) AS locations_ary
+      FROM distributions
+      JOIN (
+        SELECT geo_entities.id, geo_entities.iso_code2, 'EN' AS lng, geo_entities.name_en AS name FROM geo_entities
+        UNION
+        SELECT geo_entities.id, geo_entities.iso_code2, 'ES' AS lng, geo_entities.name_es AS name FROM geo_entities
+        UNION
+        SELECT geo_entities.id, geo_entities.iso_code2, 'FR' AS lng, geo_entities.name_fr AS name FROM geo_entities
+      ) geo_entities
+        ON geo_entities.id = distributions.geo_entity_id
+      LEFT JOIN taggings
+        ON taggable_id = distributions.id AND taggable_type = 'Distribution'
+      LEFT JOIN tags
+        ON tags.id = taggings.tag_id
+        AND (
+          UPPER(tags.name) IN (
+            'INTRODUCED', 'INTRODUCED (?)', 'REINTRODUCED',
+            'EXTINCT', 'EXTINCT (?)', 'DISTRIBUTION UNCERTAIN'
+          ) OR tags.name IS NULL
+        )
+      GROUP BY
+        distributions.taxon_concept_id,
+        tags.name,
+        geo_entities.lng
+    $crosstab_values$,
+    $crosstab_columns$
+      SELECT tag_name || '_' || lang_upper
+      FROM UNNEST(
+        ARRAY[
+          'NATIVE', 'INTRODUCED', 'INTRODUCED (?)', 'REINTRODUCED',
+          'EXTINCT', 'EXTINCT (?)', 'DISTRIBUTION UNCERTAIN'
+        ]
+      ) WITH ORDINALITY tag_names(tag_name, row_number)
+      JOIN UNNEST(
+        ARRAY['EN', 'FR', 'ES']
+      ) WITH ORDINALITY languages(lang_upper, row_number)
+      ON TRUE
+      ORDER BY languages.row_number, tag_names.row_number
+    $crosstab_columns$
+  ) AS ct(
+    taxon_concept_id INTEGER,
+    native_distribution_ary_en VARCHAR[],
+    introduced_distribution_ary_en VARCHAR[],
+    introduced_uncertain_distribution_ary_en VARCHAR[],
+    reintroduced_distribution_ary_en VARCHAR[],
+    extinct_distribution_ary_en VARCHAR[],
+    extinct_uncertain_distribution_ary_en VARCHAR[],
+    uncertain_distribution_ary_en VARCHAR[],
+    native_distribution_ary_es VARCHAR[],
+    introduced_distribution_ary_es VARCHAR[],
+    introduced_uncertain_distribution_ary_es VARCHAR[],
+    reintroduced_distribution_ary_es VARCHAR[],
+    extinct_distribution_ary_es VARCHAR[],
+    extinct_uncertain_distribution_ary_es VARCHAR[],
+    uncertain_distribution_ary_es VARCHAR[],
+    native_distribution_ary_fr VARCHAR[],
+    introduced_distribution_ary_fr VARCHAR[],
+    introduced_uncertain_distribution_ary_fr VARCHAR[],
+    reintroduced_distribution_ary_fr VARCHAR[],
+    extinct_distribution_ary_fr VARCHAR[],
+    extinct_uncertain_distribution_ary_fr VARCHAR[],
+    uncertain_distribution_ary_fr VARCHAR[]
+  )
+) distributions_by_tag ON taxon_concepts.id = distributions_by_tag.taxon_concept_id;


### PR DESCRIPTION
Fixes [this issue](https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/475) where the CITES checklist would sometimes display the wrong authorship information for synonyms where a taxon had multiple synonyms of which one or more were blank.

This was because the `taxon_concepts_view` stores `synonyms_ary` and `synoyms_author_years_ary` as two independent columns, and null elements of the synonym and synonym author arrays were being removed.

This is why you don't store related things in unrelated fields.

Also spotted a DB injection issue in the "helpers":

`ancestor_listing_auto_note` was using concatenation to build an SQL query
instead of using `format()`, which is a templating function designed for
building SQL safely. I've also fixed other instances in the same file where
SQL is being built via concatenation rather than `format()` (even if the
interpolations are currently guaranteed to be safe).