### PR TITLE
Set EU opinions to not current (Conolophus subcristatus)

### DIFF
--- a/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
+++ b/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
@@ -1,0 +1,57 @@
+namespace :ephemeral do
+  ##
+  # See ticket cites-support-maintenance 435
+  #
+  # Following SRG 107, certain opinions on Conolophus subcristatus (4404), which
+  # are applied to all countries, have changed as follows:
+  #
+  # To update: `Negative` opinions for sources W and F to be made not current
+  # New opinions: `Negative removed` for sources W and F; mark as not current
+  #
+  # It does not make sense to make these changes manually.
+  task set_eu_opinions_to_not_current: :environment do
+    OLD_EVENT_NAME = 'SRG 92'
+    NEW_EVENT_NAME = 'SRG 107'
+    OLD_DECISION_TYPE = 'Negative'
+    NEW_DECISION_TYPE = 'Negative removed'
+    SOURCE_CODES = [ 'W', 'F' ]
+
+    ApplicationRecord.transaction do
+      new_event = Event.find_by!(name: NEW_EVENT_NAME)
+      new_type = EuDecisionType.find_by!(name: NEW_DECISION_TYPE)
+
+      EuDecision.joins(
+        :eu_decision_type,
+        :start_event,
+        :source
+      ).where(
+        taxon_concept_id: 4404,
+        is_current: true,
+        eu_decision_type: { name: OLD_DECISION_TYPE },
+        start_event: { name: OLD_EVENT_NAME },
+        source: { code: SOURCE_CODES }
+      ).map do |decision|
+        decision.update!(
+          is_current: false,
+          # Following discussion with SB, end_date is not used.
+          # end_date: new_event.effective_at,
+          end_event: new_event
+        )
+
+        replacement_decision = decision.dup
+
+        replacement_decision.is_current = false
+        replacement_decision.eu_decision_type = new_type
+        replacement_decision.start_event = new_event
+        replacement_decision.start_date = new_event.effective_at # todo - confirm
+        replacement_decision.note = 'All countries' # todo - specify
+
+        replacement_decision.save!
+
+        replacement_decision
+      end
+
+      raise 'Dry run: Rollback'
+    end
+  end
+end

--- a/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
+++ b/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
@@ -1,6 +1,12 @@
 namespace :ephemeral do
   ##
   # See ticket cites-support-maintenance 435
+  # https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/435
+  #
+  # Run in dry-run mode by default:
+  #   bundle exec rake ephemeral:set_eu_opinions_to_not_current
+  # Persist changes explicitly:
+  #   DRY_RUN=false bundle exec rake ephemeral:set_eu_opinions_to_not_current
   #
   # Following SRG 107, certain opinions on Conolophus subcristatus (4404), which
   # are applied to all countries, have changed as follows:
@@ -15,6 +21,10 @@ namespace :ephemeral do
     OLD_DECISION_TYPE = 'Negative'
     NEW_DECISION_TYPE = 'Negative removed'
     SOURCE_CODES = [ 'W', 'F' ]
+    # Default to a dry run so this one-off data fix can be verified safely
+    # before it is allowed to persist changes in production-like environments.
+    DRY_RUN = ENV.fetch('DRY_RUN', 'true')
+    dry_run = ActiveModel::Type::Boolean.new.cast(DRY_RUN)
 
     ApplicationRecord.transaction do
       new_event = Event.find_by!(name: NEW_EVENT_NAME)
@@ -47,7 +57,7 @@ namespace :ephemeral do
         # The start date and the date in the note are in fact different for
         # SRG 107 decisions, and this is intentional, per ticker 435.
         replacement_decision.start_date = new_event.effective_at
-        replacement_decision.note =
+        replacement_decision.notes =
           'The decision came into effect when the Annex A listing for the species came into force on 29/06/2026'
 
         replacement_decision.save!
@@ -55,7 +65,9 @@ namespace :ephemeral do
         replacement_decision
       end
 
-      raise 'Dry run: Rollback'
+      # Use an explicit rollback instead of a generic error so the task keeps the
+      # transaction behavior intentional and predictable for dry-run verification.
+      raise ActiveRecord::Rollback, 'Dry run: rollback' if dry_run
     end
   end
 end

--- a/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
+++ b/lib/tasks/ephemeral/set_eu_opinions_to_not_current.rake
@@ -43,8 +43,12 @@ namespace :ephemeral do
         replacement_decision.is_current = false
         replacement_decision.eu_decision_type = new_type
         replacement_decision.start_event = new_event
-        replacement_decision.start_date = new_event.effective_at # todo - confirm
-        replacement_decision.note = 'All countries' # todo - specify
+
+        # The start date and the date in the note are in fact different for
+        # SRG 107 decisions, and this is intentional, per ticker 435.
+        replacement_decision.start_date = new_event.effective_at
+        replacement_decision.note =
+          'The decision came into effect when the Annex A listing for the species came into force on 29/06/2026'
 
         replacement_decision.save!
 


### PR DESCRIPTION
Resurrect a rake task, clean it up and update the wording now the Annex A listings have been published.

See [codebase ticket 435](https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/435) for details.