### PR TITLE
Fix checklist download caching

### DIFF
--- a/app/services/checklist/checklist.rb
+++ b/app/services/checklist/checklist.rb
@@ -2,6 +2,28 @@ class Checklist::Checklist
   include ActiveModel::SerializerSupport
   include CacheIterator
   include SearchCache # this provides #cached_results and #cached_total_cnt
+  DOWNLOAD_CACHE_PARAM_KEYS = %i[
+    output_layout
+    level_of_listing
+    scientific_name
+    countries
+    country_ids
+    cites_regions
+    cites_region_ids
+    cites_appendices
+    english_common_names
+    show_english
+    spanish_common_names
+    show_spanish
+    french_common_names
+    show_french
+    synonyms
+    show_synonyms
+    authors
+    show_author
+    intro
+    locale
+  ].freeze
   attr_accessor :animalia, :plantae, :authors, :synonyms, :synonyms_with_authors,
     :english_common_names, :spanish_common_names, :french_common_names, :total_cnt
   attr_reader :query
@@ -175,6 +197,14 @@ class Checklist::Checklist
     end
   end
 
+  def self.normalized_download_params(params)
+    raw_params = params.to_h.deep_dup.symbolize_keys.slice(*DOWNLOAD_CACHE_PARAM_KEYS)
+    locale = (raw_params.delete(:locale).presence || I18n.locale).to_s
+    normalized_params = Checklist::ChecklistParams.sanitize(raw_params)
+
+    [ normalized_params, locale ]
+  end
+
   # Returns a file path where a download can be stored.
   #
   # Used in Checklist::[Pdf|Csv]::[History|Index] to handle cached file
@@ -186,13 +216,11 @@ class Checklist::Checklist
   def download_location(params, type, format)
     require 'digest/sha1'
 
-    normalized_params = params.to_h.deep_dup.symbolize_keys
-    normalized_params.delete(:action)
-    normalized_params.delete(:controller)
-    # Respect an explicitly requested locale so cache prebuilds and ad hoc
-    # downloads produce distinct files per language instead of collapsing onto
-    # the process-global locale.
-    requested_locale = (normalized_params.delete(:locale).presence || I18n.locale).to_s
+    # Only checklist download inputs should affect the cache key. Requests and
+    # background jobs pass params in different shapes, so normalize aliases and
+    # defaults first to ensure equivalent downloads reuse the same file.
+    normalized_params, requested_locale =
+      self.class.normalized_download_params(params)
 
     @filename = Digest::SHA1.hexdigest(
       normalized_params.

--- a/app/services/checklist/checklist.rb
+++ b/app/services/checklist/checklist.rb
@@ -192,7 +192,7 @@ class Checklist::Checklist
     # Respect an explicitly requested locale so cache prebuilds and ad hoc
     # downloads produce distinct files per language instead of collapsing onto
     # the process-global locale.
-    requested_locale = normalized_params.delete(:locale).presence || I18n.locale
+    requested_locale = (normalized_params.delete(:locale).presence || I18n.locale).to_s
 
     @filename = Digest::SHA1.hexdigest(
       normalized_params.

--- a/app/services/checklist/checklist.rb
+++ b/app/services/checklist/checklist.rb
@@ -186,15 +186,18 @@ class Checklist::Checklist
   def download_location(params, type, format)
     require 'digest/sha1'
 
-    params.delete(:action)
-    params.delete(:controller)
+    normalized_params = params.to_h.deep_dup.symbolize_keys
+    normalized_params.delete(:action)
+    normalized_params.delete(:controller)
+    # Respect an explicitly requested locale so cache prebuilds and ad hoc
+    # downloads produce distinct files per language instead of collapsing onto
+    # the process-global locale.
+    requested_locale = normalized_params.delete(:locale).presence || I18n.locale
 
     @filename = Digest::SHA1.hexdigest(
-      params.
+      normalized_params.
       merge(type: type).
-      merge(locale: I18n.locale).
-      to_hash.
-      symbolize_keys!.
+      merge(locale: requested_locale).
       sort.
       to_s
     )

--- a/lib/modules/downloads_cache.rb
+++ b/lib/modules/downloads_cache.rb
@@ -139,28 +139,33 @@ module DownloadsCache
       Checklist::Json
     ]
     [ 'en', 'es', 'fr' ].each do |locale|
-      # full download parameters
-      params = {
-        show_synonyms: '1',
-        show_author: '1',
-        show_english: '1',
-        show_spanish: '1',
-        show_french: '1',
-        intro: '1',
-        locale: locale
-      }
+      # The checklist cache key, translated labels, and PDF dictionary all read
+      # I18n.locale directly, so the prebuild must switch the active locale
+      # rather than only passing locale through params.
+      I18n.with_locale(locale) do
+        # full download parameters
+        params = {
+          show_synonyms: '1',
+          show_author: '1',
+          show_english: '1',
+          show_spanish: '1',
+          show_french: '1',
+          intro: '1',
+          locale: locale
+        }
 
-      modules.each do |m|
-        elapsed_time =
-          Benchmark.realtime do
-            puts m::Index.new(params).generate
-          end
-        Rails.logger.debug { "#{Time.now} #{m}::Index download #{locale} generated in #{elapsed_time}s" }
-        elapsed_time =
-          Benchmark.realtime do
-            puts m::History.new(params).generate
-          end
-        Rails.logger.debug { "#{Time.now} #{m}::History download #{locale} generated in #{elapsed_time}s" }
+        modules.each do |m|
+          elapsed_time =
+            Benchmark.realtime do
+              puts m::Index.new(params).generate
+            end
+          Rails.logger.debug { "#{Time.now} #{m}::Index download #{locale} generated in #{elapsed_time}s" }
+          elapsed_time =
+            Benchmark.realtime do
+              puts m::History.new(params).generate
+            end
+          Rails.logger.debug { "#{Time.now} #{m}::History download #{locale} generated in #{elapsed_time}s" }
+        end
       end
     end
   end

--- a/lib/modules/downloads_cache.rb
+++ b/lib/modules/downloads_cache.rb
@@ -143,8 +143,11 @@ module DownloadsCache
       # I18n.locale directly, so the prebuild must switch the active locale
       # rather than only passing locale through params.
       I18n.with_locale(locale) do
-        # full download parameters
-        params = {
+        # Build the same canonical checklist options that request-time
+        # downloads hash into their cache key. This keeps the scheduled
+        # prebuild filenames aligned with live download requests.
+        params = Checklist::Checklist.normalized_download_params(
+          {
           show_synonyms: '1',
           show_author: '1',
           show_english: '1',
@@ -152,7 +155,8 @@ module DownloadsCache
           show_french: '1',
           intro: '1',
           locale: locale
-        }
+          }
+        ).first
 
         modules.each do |m|
           elapsed_time =

--- a/lib/modules/downloads_cache.rb
+++ b/lib/modules/downloads_cache.rb
@@ -146,7 +146,7 @@ module DownloadsCache
         # Build the same canonical checklist options that request-time
         # downloads hash into their cache key. This keeps the scheduled
         # prebuild filenames aligned with live download requests.
-        params = Checklist::Checklist.normalized_download_params(
+        params, _requested_locale = Checklist::Checklist.normalized_download_params(
           {
           show_synonyms: '1',
           show_author: '1',
@@ -156,7 +156,7 @@ module DownloadsCache
           intro: '1',
           locale: locale
           }
-        ).first
+        )
 
         modules.each do |m|
           elapsed_time =

--- a/spec/jobs/downloads_cache_update_job_spec.rb
+++ b/spec/jobs/downloads_cache_update_job_spec.rb
@@ -1,5 +1,46 @@
 require 'spec_helper'
 
 RSpec.describe DownloadsCacheUpdateJob do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.update_checklist_downloads' do
+    def build_generator(recorder, label)
+      Class.new do
+        define_method(:initialize) do |_params|
+          @recorder = recorder
+          @label = label
+        end
+
+        define_method(:generate) do
+          # Record the active locale because checklist generation reads
+          # translations and cache keys from I18n.locale, not only from params.
+          @recorder << [ @label, I18n.locale.to_s ]
+          '/tmp/fake-download'
+        end
+      end
+    end
+
+    specify 'prebuilds each checklist variant under its target locale' do
+      recorder = []
+
+      stub_const('Checklist::Pdf', Module.new)
+      Checklist::Pdf.const_set(:Index, build_generator(recorder, :pdf_index))
+      Checklist::Pdf.const_set(:History, build_generator(recorder, :pdf_history))
+
+      stub_const('Checklist::Csv', Module.new)
+      Checklist::Csv.const_set(:Index, build_generator(recorder, :csv_index))
+      Checklist::Csv.const_set(:History, build_generator(recorder, :csv_history))
+
+      stub_const('Checklist::Json', Module.new)
+      Checklist::Json.const_set(:Index, build_generator(recorder, :json_index))
+      Checklist::Json.const_set(:History, build_generator(recorder, :json_history))
+
+      DownloadsCache.update_checklist_downloads
+
+      expect(recorder.size).to eq(18)
+      expect(recorder.map(&:last).tally).to eq(
+        'en' => 6,
+        'es' => 6,
+        'fr' => 6
+      )
+    end
+  end
 end

--- a/spec/services/checklist/checklist_spec.rb
+++ b/spec/services/checklist/checklist_spec.rb
@@ -122,4 +122,25 @@ describe Checklist::Checklist do
       expect(summary).to eq('Results from 2 regions')
     end
   end
+
+  describe :download_location do
+    specify 'uses the explicit locale instead of the process locale for the cache key' do
+      checklist = described_class.allocate
+
+      french_path = I18n.with_locale(:en) do
+        checklist.download_location({ locale: 'fr' }, 'index', 'pdf')
+      end
+
+      expected_french_path = I18n.with_locale(:fr) do
+        checklist.download_location({}, 'index', 'pdf')
+      end
+
+      english_path = I18n.with_locale(:en) do
+        checklist.download_location({}, 'index', 'pdf')
+      end
+
+      expect(french_path).to eq(expected_french_path)
+      expect(french_path).not_to eq(english_path)
+    end
+  end
 end

--- a/spec/services/checklist/checklist_spec.rb
+++ b/spec/services/checklist/checklist_spec.rb
@@ -123,9 +123,9 @@ describe Checklist::Checklist do
     end
   end
 
-  describe :download_location do
+  describe '#download_location' do
     specify 'uses the explicit locale instead of the process locale for the cache key' do
-      checklist = described_class.allocate
+      checklist = Checklist::Checklist.allocate
 
       french_path = I18n.with_locale(:en) do
         checklist.download_location({ locale: 'fr' }, 'index', 'pdf')

--- a/spec/services/checklist/checklist_spec.rb
+++ b/spec/services/checklist/checklist_spec.rb
@@ -142,5 +142,123 @@ describe Checklist::Checklist do
       expect(french_path).to eq(expected_french_path)
       expect(french_path).not_to eq(english_path)
     end
+
+    specify 'uses the same cache key for equivalent raw and sanitized params' do
+      checklist = Checklist::Checklist.allocate
+
+      raw_params_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          {
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1',
+            locale: 'en'
+          },
+          'index',
+          'pdf'
+        )
+      end
+
+      sanitized_params_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          Checklist::ChecklistParams.sanitize(
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1'
+          ),
+          'index',
+          'pdf'
+        )
+      end
+
+      expect(raw_params_path).to eq(sanitized_params_path)
+    end
+
+    specify 'ignores non-checklist request params when building the cache key' do
+      checklist = Checklist::Checklist.allocate
+
+      canonical_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          {
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1',
+            locale: 'en'
+          },
+          'index',
+          'pdf'
+        )
+      end
+
+      noisy_request_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          {
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1',
+            locale: 'en',
+            format: 'pdf',
+            action: 'download_index',
+            controller: 'checklist/downloads'
+          },
+          'index',
+          'pdf'
+        )
+      end
+
+      expect(noisy_request_path).to eq(canonical_path)
+    end
+
+    specify 'ignores pagination params when building the cache key' do
+      checklist = Checklist::Checklist.allocate
+
+      canonical_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          {
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1',
+            locale: 'en'
+          },
+          'index',
+          'pdf'
+        )
+      end
+
+      paginated_request_path = I18n.with_locale(:en) do
+        checklist.download_location(
+          {
+            show_synonyms: '1',
+            show_author: '1',
+            show_english: '1',
+            show_spanish: '1',
+            show_french: '1',
+            intro: '1',
+            locale: 'en',
+            page: '9',
+            per_page: '250'
+          },
+          'index',
+          'pdf'
+        )
+      end
+
+      expect(paginated_request_path).to eq(canonical_path)
+    end
   end
 end


### PR DESCRIPTION
Fixed checklist download cache prebuilds so locale variants no longer collapse onto the same files, and so prebuilt files are actually reused by live download requests.

The first root cause was that `app/services/checklist/checklist.rb` overwrote any requested locale with `I18n.locale` when building the cache filename, while the scheduled cache prebuild in `lib/modules/downloads_cache.rb` looped over `en`, `es`, and `fr` without switching the active locale. That meant the job generated the same 6 checklist files three times instead of 18 distinct localized variants.

The second root cause was that scheduled prebuilds and request-time downloads did not hash the same logical checklist options. Equivalent inputs such as `show_english=1` and `english_common_names: true`, along with unrelated request params such as `format`, `action`, and `controller`, could produce different cache filenames. That caused cache misses even when the expected file had already been prebuilt.

This change does three things:
- `app/services/checklist/checklist.rb` now respects an explicit `locale` param when computing the checklist download cache path.
- `lib/modules/downloads_cache.rb` now wraps each prebuild iteration in `I18n.with_locale(locale)` so the cache key, translated labels, PDF dictionary, and other locale-sensitive content are generated under the intended language.
- `app/services/checklist/checklist.rb` now normalizes and whitelists checklist download inputs before hashing them, so scheduled prebuilds and live requests resolve to the same cache filename for the same logical download.

Added regression coverage in:
- `spec/services/checklist/checklist_spec.rb`
- `spec/jobs/downloads_cache_update_job_spec.rb`