### PR TITLE
Fix: ids arrays in params.expect()

### DIFF
--- a/app/controllers/admin/taxon_listing_changes_controller.rb
+++ b/app/controllers/admin/taxon_listing_changes_controller.rb
@@ -153,8 +153,8 @@ private
         party_listing_distribution_attributes: [
           :id, :_destroy, :geo_entity_id, :listing_change_id, :is_party
         ],
-        geo_entity_ids: [ [] ],
-        excluded_geo_entities_ids: [ [] ]
+        geo_entity_ids: [],
+        excluded_geo_entities_ids: []
       ]
     )
   end

--- a/app/controllers/admin/taxon_quotas_controller.rb
+++ b/app/controllers/admin/taxon_quotas_controller.rb
@@ -18,6 +18,7 @@ class Admin::TaxonQuotasController < Admin::SimpleCrudController
       failure.html { render 'create' }
     end
   end
+
   def update
     update! do |success, failure|
       success.html do
@@ -87,9 +88,9 @@ private
         :nomenclature_note_en, :nomenclature_note_es, :nomenclature_note_fr,
         :created_by_id, :updated_by_id, :url,
         :taxon_concept_id,
-        term_ids: [ [] ],
-        source_ids: [ [] ],
-        purpose_ids: [ [] ]
+        term_ids: [],
+        source_ids: [],
+        purpose_ids: []
       ]
     )
   end


### PR DESCRIPTION
Fixes https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/503

Also fixes a similar issue where values in listing changes' distribution fields (pictured) were ignored, found via `$ git grep '_ids: \[ \[\]'`.

<img width="485" height="78" alt="image" src="https://github.com/user-attachments/assets/cebd4d32-a77e-4f4d-907d-834be83a8a5c" />